### PR TITLE
Ensure default admin set exists

### DIFF
--- a/spec/system/create_collection_spec.rb
+++ b/spec/system/create_collection_spec.rb
@@ -3,10 +3,14 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.describe 'Creating a collection', :perform_jobs, :clean, type: :system, js: true do
+RSpec.describe 'Creating a collection', :perform_jobs, clean: true, type: :system, js: true do
   context 'logged in as an admin user' do
+    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
     let(:admin_user) { FactoryBot.create(:admin) }
     before do
+      admin_set_id
+      permission_template
       login_as admin_user
     end
 


### PR DESCRIPTION
Before we create a collection, ensure default admin set and permission
template exist. Otherwise, we get intermittent test failures for this
one.

Connected to https://github.com/curationexperts/in-house/issues/194