### PR TITLE
Ensure library collection type exists on all curate systems

### DIFF
--- a/app/models/curate/collection_type.rb
+++ b/app/models/curate/collection_type.rb
@@ -1,5 +1,9 @@
 module Curate
   class CollectionType < Hyrax::CollectionType
+    def self.find_or_create_library_collection_type
+      Curate::CollectionType.find_by_title("Library Collection") || Curate::CollectionType.new.save
+    end
+
     def initialize
       super
       self.title = "Library Collection"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -67,6 +67,15 @@ namespace :deploy do
   end
 end
 
+# On deploy, ensure library collection type exists
+namespace :deploy do
+  after :finishing, :create_library_collection_type do
+    on roles(:app) do
+      execute "cd #{current_path} && RAILS_ENV=production bundle exec rake curate:create_library_collection_type"
+    end
+  end
+end
+
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 

--- a/lib/tasks/curate_collection_type.rake
+++ b/lib/tasks/curate_collection_type.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :curate do
+  desc 'Ensure CollectionType "Library Collection" exists'
+  task create_library_collection_type: [:environment] do
+    Curate::CollectionType.find_or_create_library_collection_type
+  end
+end

--- a/spec/models/curate/curate_collection_type_spec.rb
+++ b/spec/models/curate/curate_collection_type_spec.rb
@@ -1,7 +1,15 @@
 require 'rails_helper'
 
-RSpec.describe Curate::CollectionType, type: :model do
+RSpec.describe Curate::CollectionType, :clean, type: :model do
   let(:collection_type) { described_class.new }
+
+  it "we can find or create it easily and it won't proliferate" do
+    expect(Curate::CollectionType.count).to eq 0
+    Curate::CollectionType.find_or_create_library_collection_type
+    expect(Curate::CollectionType.count).to eq 1
+    Curate::CollectionType.find_or_create_library_collection_type
+    expect(Curate::CollectionType.count).to eq 1
+  end
 
   it "is named Library Collection" do
     expect(collection_type.title).to eq "Library Collection"


### PR DESCRIPTION
* Create it easily with an idempotent rake task
* Run this task whenever we deploy, so we always have the expected collection type to work with

Connected to https://github.com/emory-libraries/dlp-curate/issues/383