### PR TITLE
Fixes a warning from the Passenger logs

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -102,7 +102,7 @@ Hyrax.config do |config|
   # config.arkivo_api = false
 
   # Stream realtime notifications to users in the browser
-  # config.realtime_notifications = true
+  config.realtime_notifications = false
 
   # Location autocomplete uses geonames to search for named regions
   # Username for connecting to geonames


### PR DESCRIPTION
WARN -- : Cannot enable realtime notifications atop Passenger + Apache.
Coercing `Hyrax.config.realtime_notifications` to `false`. Set this
value to `false` in config/initializers/hyrax.rb to stop seeing this
warning.