### PR TITLE
Add UV config

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -136,21 +136,29 @@ Hyrax.config do |config|
   #   * iiif_image_size_default
   #
   # Default is false
-  # config.iiif_image_server = false
+  config.iiif_image_server = true
 
-  # Returns a URL that resolves to an image provided by a IIIF image server
+  # If we have an external IIIF server, use it for image requests; else, use riiif
   config.iiif_image_url_builder = lambda do |file_id, base_url, size|
-    Riiif::Engine.routes.url_helpers.image_url(file_id, host: base_url, size: size)
+    if ENV['IIIF_SERVER_URL'].present?
+      iiif_url = ENV['IIIF_SERVER_URL'] + file_id.gsub('/', '%2F') + "/full/" + size + "/0/default.jpg"
+      Rails.logger.debug "event: iiif_image_request: #{iiif_url}"
+      iiif_url
+    else
+      Riiif::Engine.routes.url_helpers.image_url(file_id, host: base_url, size: size)
+    end
   end
-  # config.iiif_image_url_builder = lambda do |file_id, base_url, size|
-  #   "#{base_url}/downloads/#{file_id.split('/').first}"
-  # end
 
-  # Returns a URL that resolves to an info.json file provided by a IIIF image server
+  # If we have an external IIIF server, use it for info.json; else, use riiif
   config.iiif_info_url_builder = lambda do |file_id, base_url|
-    uri = Riiif::Engine.routes.url_helpers.info_url(file_id, host: base_url)
-    uri.sub(%r{/info\.json\Z}, '')
+    if ENV['IIIF_SERVER_URL'].present?
+      ENV['IIIF_SERVER_URL'] + file_id.gsub('/', '%2F')
+    else
+      uri = Riiif::Engine.routes.url_helpers.info_url(file_id, host: base_url)
+      uri.sub(%r{/info\.json\Z}, '')
+    end
   end
+
   # config.iiif_info_url_builder = lambda do |_, _|
   #   ""
   # end


### PR DESCRIPTION
This adds the basic UV config to turn it on
and have it display images in developement
mode. If the `IIIF_SERVER_URL` is not set
it will use `Riiif` to display the images.

When Cantaloupe is setup that variable should
be set.