### PR TITLE
Update CircleCI to use latest Samvera orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    samvera: samvera/circleci-orb@dev:fix-bundle-cache
+    samvera: samvera/circleci-orb@0.3.1
 jobs:
     build:
         parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,3 +49,7 @@ workflows:
         jobs:
             - build:
                 name: ruby2-5-3
+
+notify:
+    webhooks:
+        url: https://coveralls.io/webhook?repo_token=${COVERALLS_REPO_TOKEN}


### PR DESCRIPTION
The orb release being referenced wasn't a valid release number according to https://circleci.com/orbs/registry/orb/samvera/circleci-orb.  Trying the latest samvera/circleci-orb version to see if it fixes coveralls notifications.