### PR TITLE
Admin group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'omniauth-shibboleth', '~> 1.3'
 gem 'factory_bot_rails'
 gem 'ffaker'
+gem 'hydra-role-management'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
@@ -44,6 +45,7 @@ group :development, :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13'
   gem 'selenium-webdriver'
+  gem 'database_cleaner'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,8 @@ GEM
     bootstrap-sass (3.4.0)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
+    bootstrap_form (4.1.0)
+      rails (>= 5.0)
     breadcrumbs_on_rails (3.0.1)
     browse-everything (0.15.1)
       addressable (~> 2.5)
@@ -154,6 +156,7 @@ GEM
     connection_pool (2.2.2)
     crass (1.0.4)
     daemons (1.3.1)
+    database_cleaner (1.7.0)
     declarative (0.0.10)
     declarative-option (0.1.0)
     deprecation (1.0.0)
@@ -311,6 +314,10 @@ GEM
       active-fedora (>= 10, < 13)
       activesupport (< 5.2)
       mime-types (>= 1)
+    hydra-role-management (1.0.0)
+      blacklight
+      bootstrap_form
+      cancancan
     hydra-works (1.0.0)
       activesupport (>= 4.2.10, < 5.2)
       hydra-derivatives (~> 3.0)
@@ -778,11 +785,13 @@ DEPENDENCIES
   byebug
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
+  database_cleaner
   devise
   devise-guests (~> 0.6)
   factory_bot_rails
   fcrepo_wrapper
   ffaker
+  hydra-role-management
   hyrax (= 3.0.0.pre.beta1)
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -12,6 +12,11 @@ class Ability
     #   can [:destroy], ActiveFedora::Base
     # end
 
+    if current_user.admin?
+      can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role
+      can [:destroy], ActiveFedora::Base
+    end
+
     # Limits creating new objects to a specific group
     #
     # if user_groups.include? 'special_group'

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,7 +14,6 @@ class Ability
 
     if current_user.admin?
       can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role
-      can [:destroy], ActiveFedora::Base
     end
 
     # Limits creating new objects to a specific group

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,10 @@
 class User < ApplicationRecord
   # Connects this user object to Hydra behaviors.
   include Hydra::User
+  # Connects this user object to Role-management behaviors.
+  include Hydra::RoleManagement::UserRoles
+
+
   # Connects this user object to Hyrax behaviors.
   include Hyrax::User
   include Hyrax::UserUsageStats

--- a/config/role_map.yml
+++ b/config/role_map.yml
@@ -1,23 +1,10 @@
 development:
-  archivist:
-    - archivist1@example.com
+  admin:
+    - dev-admin
 
 test:
-  archivist:
-    - archivist1@example.com
-    - archivist2@example.com
-    - leland_himself@example.com
-  admin_policy_object_editor:
-    - archivist1@example.com
-  donor:
-    - donor1@example.com
-    - leland_himself@example.com
-  researcher:
-    - archivist1@example.com
-    - researcher1@example.com
-  patron:
-    - patron1@example.com
-    - leland_himself@example.com
+  admin:
+    - test-admin
 
-production:
+# production:
   # Add roles for users here.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
       get 'sign_out', to: 'devise/sessions#destroy', as: :destroy_user_session
     end
   end
+  
+  mount Hydra::RoleManagement::Engine => '/'
   mount Qa::Engine => '/authorities'
   mount Hyrax::Engine, at: '/'
   resources :welcome, only: 'index'

--- a/db/migrate/20190124224346_user_roles.rb
+++ b/db/migrate/20190124224346_user_roles.rb
@@ -1,0 +1,18 @@
+class UserRoles < ActiveRecord::Migration[5.0]
+  def up
+    create_table :roles do |t|
+      t.string :name
+    end
+    create_table :roles_users, :id => false do |t|
+      t.references :role
+      t.references :user
+    end
+    add_index :roles_users, [:role_id, :user_id]
+    add_index :roles_users, [:user_id, :role_id]
+  end
+
+  def down
+    drop_table :roles_users
+    drop_table :roles
+  end
+end

--- a/db/migrate/20190126002457_remove_email_index_from_users.rb
+++ b/db/migrate/20190126002457_remove_email_index_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveEmailIndexFromUsers < ActiveRecord::Migration[5.1]
+  def change
+  	remove_index :users, :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190124182020) do
+ActiveRecord::Schema.define(version: 20190126002457) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -283,6 +283,19 @@ ActiveRecord::Schema.define(version: 20190124182020) do
     t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
   end
 
+  create_table "roles", force: :cascade do |t|
+    t.string "name"
+  end
+
+  create_table "roles_users", id: false, force: :cascade do |t|
+    t.integer "role_id"
+    t.integer "user_id"
+    t.index ["role_id", "user_id"], name: "index_roles_users_on_role_id_and_user_id"
+    t.index ["role_id"], name: "index_roles_users_on_role_id"
+    t.index ["user_id", "role_id"], name: "index_roles_users_on_user_id_and_role_id"
+    t.index ["user_id"], name: "index_roles_users_on_user_id"
+  end
+
   create_table "searches", force: :cascade do |t|
     t.binary "query_params"
     t.integer "user_id"
@@ -533,7 +546,6 @@ ActiveRecord::Schema.define(version: 20190124182020) do
     t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
-    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid"], name: "index_users_on_uid"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,8 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+require 'admin_setup'
+# Initialize AdminSetup class
+a = AdminSetup.new
+# Setup admins
+a.setup

--- a/lib/admin_setup.rb
+++ b/lib/admin_setup.rb
@@ -1,0 +1,67 @@
+# Set up admin users
+require 'yaml'
+
+# Set up application's initial state: load required roles and users
+class AdminSetup
+  attr_accessor :admins_config
+  DEFAULT_ADMIN_CONFIG = "#{::Rails.root}/config/role_map.yml".freeze
+
+  # Set up the parameters for
+  # @param [String] admins_config a file containing the email addresses of the application's admin users
+  def initialize(admins_config = DEFAULT_ADMIN_CONFIG, log_location = STDOUT)
+	raise "File #{admins_config} does not exist" unless File.exist?(admins_config)
+    @admins_config = YAML.safe_load(File.read(admins_config))
+    @logger = Logger.new(log_location)
+    @logger.level = Logger::DEBUG
+    @logger.info "Initializing new admin setup with admins file #{admins_config}"
+  end
+
+  # Load the admins
+  def setup
+    load_admins
+  end
+
+  # Create the admin role, or find it if it exists already
+  # @return [Role] the admin Role
+  def admin_role
+    Role.find_or_create_by(name: "admin")
+  end
+
+  # Load admins from a config file
+  def load_admins
+    admin_role.users = [] # Remove all the admin users every time you reload
+    admin_role.save
+    @admins_config.each_key do |provider|
+      @admins_config[provider]["admin"].each do |a|
+        make_admin(a, provider)
+      end
+    end
+  end
+
+  # Make an admin
+  # @param [String] the uid of the admin
+  # @return [User] the admin who was just created
+  def make_admin(uid, provider = "development")
+    @logger.debug "Making admin #{uid}"
+    admin_user = ::User.find_or_create_by(uid: uid)
+    admin_user.password = "123456" if set_default_password?
+    admin_user.ppid = uid # temporary ppid, will get replaced when user signs in with shibboleth
+    admin_user.provider = provider
+    admin_user.save
+    admin_role.users << admin_user
+    admin_role.save
+    admin_user
+  end
+
+  # Don't set default passwords in production mode
+  def set_default_password?
+    AuthConfig.use_database_auth? && !Rails.env.production?
+  end
+
+  # return an array of all current admins
+  # @return [Array(User)]
+  def admins
+    raise "No admins are defined" unless admin_role.users.count > 0
+    admin_role.users
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -20,6 +20,16 @@ FactoryBot.define do
       ::RSpec::Mocks.allow_message(user.class.group_service, :fetch_groups).with(user: user).and_return(Array.wrap(evaluator.groups))
     end
 
+    factory :admin do
+      groups { ['admin'] }
+
+      after(:create) do |user|
+        role = Role.find_or_create_by(name: 'admin')
+        role.users << user
+        role.save
+      end
+    end
+
     trait :guest do
       guest true
     end

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Admin dashboard', integration: true do
+
+  context 'as a non-admin user' do
+	let(:user) { FactoryBot.create(:user) }
+
+	before do
+	  login_as user
+	  visit '/dashboard'
+	end
+
+	scenario 'does not have settings tab' do
+		expect(page).not_to have_link 'Settings'
+	end
+  end
+
+  context 'as an admin user' do
+  	let(:admin) { FactoryBot.create(:admin) }
+
+  	before do
+	  login_as admin
+	  visit '/dashboard'
+	end
+
+  	scenario 'view the workflow roles page' do
+      click_on 'Workflow Roles'
+      expect(page).to have_content 'Assign Role'
+    end
+
+    scenario 'does have settings tab' do
+    	expect(page).to have_link 'Settings'
+    end
+
+    # TODO: Add more admin tests, for eg: stats page, when work is created
+
+    # scenario 'view the statistics page' do
+    # 	click_on 'Reports'
+    # 	expect(page).to have_content ''
+    # end
+  end
+end

--- a/spec/fixtures/config/role_map.yml
+++ b/spec/fixtures/config/role_map.yml
@@ -1,0 +1,11 @@
+development:
+  admin:
+    - adminuser001
+
+test:
+  admin:
+    - adminuser002
+
+production:
+  admin:
+    - adminuser003

--- a/spec/lib/admin_setup_spec.rb
+++ b/spec/lib/admin_setup_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+require 'admin_setup'
+
+RSpec.describe AdminSetup, :clean do
+  before(:context) { DatabaseCleaner.clean_with(:truncation) }
+
+  # Change STDOUT to "/dev/null" to block all logging output
+  let(:w) { described_class.new("#{fixture_path}/config/role_map.yml", STDOUT) }
+  let(:admin_user_uid) { "adminuser001" }
+  it "makes an admin Role" do
+  	admin = w.admin_role
+  	expect(admin).to be_instance_of(Role)
+  	expect(Role.where(name: "admin").count).to eq 1
+  end
+  it "loads all admins from a file" do
+    w.load_admins
+    expect((w.admin_role.users.map(&:uid).include? "adminuser002")).to eq true
+    expect(w.admins.pluck(:uid).include?("adminuser002")).to eq true
+  end
+  it "makes user as admin" do
+  	w.make_admin(admin_user_uid)
+  	expect(User.where(uid: admin_user_uid).count).to eq 1
+  	expect((w.admin_role.users.map(&:uid).include? admin_user_uid)).to eq true
+  end
+  it "returns all admins" do
+    s = %w[admin1 admin2 admin3]
+    s.each do |t|
+      w.make_admin(t)
+    end
+    expect(w.admins.count).to eq 3
+    expect(w.admins.pluck(:uid).include?(s.first)).to be true
+  end
+end


### PR DESCRIPTION
Adds the hydra-role-management gem to create roles for users;
Adds solution to create user admins from role_map.yml file on dev (via seeds);
Removes unique constraint and index from users.email since we are using `uid` for authentication;

Creates user admin factory and adds initial tests for admin dashboard

Closes #44 
Connected to #36 

Roles can be found at `/roles` (accessible by admins):
![image](https://user-images.githubusercontent.com/17075287/51935729-8735ce00-23d4-11e9-96ea-c113419e8687.png)

Select `role` to add users (accessible by admins):
![image](https://user-images.githubusercontent.com/17075287/51935737-8c931880-23d4-11e9-9f8c-ea184ef4b22b.png)
