### PR TITLE
Makes factory traits dynamic

### DIFF
--- a/spec/factories/curate_generic_works.rb
+++ b/spec/factories/curate_generic_works.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     transient do
       user { create(:user) }
       # Set to true (or a hash) if you want to create an admin set
-      with_admin_set false
+      with_admin_set { false }
     end
 
     # It is reasonable to assume that a work has an admin set; However, we don't want to
@@ -22,8 +22,8 @@ FactoryBot.define do
       work.save! if work.member_of_collections.present?
     end
 
-    title ["Test title"]
-    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    title { ["Test title"] }
+    visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
 
     after(:build) do |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
@@ -32,15 +32,15 @@ FactoryBot.define do
     factory :public_generic_work, aliases: [:public_work], traits: [:public]
 
     trait :public do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
 
     factory :private_work do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
     factory :registered_generic_work do
-      read_groups ["registered"]
+      read_groups { ["registered"] }
     end
 
     factory :work_with_one_file do
@@ -100,7 +100,7 @@ FactoryBot.define do
       # let(:work) { create(:embargoed_work, with_embargo_attributes: embargo_attributes) }
 
       transient do
-        with_embargo_attributes false
+        with_embargo_attributes { false }
         embargo_date { Date.tomorrow.to_s }
         current_state { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
         future_state { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
@@ -147,7 +147,7 @@ FactoryBot.define do
       # let(:work) { create(:leased_work, with_lease_attributes: lease_attributes) }
 
       transient do
-        with_lease_attributes false
+        with_lease_attributes { false }
         lease_date { Date.tomorrow.to_s }
         current_state { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
         future_state { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
@@ -184,7 +184,7 @@ FactoryBot.define do
 
   # Doesn't set up any edit_users
   factory :work_without_access, class: CurateGenericWork do
-    title ['Test title']
+    title { ['Test title'] }
     depositor { create(:user).user_key }
   end
 end

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :file_set do
     transient do
       user { create(:user) }
-      content nil
+      content { nil }
     end
     after(:build) do |fs, evaluator|
       fs.apply_depositor_metadata evaluator.user.user_key
@@ -13,11 +13,11 @@ FactoryBot.define do
     end
 
     trait :public do
-      read_groups ["public"]
+      read_groups { ["public"] }
     end
 
     trait :registered do
-      read_groups ["registered"]
+      read_groups { ["registered"] }
     end
 
     factory :file_with_work do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     transient do
       # Allow for custom groups when a user is instantiated.
       # @example FactoryBot.create(:user, groups: 'admin')
-      groups []
+      groups { [] }
     end
 
     after(:build) do |user, evaluator|
@@ -31,7 +31,7 @@ FactoryBot.define do
     end
 
     trait :guest do
-      guest true
+      guest { true }
     end
   end
 end


### PR DESCRIPTION
Rubocop complains that the current factories use static traits, which will be removed in a upcoming version of FactoryBot. This changes them to be dynamic, and removes those warnings.