### PR TITLE
Bug fix: key not found: "active"

### DIFF
--- a/config/authorities/administrative_unit.yml
+++ b/config/authorities/administrative_unit.yml
@@ -1,5 +1,7 @@
 terms:
     - id: Emory University Archives
       term: Emory University Archives
+      active: true
     - id: Stuart A. Rose Manuscript, Archives, and Rare Book Library
       term: Stuart A. Rose Manuscript, Archives, and Rare Book Library
+      active: true

--- a/spec/factories/object_id.rb
+++ b/spec/factories/object_id.rb
@@ -1,0 +1,6 @@
+# Defines a new sequence
+FactoryBot.define do
+  sequence :object_id do |n|
+    "object_id_#{n}"
+  end
+end

--- a/spec/factories/permission_template_accesses.rb
+++ b/spec/factories/permission_template_accesses.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :permission_template_access, class: Hyrax::PermissionTemplateAccess do
+    permission_template
+    trait :manage do
+      access { 'manage' }
+    end
+
+    trait :deposit do
+      access { 'deposit' }
+    end
+
+    trait :view do
+      access { 'view' }
+    end
+  end
+end

--- a/spec/factories/permission_templates.rb
+++ b/spec/factories/permission_templates.rb
@@ -1,0 +1,79 @@
+FactoryBot.define do
+  factory :permission_template, class: Hyrax::PermissionTemplate do
+    # Given that there is a one to one strong relation between permission_template and admin_set,
+    # with a unique index on the source_id, I don't want to have duplication in source_id
+    sequence(:source_id) { |n| format("%010d", n) }
+
+    before(:create) do |permission_template, evaluator|
+      if evaluator.with_admin_set
+        source_id = permission_template.source_id
+        admin_set =
+          if source_id.present?
+            begin
+              AdminSet.find(source_id)
+            rescue ActiveFedora::ObjectNotFoundError
+              create(:admin_set, id: source_id)
+            end
+          else
+            create(:admin_set)
+          end
+        permission_template.source_id = admin_set.id
+      elsif evaluator.with_collection
+        source_id = permission_template.source_id
+        collection =
+          if source_id.present?
+            begin
+              Collection.find(source_id)
+            rescue ActiveFedora::ObjectNotFoundError
+              create(:collection, id: source_id)
+            end
+          else
+            create(:collection)
+          end
+        permission_template.source_id = collection.id
+      end
+    end
+
+    after(:create) do |permission_template, evaluator|
+      if evaluator.with_workflows
+        Hyrax::Workflow::WorkflowImporter.load_workflow_for(permission_template: permission_template)
+        Sipity::Workflow.activate!(permission_template: permission_template, workflow_id: permission_template.available_workflows.pluck(:id).first)
+      end
+      if evaluator.with_active_workflow
+        workflow = create(:workflow, active: true, permission_template: permission_template)
+        create(:workflow_action, workflow: workflow) # Need to create a single action that can be taken
+      end
+      AccessHelper.create_access(permission_template, 'user', :manage, evaluator.manage_users) if evaluator.manage_users.present?
+      AccessHelper.create_access(permission_template, 'group', :manage, evaluator.manage_groups) if evaluator.manage_groups.present?
+      AccessHelper.create_access(permission_template, 'user', :deposit, evaluator.deposit_users) if evaluator.deposit_users.present?
+      AccessHelper.create_access(permission_template, 'group', :deposit, evaluator.deposit_groups) if evaluator.deposit_groups.present?
+      AccessHelper.create_access(permission_template, 'user', :view, evaluator.view_users) if evaluator.view_users.present?
+      AccessHelper.create_access(permission_template, 'group', :view, evaluator.view_groups) if evaluator.view_groups.present?
+    end
+
+    transient do
+      with_admin_set { false }
+      with_collection { false }
+      with_workflows { false }
+      with_active_workflow { false }
+      manage_users { nil }
+      manage_groups { nil }
+      deposit_users { nil }
+      deposit_groups { nil }
+      view_users { nil }
+      view_groups { nil }
+    end
+  end
+
+  class AccessHelper
+    def self.create_access(permission_template_id, agent_type, access, agent_ids)
+      agent_ids.each do |agent_id|
+        FactoryBot.create(:permission_template_access,
+                          access,
+                          permission_template: permission_template_id,
+                          agent_type: agent_type,
+                          agent_id: agent_id)
+      end
+    end
+  end
+end

--- a/spec/models/qa/local_authority_spec.rb
+++ b/spec/models/qa/local_authority_spec.rb
@@ -1,5 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Qa::LocalAuthority, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context 'resource_types' do
+    it 'has active terms for everything' do
+      active_terms = Qa::Authorities::Local.subauthority_for('resource_types').all.select { |term| term[:active] }
+      expect(active_terms).not_to be_empty
+    end
+  end
+
+  context 'administrative_unit' do
+    it 'has active terms for everything' do
+      active_terms = Qa::Authorities::Local.subauthority_for('administrative_unit').all.select { |term| term[:active] }
+      expect(active_terms).not_to be_empty
+    end
+  end
 end

--- a/spec/system/edit_collection_spec.rb
+++ b/spec/system/edit_collection_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Edit an existing collection', :clean, type: :system, js: true do
+  let(:collection) { Collection.create!(collection_attrs) }
+  let(:collection) { FactoryBot.create(:collection_lw, user: admin) }
+  let(:admin) { FactoryBot.create :admin }
+
+  let(:collection_attrs) do
+    {
+      title: ['Robert Langmuir African American Photograph Collection'],
+      institution: 'Emory University',
+      creator: ['Langmuir, Robert, collector.'],
+      holding_repository: ['Stuart A. Rose Manuscript, Archives, and Rare Book Library'],
+      administrative_unit: ['Stuart A. Rose Manuscript, Archives, and Rare Book Library'],
+      contact_information: 'Woodruff Library',
+      abstract: 'Collection of photographs depicting African American life and culture collected by Robert Langmuir.',
+      primary_language: 'English',
+      local_call_number: 'MSS1218',
+      keywords: ['keyword1', 'keyword2']
+    }
+  end
+
+  before do
+    # Set all the attributes of collection
+    # Normally we'd do this in the FactoryBot factory, but in this case we want
+    # to use the Hyrax factories.
+    collection_attrs.each do |k, v|
+      collection.send((k.to_s + "=").to_sym, v)
+    end
+    collection.save
+  end
+
+  context 'logged in as an admin user' do
+    before { login_as admin }
+
+    scenario 'successfully edits the work' do
+      visit "/dashboard/collections/#{collection.id}/edit"
+      expect(find_field('Title').value).to eq 'Robert Langmuir African American Photograph Collection'
+      expect(find_field('Library').value).to eq 'Stuart A. Rose Manuscript, Archives, and Rare Book Library'
+      expect(find_field('Creator').value).to eq 'Langmuir, Robert, collector.'
+      expect(find_field('Description/Abstract').value).to eq 'Collection of photographs depicting African American life and culture collected by Robert Langmuir.'
+      click_on 'Additional fields'
+      expect(find_field('Administrative Unit').value).to eq 'Stuart A. Rose Manuscript, Archives, and Rare Book Library'
+
+      # Edit some fields in the form
+      fill_in 'Title', with: 'New Title'
+
+      click_on 'Save changes'
+
+      # Now the form should have the new values
+      expect(page).to have_content 'New Title'
+    end
+  end
+end


### PR DESCRIPTION
This fixes a bug where the collection edit form would not render if
there was a saved value in the administrative_unit field. The root cause
of this was that the form wanted to filter on "active" QA values, and
administrative_unit didn't have anything explicitly marked as "active".

This PR adds explicit "active" designation to the administrative_unit QA
config.

It also adds a system spec for the collection edit form as well as some
unit tests for QA configuration.

Connected to https://github.com/emory-libraries/dlp-curate/issues/418