### PR TITLE
Database migrations should always run on cap deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,6 +6,7 @@ set :repo_url, "https://github.com/emory-libraries/dlp-curate.git"
 set :deploy_to, '/opt/dlp-curate'
 set :rails_env, 'production'
 set :assets_prefix, "#{shared_path}/public/assets"
+set :migration_role, :app
 
 SSHKit.config.command_map[:rake] = 'bundle exec rake'
 set :branch, ENV['REVISION'] || ENV['BRANCH'] || ENV['BRANCH_NAME'] || 'master'
@@ -47,9 +48,6 @@ namespace :deploy do
   end
 end
 
-namespace :deploy do
-  Rake::Task["migrate"].clear_actions
-end
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 


### PR DESCRIPTION
Running a cap deploy should always include running database migrations;
Otherwise, we could get into a state where the database schema
and the software do not align.

I do not know what this line was trying to do:

`Rake::Task["migrate"].clear_actions`

But removing it restores the expected db:migrate task during a cap
deploy:

```
bess@paz: (master):~/projects/dlp-curate$ cap qa deploy | grep migrate
00:42 deploy:migrate
      [deploy:migrate] Run `rake db:migrate`
      01 bundle exec rake db:migrate
```

Connected to https://github.com/curationexperts/dlp-curate/issues/21