### PR TITLE
Import content_type as a uri

### DIFF
--- a/spec/importers/curate_mapper_spec.rb
+++ b/spec/importers/curate_mapper_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe CurateMapper do
 
   let(:metadata) do
     {
-      "title" => "what an awesome title" # title
+      "title" => "what an awesome title", # title
+      "content_type" => 'still image'
     }
   end
 
@@ -17,10 +18,29 @@ RSpec.describe CurateMapper do
     expect(Zizia.config.metadata_mapper_class).to eq described_class
   end
 
-  it "maps resource type to local authority values, if possible" do
-    expect(mapper.title).to contain_exactly(
-      "what an awesome title"
-    )
+  context "content_type" do
+    context "when the string matches exactly" do
+      let(:metadata) do
+        {
+          "title" => "my title",
+          "content_type" => 'Still image'
+        }
+      end
+      it "maps content_type to a uri" do
+        expect(mapper.content_type).to eq "http://id.loc.gov/vocabulary/resourceTypes/img"
+      end
+    end
+    context "when the string matches except for capitalization and whitespace" do
+      let(:metadata) do
+        {
+          "title" => "my title",
+          "content_type" => 'still image  '
+        }
+      end
+      it "maps content_type to a uri" do
+        expect(mapper.content_type).to eq "http://id.loc.gov/vocabulary/resourceTypes/img"
+      end
+    end
   end
 
   it "maps the required title field" do

--- a/spec/system/import_langmuir_from_csv_spec.rb
+++ b/spec/system/import_langmuir_from_csv_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe 'Importing records from a Langmuir CSV', :perform_jobs, :clean, t
       # Ensure that all the fields got assigned as expected
       work = CurateGenericWork.where(title: "*Tennessee*").first
       expect(work.title.first).to match(/Tennessee/)
+      expect(work.content_type).to eq "http://id.loc.gov/vocabulary/resourceTypes/img"
 
       visit "/dashboard/works"
       click_on 'Faculty and graduates of University of West Tennessee, Memphis, Tenn. in medicine, dentistry and nurse training in 1921'


### PR DESCRIPTION
* Expect the csv to contain a content type string
* Match that string to a label in the appropriate QA authority
* Record the URI on the record

Connected to https://github.com/curationexperts/in-house/issues/190