### PR TITLE
Create Langmuir collection on every system

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,10 @@ AllCops:
 Style/FrozenStringLiteralComment:
     Enabled: false
 
+Metrics/AbcSize:
+  Exclude:
+    - app/importers/curate_collection_importer.rb
+
 Metrics/BlockLength:
     Exclude:
         - 'spec/**/*'
@@ -23,6 +27,7 @@ Metrics/BlockLength:
         - 'config/initializers/simple_form_bootstrap.rb'
         - 'app/controllers/catalog_controller.rb'
         - 'config/initializers/hyrax.rb'
+        - app/importers/curate_collection_importer.rb
 
 Metrics/ClassLength:
     Exclude:
@@ -36,6 +41,7 @@ Metrics/ClassLength:
 Metrics/MethodLength:
     Exclude:
         - app/uploaders/zizia/csv_manifest_validator.rb
+        - app/importers/curate_collection_importer.rb
 
 RSpec/ExampleLength:
     Exclude:

--- a/app/importers/curate_collection_importer.rb
+++ b/app/importers/curate_collection_importer.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require 'csv'
+
+class CurateCollectionImporter
+  def initialize
+    @library_collection_type_gid = Curate::CollectionType.find_or_create_library_collection_type.gid
+  end
+
+  # If a Collection object with the specified call number already exists, return it
+  # for updating. Otherwise, create a new Collection object.
+  def check_for_existing_collection(local_call_number)
+    existing_collection = Collection.where(local_call_number: local_call_number)&.first
+    return existing_collection if existing_collection
+    Collection.new
+  end
+
+  def import(csv_file)
+    CSV.foreach(csv_file, headers: true) do |row|
+      collection_attrs = row.to_hash
+      local_call_number = collection_attrs["local_call_number"]
+      collection = check_for_existing_collection(local_call_number)
+      collection.local_call_number = local_call_number
+      collection.collection_type_gid = @library_collection_type_gid
+      collection.title = multivalue_mapping(collection_attrs, "title")
+      collection.institution = collection_attrs["institution"]
+      collection.holding_repository = multivalue_mapping(collection_attrs, "holding_repository")
+      collection.administrative_unit = multivalue_mapping(collection_attrs, "administrative_unit")
+      collection.contact_information = collection_attrs["contact_information"]
+      collection.abstract = collection_attrs["abstract"]
+      collection.primary_language = collection_attrs["primary_language"]
+      collection.keywords = multivalue_mapping(collection_attrs, "keywords")
+      collection.subject_topics = multivalue_mapping(collection_attrs, "subject_topics")
+      collection.subject_names = multivalue_mapping(collection_attrs, "subject_names")
+      collection.subject_geo = multivalue_mapping(collection_attrs, "subject_geo")
+      collection.subject_time_periods = multivalue_mapping(collection_attrs, "subject_time_periods")
+      collection.creator = multivalue_mapping(collection_attrs, "creator")
+      collection.contributor = multivalue_mapping(collection_attrs, "contributor")
+      collection.note = multivalue_mapping(collection_attrs, "note")
+      collection.rights_documentation = collection_attrs["rights_documentation"]
+      collection.internal_rights_note = collection_attrs["internal_rights_note"]
+      collection.sensitive_material = collection_attrs["sensitive_material"]
+      collection.staff_note = multivalue_mapping(collection_attrs, "staff_note")
+      collection.system_of_record_ID = collection_attrs["system_of_record_ID"]
+      collection.legacy_ark = multivalue_mapping(collection_attrs, "legacy_ark")
+      collection.primary_repository_ID = collection_attrs["primary_repository_ID"]
+      collection.save
+    end
+  end
+
+  # Return an array of values. Use pipe (|) as the delimiter for values.
+  # Strip any extra whitespace.
+  def multivalue_mapping(collection_attrs, fieldname)
+    return [] unless collection_attrs[fieldname]
+    collection_attrs[fieldname].split("|").map(&:strip)
+  end
+end

--- a/app/importers/curate_collection_importer.rb
+++ b/app/importers/curate_collection_importer.rb
@@ -19,6 +19,7 @@ class CurateCollectionImporter
       collection_attrs = row.to_hash
       local_call_number = collection_attrs["local_call_number"]
       collection = check_for_existing_collection(local_call_number)
+      collection.visibility = "open"
       collection.local_call_number = local_call_number
       collection.collection_type_gid = @library_collection_type_gid
       collection.title = multivalue_mapping(collection_attrs, "title")

--- a/config/collection_metadata/langmuir_collection.csv
+++ b/config/collection_metadata/langmuir_collection.csv
@@ -1,0 +1,8 @@
+title,institution,holding_repository,administrative_unit,contact_information,abstract,primary_language,local_call_number,keywords,subject_topics,subject_names,subject_geo,subject_time_periods,creator,contributor,note,rights_documentation,internal_rights_note,sensitive_material,staff_note,system_of_record_ID,legacy_ark,primary_repository_ID
+Robert Langmuir African American Photograph Collection,Emory University,"Stuart A. Rose Manuscript, Archives, and Rare Book Library","Stuart A. Rose Manuscript, Archives, and Rare Book Library","Rose Library
+Woodruff Library
+Emory University 
+540 Asbury Circle
+Atlanta, GA 30322 
+rose.library@emory.edu
+404-727-6887",Collection of photographs depicting African American life and culture collected by Robert Langmuir.,English,MSS1218,Keyword 1 | Keyword 2,African American children--Photographs | African American families--Photographs | African American photographers | African American men--Photographs | African American women--Photographs | African Americans--Southern States--Photographs | Photography--United States--History--19th century | Photography--United States--History--20th century,,,,"Langmuir, Robert, collector",,,,,No,,,,

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -76,6 +76,14 @@ namespace :deploy do
   end
 end
 
+namespace :deploy do
+  after :finishing, :create_migration_collections do
+    on roles(:app) do
+      execute "cd #{current_path} && RAILS_ENV=production bundle exec rake curate:collections:langmuir_setup"
+    end
+  end
+end
+
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 

--- a/lib/tasks/curate_collections.rake
+++ b/lib/tasks/curate_collections.rake
@@ -1,0 +1,14 @@
+namespace :curate do
+  namespace :collections do
+    desc 'Langmuir collection setup'
+    task langmuir_setup: [:environment] do
+      Rake::Task["hyrax:default_admin_set:create"].invoke
+      Rake::Task["hyrax:default_collection_types:create"].invoke
+      Rake::Task["curate:create_library_collection_type"].invoke
+      Rake::Task["hyrax:workflow:load"].invoke
+      langmuir_csv_file = Rails.root.join('config', 'collection_metadata', 'langmuir_collection.csv')
+      CurateCollectionImporter.new.import(langmuir_csv_file)
+      puts "Langmuir collection object created"
+    end
+  end
+end

--- a/spec/fixtures/csv_import/collections/langmuir_collection.csv
+++ b/spec/fixtures/csv_import/collections/langmuir_collection.csv
@@ -1,0 +1,8 @@
+title,institution,holding_repository,administrative_unit,contact_information,abstract,primary_language,local_call_number,keywords,subject_topics,subject_names,subject_geo,subject_time_periods,creator,contributor,note,rights_documentation,internal_rights_note,sensitive_material,staff_note,system_of_record_ID,legacy_ark,primary_repository_ID
+Robert Langmuir African American Photograph Collection,Emory University,"Stuart A. Rose Manuscript, Archives, and Rare Book Library","Stuart A. Rose Manuscript, Archives, and Rare Book Library","Rose Library
+Woodruff Library
+Emory University 
+540 Asbury Circle
+Atlanta, GA 30322 
+rose.library@emory.edu
+404-727-6887",Collection of photographs depicting African American life and culture collected by Robert Langmuir.,English,MSS1218,Keyword 1 | Keyword 2,African American children--Photographs | African American families--Photographs | African American photographers | African American men--Photographs | African American women--Photographs | African Americans--Southern States--Photographs | Photography--United States--History--19th century | Photography--United States--History--20th century,Name 1 | Name 2,Place 1 | Place 2,Era 1 | Era 2,"Langmuir, Robert, collector",Fake Contributor,Fake Note,http://rightsstatements.org/vocab/InC-NC/1.0/,Fake Internal Rights Note,No,Fake Staff Note,Fake System of Record ID,Fake legacy ark,Fake primary repository ID

--- a/spec/importers/curate_collection_importer_spec.rb
+++ b/spec/importers/curate_collection_importer_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CurateCollectionImporter, :clean do
+  subject(:cci) { described_class.new }
+  let(:langmuir_csv) { File.join(fixture_path, 'csv_import', 'collections', 'langmuir_collection.csv') }
+  let(:langmuir_collection) do
+    cci.import(langmuir_csv)
+    Collection.last
+  end
+
+  it 'makes a collection object' do
+    cci.import(langmuir_csv)
+    expect(Collection.count).to eq 1
+  end
+
+  it 'only makes one collection object per call number' do
+    cci.import(langmuir_csv)
+    expect(Collection.count).to eq 1
+    cci.import(langmuir_csv)
+    expect(Collection.count).to eq 1
+  end
+
+  it 'makes a collection using Curate::CollectionType' do
+    library_collection_type_gid = Curate::CollectionType.find_or_create_library_collection_type.gid
+    expect(langmuir_collection.collection_type_gid).to eq library_collection_type_gid
+  end
+
+  it 'has all expected metadata' do
+    langmuir_collection.reload
+    expect(langmuir_collection.title).to eq ["Robert Langmuir African American Photograph Collection"]
+    expect(langmuir_collection.institution).to eq "Emory University"
+    expect(langmuir_collection.holding_repository).to eq ["Stuart A. Rose Manuscript, Archives, and Rare Book Library"]
+    expect(langmuir_collection.administrative_unit).to eq ["Stuart A. Rose Manuscript, Archives, and Rare Book Library"]
+    expect(langmuir_collection.contact_information).to match(/Rose Library/)
+    expect(langmuir_collection.abstract).to match(/Collection of photographs/)
+    expect(langmuir_collection.primary_language).to eq "English"
+    expect(langmuir_collection.local_call_number).to eq "MSS1218"
+    expect(langmuir_collection.keywords).to contain_exactly("Keyword 1", "Keyword 2")
+    expect(langmuir_collection.subject_topics).to include("Photography--United States--History--19th century")
+    expect(langmuir_collection.subject_names).to include("Name 2")
+    expect(langmuir_collection.subject_geo).to include("Place 2")
+    expect(langmuir_collection.subject_time_periods).to include("Era 2")
+    expect(langmuir_collection.creator).to eq ["Langmuir, Robert, collector"]
+    expect(langmuir_collection.contributor).to include("Fake Contributor")
+    expect(langmuir_collection.note).to include("Fake Note")
+    expect(langmuir_collection.rights_documentation).to eq "http://rightsstatements.org/vocab/InC-NC/1.0/"
+    expect(langmuir_collection.internal_rights_note).to include("Fake Internal Rights Note")
+    expect(langmuir_collection.sensitive_material).to include("No")
+    expect(langmuir_collection.staff_note).to include("Fake Staff Note")
+    expect(langmuir_collection.system_of_record_ID).to include("Fake System of Record ID")
+    expect(langmuir_collection.legacy_ark).to include("Fake legacy ark")
+    expect(langmuir_collection.primary_repository_ID).to include("Fake primary repository ID")
+  end
+end


### PR DESCRIPTION
* Ensure only one collection per call number is created
* If a collection object exists already, find it and update its metadata
* Run the collection creation script on deploy so we always have the
expected collections in every environment

Connected to https://github.com/emory-libraries/dlp-curate/issues/403