### PR TITLE
Changes institution_name to Emory Network.

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -52,7 +52,7 @@ en:
     footer:
       copyright_html: "<strong>Copyright &copy; 2018 Samvera</strong> Licensed under the Apache License, Version 2.0"
       service_html: A service of <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
-    institution_name: Institution
+    institution_name: Emory Network
     institution_name_full: The Institution Name
     product_name: Hyrax
     product_twitter_handle: "@SamveraRepo"


### PR DESCRIPTION
After: ![visibility](https://user-images.githubusercontent.com/638392/59209689-ea512180-8b79-11e9-81e7-53abb079f237.JPG)

Note: This changes the name in other places as well, including the terms of service.