### PR TITLE
Original file fix

### DIFF
--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -26,6 +26,10 @@ class FileSet < ActiveFedora::Base
     !primary?
   end
 
+  def original_file
+    preservation_master_file
+  end
+
   include ::Hyrax::FileSetBehavior
 
   directly_contains_one :preservation_master_file, through: :files, type: ::RDF::URI('http://pcdm.org/use#PreservationMasterFile'), class_name: 'Hydra::PCDM::File'

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -1,8 +1,14 @@
 require 'rails_helper'
 
-RSpec.describe FileSet do
+RSpec.describe FileSet, :perform_enqueued do
   describe '#related_files' do
-    let!(:f1) { described_class.new }
+    let!(:f1) { FactoryBot.create(:file_set, content: File.open(Rails.root.join('spec', 'fixtures', 'world.png'))) }
+
+    describe "#original_file" do
+      it "is the same as the preservation_master_file" do
+        expect(f1.original_file).to eq(f1.preservation_master_file)
+      end
+    end
 
     context 'when there are no related files' do
       it 'returns an empty array' do


### PR DESCRIPTION
The `original_file` property is empty when creating
a Work through the UI. This needs to be set
because it used to create file metadata and derivatives.