### PR TITLE
Adds visibility and other params to permitted_params for form

### DIFF
--- a/app/forms/hyrax/curate_generic_work_form.rb
+++ b/app/forms/hyrax/curate_generic_work_form.rb
@@ -43,5 +43,20 @@ module Hyrax
     def primary_admin_metadata_fields
       [:staff_note, :system_of_record_ID, :legacy_identifier, :legacy_ark, :date_digitized, :transfer_engineer]
     end
+
+    def self.build_permitted_params
+      permitted = super
+      permitted += [:representative_id,
+                    :thumbnail_id,
+                    :admin_set_id,
+                    :visibility_during_embargo,
+                    :embargo_release_date,
+                    :visibility_after_embargo,
+                    :visibility_during_lease,
+                    :lease_expiration_date,
+                    :visibility_after_lease,
+                    :visibility]
+      permitted
+    end
   end
 end

--- a/app/views/records/edit_fields/_data_classification.html.erb
+++ b/app/views/records/edit_fields/_data_classification.html.erb
@@ -1,7 +1,8 @@
 <% data_classification = Hyrax::DataClassificationService.new %>
 
-<%= f.input :data_classification, as: :select,
+<%= f.input :data_classification, as: :multi_value_select,
     collection: data_classification.select_active_options,
     include_blank: true, required: true,
     item_helper: data_classification.method(:include_current_value),
     input_html: { class: 'form-control' } %>
+    

--- a/app/views/records/edit_fields/_subject_geo.html.erb
+++ b/app/views/records/edit_fields/_subject_geo.html.erb
@@ -1,5 +1,6 @@
 <%=
   f.input key,
+  as: :multi_value,
   input_html: {
     class: 'form-control',
     data: { 'autocomplete-url' => "/authorities/search/geonames",

--- a/config/authorities/data_classification.yml
+++ b/config/authorities/data_classification.yml
@@ -1,9 +1,13 @@
 terms:
     - id: Public
       term: Public
+      active: true
     - id: Internal
       term: Internal
+      active: true
     - id: Confidential
       term: Confidential
+      active: true
     - id: Restricted
       term: Restricted
+      active: true

--- a/spec/features/create_curate_generic_work_spec.rb
+++ b/spec/features/create_curate_generic_work_spec.rb
@@ -17,8 +17,6 @@ RSpec.feature 'Create a CurateGenericWork' do
     let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
     let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
 
-    let(:new_cgw_form) { NewCurateGenericWorkForm.new }
-
     before do
       # Create a single action that can be taken
       Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
@@ -32,6 +30,9 @@ RSpec.feature 'Create a CurateGenericWork' do
       )
       login_as user
     end
+
+    let(:new_cgw_form) { NewCurateGenericWorkForm.new }
+    let(:cgw) { FactoryBot.create(:work, user: user) }
 
     scenario "'descriptions' loads with all its inputs", js: true do
       new_cgw_form.visit_new_page
@@ -92,6 +93,19 @@ RSpec.feature 'Create a CurateGenericWork' do
       click_link('Additional descriptive fields')
       fill_in "curate_generic_work[institution]", with: "Test3"
       expect(find('div.ui-menu-item-wrapper', match: :first).text).to eq 'Test3'
+    end
+
+    scenario "verify work visibility can be edited" do
+      expect(cgw.visibility).to eq 'restricted'
+
+      visit("/concern/curate_generic_works/#{cgw.id}/edit")
+
+      find('body').click
+      choose('curate_generic_work_visibility_open')
+      click_on('Save')
+
+      cgw.reload
+      expect(cgw.visibility).to eq 'open'
     end
 
     scenario "Create Curate Work" do


### PR DESCRIPTION
Visibility and a few other params were getting escaped and being listed as unpermitted when saving form.
This commit also edits data_classification and subject_geo metadata properties to align them with the given requirements.

Closes #202 