### PR TITLE
Change Collection Indexer to match new terms

### DIFF
--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -8,7 +8,7 @@ module Hyrax
       # Used by the search builder
       attr_reader :scope
 
-      delegate :id, :depositor, :permissions, :human_readable_type, :member_ids, :nestable?, to: :model
+      delegate :id, :depositor, :permissions, :human_readable_type, :member_ids, :nestable?, :thumbnail_id, to: :model
 
       class_attribute :membership_service_class
 

--- a/app/indexers/curate_collection_indexer.rb
+++ b/app/indexers/curate_collection_indexer.rb
@@ -1,0 +1,5 @@
+class CurateCollectionIndexer < Hyrax::CollectionIndexer
+  def rdf_service
+    CurateIndexer
+  end
+end

--- a/app/indexers/curate_indexer.rb
+++ b/app/indexers/curate_indexer.rb
@@ -1,0 +1,49 @@
+# This class gets called by ActiveFedora::IndexingService#olrize_rdf_assertions
+class CurateIndexer < ActiveFedora::RDF::IndexingService
+  class_attribute :stored_and_facetable_fields, :stored_fields, :symbol_fields
+  self.stored_and_facetable_fields = %i[creator contributor holding_repository primary_language subject_topics subject_names subject_geo]
+  self.stored_fields = %i[abstract administrative_unit abstract institution
+                          local_call_number keywords subject_time_periods note sensitive_material
+                          internal_rights_note contact_information staff_note system_of_record_ID
+                          legacy_ark primary_repository_ID]
+  # self.symbol_fields = %i[import_url]
+
+  private
+
+    # This method overrides ActiveFedora::RDF::IndexingService
+    # @return [ActiveFedora::Indexing::Map]
+    def index_config
+      merge_config(
+        merge_config(super, stored_and_facetable_index_config),
+        stored_searchable_index_config
+      )
+    end
+
+    # This can be replaced by a simple merge once
+    # https://github.com/samvera/active_fedora/pull/1227
+    # is available to us
+    # @param [ActiveFedora::Indexing::Map] first
+    # @param [Hash] second
+    def merge_config(first, second)
+      first_hash = first.instance_variable_get(:@hash).deep_dup
+      ActiveFedora::Indexing::Map.new(first_hash.merge(second))
+    end
+
+    def stored_and_facetable_index_config
+      stored_and_facetable_fields.each_with_object({}) do |name, hash|
+        hash[name] = index_object_for(name, as: [:stored_searchable, :facetable])
+      end
+    end
+
+    def stored_searchable_index_config
+      stored_fields.each_with_object({}) do |name, hash|
+        hash[name] = index_object_for(name, as: [:stored_searchable])
+      end
+    end
+
+    def index_object_for(attribute_name, as: [])
+      ActiveFedora::Indexing::Map::IndexObject.new(attribute_name) do |idx|
+        idx.as(*as)
+      end
+    end
+end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -3,7 +3,7 @@ class Collection < ActiveFedora::Base
   include ::Hyrax::CollectionBehavior
   require 'noid-rails'
 
-  self.indexer = Hyrax::CollectionWithBasicMetadataIndexer
+  self.indexer = CurateCollectionIndexer
 
   def assign_id
     self.id = service.mint unless new_record?

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,7 @@ require 'noid/rails/rspec'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -81,12 +81,4 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
-
-  # Selenium-webdriver with longer timeout
-  Capybara.register_driver :selenium_with_long_timeout do |app|
-    client = Selenium::WebDriver::Remote::Http::Default.new
-    client.read_timeout = 120
-    Capybara::Selenium::Driver.new(app, browser: :chrome, http_client: client)
-  end
-  Capybara.javascript_driver = :selenium_with_long_timeout
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,28 @@
+# Setup chrome headless driver
+Capybara.server = :puma, { Silent: true }
+
+Capybara.register_driver :chrome_headless do |app|
+  client = Selenium::WebDriver::Remote::Http::Default.new
+  client.read_timeout = 120
+
+  options = ::Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('--headless')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
+  options.add_argument('--window-size=1400,1400')
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options, http_client: client)
+end
+
+Capybara.javascript_driver = :chrome_headless
+
+# Setup rspec
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by :chrome_headless
+  end
+end

--- a/spec/system/create_collection_spec.rb
+++ b/spec/system/create_collection_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Creating a collection', :perform_jobs, :clean, type: :system, js: true do
+  context 'logged in as an admin user' do
+    let(:admin_user) { FactoryBot.create(:admin) }
+    before do
+      login_as admin_user
+    end
+
+    it 'sucessfully creates a collection with the UI' do
+      visit 'dashboard/collections/new'
+      expect(page).to have_content 'New User Collection'
+      fill_in 'Title', with: 'testing title'
+      fill_in 'Library', with: 'testing library'
+      fill_in 'Creator', with: 'creator'
+      fill_in 'Description/Abstract', with: 'test'
+      fill_in 'Persistent URL', with: 'https://example.org/collection'
+      click_on 'Save'
+      expect(page).to have_content 'Collection was successfully created'
+    end
+  end
+end


### PR DESCRIPTION
This changes the indexers for the `Collection` model
to match the chosen terms.

This is tested with a system spec that creates a `Collection`
in the UI and checks to see if it was successful. Without
these indexer changes the process will fail because it will
try to index terms that don't exist on the `Collection` model.