### PR TITLE
Adds descriptive metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,5 +88,6 @@ end
 
 group :development, :test do
   gem 'fcrepo_wrapper'
+  gem 'rspec-its'
   gem 'rspec-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -693,6 +693,9 @@ GEM
     rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
@@ -886,6 +889,7 @@ DEPENDENCIES
   rails (~> 5.1.6)
   riiif (~> 2.0)
   rsolr (>= 1.0)
+  rspec-its
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/models/curate_generic_work.rb
+++ b/app/models/curate_generic_work.rb
@@ -8,6 +8,44 @@ class CurateGenericWork < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  property :institution, predicate: "http://rdaregistry.info/Elements/u/P60402", multiple: false do |index|
+    index.as :stored_searchable
+  end
+
+  property :holding_repository, predicate: "http://id.loc.gov/vocabulary/relators/rps", multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
+  property :administrative_unit, predicate: "http://id.loc.gov/vocabulary/relators/cur", multiple: false do |index|
+    index.as :stored_searchable
+  end
+
+  property :sublocation, predicate: "http://metadata.emory.edu/vocab/cor-terms#physicalSublocation", multiple: false do |index|
+    index.as :stored_searchable
+  end
+
+  property :content_type, predicate: "http://purl.org/dc/terms/type", multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
+  property :content_genre, predicate: "http://www.europeana.eu/schemas/edm/" do |index|
+    index.as :stored_searchable, :facetable
+  end
+
+  property :abstract, predicate: "http://purl.org/dc/elements/1.1/description", multiple: false do |index|
+    index.as :stored_searchable
+  end
+
+  property :table_of_contents, predicate: "http://purl.org/dc/terms/tableOfContents", multiple: false do |index|
+    index.as :stored_searchable
+  end
+
+  property :edition, predicate: "http://id.loc.gov/ontologies/bibframe/editionStatement", multiple: false
+
+  property :primary_language, predicate: "http://purl.org/dc/elements/1.1/language", multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/spec/models/curate_generic_work_spec.rb
+++ b/spec/models/curate_generic_work_spec.rb
@@ -3,7 +3,183 @@
 require 'rails_helper'
 
 RSpec.describe CurateGenericWork do
-  it "has tests" do
-    skip "Add your tests here"
+  describe "#institution" do
+    subject { described_class.new }
+    let(:institution) { 'Emory University' }
+
+    context "with new CurateGenericWork work" do
+      its(:institution) { is_expected.to be_falsey }
+    end
+
+    context "with a CurateGenericWork work that has an institution" do
+      subject do
+        described_class.create.tap do |cgw|
+          cgw.institution = institution
+        end
+      end
+      its(:institution) { is_expected.to eq 'Emory University' }
+    end
+  end
+
+  describe "#holding_repository" do
+    subject { described_class.new }
+    let(:holding_repository) { 'Woodruff' }
+
+    context "with new CurateGenericWork work" do
+      its(:holding_repository) { is_expected.to be_falsey }
+    end
+
+    context "with a CurateGenericWork work that has a holding_repository" do
+      subject do
+        described_class.create.tap do |cgw|
+          cgw.holding_repository = holding_repository
+        end
+      end
+      its(:holding_repository) { is_expected.to eq 'Woodruff' }
+    end
+  end
+
+  describe "#administrative_unit" do
+    subject { described_class.new }
+    let(:administrative_unit) { 'LTDS' }
+
+    context "with new CurateGenericWork work" do
+      its(:administrative_unit) { is_expected.to be_falsey }
+    end
+
+    context "with a CurateGenericWork work that has an administrative_unit" do
+      subject do
+        described_class.create.tap do |cgw|
+          cgw.administrative_unit = administrative_unit
+        end
+      end
+      its(:administrative_unit) { is_expected.to eq 'LTDS' }
+    end
+  end
+
+  describe "#sublocation" do
+    subject { described_class.new }
+    let(:sublocation) { 'Box Folder' }
+
+    context "with new CurateGenericWork work" do
+      its(:sublocation) { is_expected.to be_falsey }
+    end
+
+    context "with a CurateGenericWork work that has a sublocation" do
+      subject do
+        described_class.create.tap do |cgw|
+          cgw.sublocation = sublocation
+        end
+      end
+      its(:sublocation) { is_expected.to eq 'Box Folder' }
+    end
+  end
+
+  describe "#content_type" do
+    subject { described_class.new }
+    let(:content_type) { 'Book' }
+
+    context "with new CurateGenericWork work" do
+      its(:content_type) { is_expected.to be_falsey }
+    end
+
+    context "with a CurateGenericWork work that has a content_type" do
+      subject do
+        described_class.create.tap do |cgw|
+          cgw.content_type = content_type
+        end
+      end
+      its(:content_type) { is_expected.to eq 'Book' }
+    end
+  end
+
+  describe "#content_genre" do
+    subject { described_class.new }
+    let(:content_genre) { ['Fictional book'] }
+
+    context "with new CurateGenericWork work" do
+      its(:content_genre) { is_expected.to be_empty }
+    end
+
+    context "with a CurateGenericWork work that has a content_genre" do
+      subject do
+        described_class.create.tap do |cgw|
+          cgw.content_genre = content_genre
+        end
+      end
+      its(:content_genre) { is_expected.to eq ['Fictional book'] }
+    end
+  end
+
+  describe "#abstract" do
+    subject { described_class.new }
+    let(:abstract) { 'This is an abstract of an ETD' }
+
+    context "with new CurateGenericWork work" do
+      its(:abstract) { is_expected.to be_falsey }
+    end
+
+    context "with a CurateGenericWork work that has an abstract" do
+      subject do
+        described_class.create.tap do |cgw|
+          cgw.abstract = abstract
+        end
+      end
+      its(:abstract) { is_expected.to include 'abstract of an ETD' }
+    end
+  end
+
+  describe "#table_of_contents" do
+    subject { described_class.new }
+    let(:table_of_contents) { 'This is an example table of contents' }
+
+    context "with new CurateGenericWork work" do
+      its(:table_of_contents) { is_expected.to be_falsey }
+    end
+
+    context "with a CurateGenericWork work that has a table_of_contents" do
+      subject do
+        described_class.create.tap do |cgw|
+          cgw.table_of_contents = table_of_contents
+        end
+      end
+      its(:table_of_contents) { is_expected.to include 'example' }
+    end
+  end
+
+  describe "#edition" do
+    subject { described_class.new }
+    let(:edition) { 'Version 2.0' }
+
+    context "with new CurateGenericWork work" do
+      its(:edition) { is_expected.to be_falsey }
+    end
+
+    context "with a CurateGenericWork work that has an edition" do
+      subject do
+        described_class.create.tap do |cgw|
+          cgw.edition = edition
+        end
+      end
+      its(:edition) { is_expected.to include '2.0' }
+    end
+  end
+
+  describe "#primary_language" do
+    subject { described_class.new }
+    let(:primary_language) { 'English' }
+
+    context "with new CurateGenericWork work" do
+      its(:primary_language) { is_expected.to be_falsey }
+    end
+
+    context "with a CurateGenericWork work that has a primary_language" do
+      subject do
+        described_class.create.tap do |cgw|
+          cgw.primary_language = primary_language
+        end
+      end
+      its(:primary_language) { is_expected.to eq 'English' }
+    end
   end
 end


### PR DESCRIPTION
This commit adds first 10 descriptive metadata properties. Also adds `rspec-its` gem.

Closes #85 