### PR TITLE
Database auth in production

### DIFF
--- a/app/models/auth_config.rb
+++ b/app/models/auth_config.rb
@@ -3,6 +3,6 @@ class AuthConfig
   # but in development mode, you may want to use local database
   # authentication instead.
   def self.use_database_auth?
-    !Rails.env.production? && ENV['DATABASE_AUTH'] == 'true'
+    ENV['DATABASE_AUTH'] == 'true'
   end
 end

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 server 'curate-qa.curationexperts.com', user: 'deploy', roles: [:web, :app, :db, :ubuntuapp]
-set :repo_url, "https://github.com/curationexperts/dlp-curate.git"
 
 namespace :deploy do
   after :finishing, :restart_apache do


### PR DESCRIPTION
@rotated8 Would it be okay if we use database authentication on our systems instead of getting shibboleth set up? It would let us get to the building of the importer much more quickly.