### PR TITLE
Updates Rubocop and adds Pry for debugging.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,14 +1,31 @@
 inherit_gem:
   bixby: bixby_default.yml
 
-Metrics/AbcSize:
-  Enabled: false
+AllCops:
+    TargetRubyVersion: 2.5
+    Exclude:
+        - 'bin/**/*'
+        - 'db/**/*'
+        - 'tmp/**/*'
+        - 'vendor/**/*'
+
+Style/FrozenStringLiteralComment:
+    Enabled: false
 
 Metrics/BlockLength:
-  Enabled: false
-
-RSpec/ExampleLength:
-  Enabled: false
+    Exclude:
+        - 'spec/**/*'
+        - 'config/routes.rb'
+        - 'config/initializers/simple_form_bootstrap.rb'
+        - 'app/controllers/catalog_controller.rb'
 
 Metrics/ClassLength:
-  Enabled: false
+    Exclude:
+        - 'spec/**/*'
+        - 'app/models/curate_generic_work.rb'
+        - 'app/controllers/catalog_controller.rb'
+
+RSpec/ExampleLength:
+    Exclude:
+        - 'spec/**/*'
+

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ group :development, :test do
   gem 'bixby' # bixby = rubocop rules for Hyrax apps
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry' unless ENV['CI']
+  gem 'pry-byebug' unless ENV['CI']
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13'
   gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,7 @@ GEM
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     clipboard-rails (1.7.1)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -563,6 +564,12 @@ GEM
     posix-spawn (0.3.13)
     power_converter (0.1.2)
     powerpack (0.1.2)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.7.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     public_suffix (3.0.3)
     pul_uv_rails (2.0.1)
     puma (3.12.1)
@@ -882,6 +889,8 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mysql2
   omniauth-shibboleth (~> 1.3)
+  pry
+  pry-byebug
   puma (~> 3.7)
   rails (~> 5.1.6)
   riiif (~> 2.0)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,12 +39,9 @@ class User < ApplicationRecord
   # a new one. Populate it with data we get from shibboleth.
   # @param [OmniAuth::AuthHash] auth
   def self.from_omniauth(auth)
-    Rails.logger.debug "auth = #{auth.inspect}"
     raise User::NilShibbolethUserError.new("No uid", auth) if auth.uid.empty? || auth.info.uid.empty?
-    user = where(provider: auth.provider, uid: auth.info.uid).first_or_create
-    user.display_name = auth.info.display_name
-    user.uid = auth.info.uid
-    user.ppid = auth.uid
+    user = User.find_or_initialize_by(provider: auth.provider, uid: auth.info.uid)
+    user.assign_attributes(display_name: auth.info.display_name, ppid: auth.uid)
     # tezprox@emory.edu isn't a real email address
     user.email = auth.info.uid + '@emory.edu' unless auth.info.uid == 'tezprox'
     user.save

--- a/lib/admin_setup.rb
+++ b/lib/admin_setup.rb
@@ -78,7 +78,7 @@ class AdminSetup
   # return an array of all current admins
   # @return [Array(User)]
   def admins
-    raise "No admins are defined" unless admin_role.users.count > 0
+    raise "No admins are defined" unless admin_role.users.count.positive?
     admin_role.users
   end
 end


### PR DESCRIPTION
- Push Rubocop to use Ruby 2.5 syntax. This pushes the admins task, and turning off the frozen string literal changes.

- Enable the ABC Size metric, and limit the others that are still off to only the failing files.

- The User model had two problems. First, the ABC size was too high, and second, AR's #first_or_create method has been silently unsupported. Switching to #find_or_initialize_by solves the second problem, and
using #assign_attributes fixes the first.

- Pry can do debugging like byebug, but adds a bunch of convenience. Use `binding.pry` where you would have used `byebug`.