### PR TITLE
Adjust fieldname for Collections metadata

### DIFF
--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -22,7 +22,7 @@ module Hyrax
       delegate :blacklight_config, to: Hyrax::CollectionsController
 
       self.terms = [:title, :holding_repository, :administrative_unit, :creator,
-                    :contributor, :abstract, :primary_language, :related_material,
+                    :contributor, :abstract, :primary_language, :finding_aid_link,
                     :institution, :local_call_number, :keywords, :subject_topics,
                     :subject_names, :subject_geo, :subject_time_periods, :note,
                     :rights_documentation, :sensitive_material, :internal_rights_note,
@@ -66,7 +66,7 @@ module Hyrax
 
       # Terms that appear within the accordion
       def secondary_terms
-        [:administrative_unit, :contributor, :primary_language, :related_material,
+        [:administrative_unit, :contributor, :primary_language, :finding_aid_link,
          :institution, :local_call_number, :keywords, :subject_topics, :subject_names,
          :subject_geo, :subject_time_periods, :note, :rights_documentation, :sensitive_material,
          :internal_rights_note, :contact_information, :staff_note, :system_of_record_ID, :legacy_ark]

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -9,7 +9,7 @@ class Collection < ActiveFedora::Base
     service.mint
   end
 
-  validates :related_material, url: true, if: -> { related_material.present? }
+  validates :finding_aid_link, url: true, if: -> { finding_aid_link.present? }
   validates :rights_documentation, url: true, if: -> { rights_documentation.present? }
 
   property :holding_repository, predicate: 'http://id.loc.gov/vocabulary/relators/rps' do |index|
@@ -36,7 +36,7 @@ class Collection < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
-  property :related_material, predicate: 'http://metadata.emory.edu/vocab/cor-terms#findingAid', multiple: false
+  property :finding_aid_link, predicate: 'http://metadata.emory.edu/vocab/cor-terms#findingAid', multiple: false
 
   property :institution, predicate: 'http://rdaregistry.info/Elements/u/P60402', multiple: false do |index|
     index.as :stored_searchable

--- a/app/views/collections/edit_fields/_related_material.html.erb
+++ b/app/views/collections/edit_fields/_related_material.html.erb
@@ -1,3 +1,3 @@
 <div>
-  <%= f.input :related_material, as: :text, input_html: { rows: '10' } %>
+  <%= f.input :finding_aid_link, as: :text, input_html: { rows: '10' } %>
 </div>

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -117,7 +117,7 @@ FactoryBot.define do
     contributor { ['Someone else'] }
     abstract { 'A detailed abstract' }
     primary_language { 'English' }
-    related_material { 'https://my-finding-aid.com' }
+    finding_aid_link { 'https://my-finding-aid.com' }
     institution { 'Emory' }
     local_call_number { '90210' }
     keywords { ['test collection'] }

--- a/spec/features/create_collection_spec.rb
+++ b/spec/features/create_collection_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'Create a collection' do
       visit("dashboard/collections/new?collection_type_id=1")
 
       click_link('Additional fields')
-      fill_in "collection[related_material]", with: "teststring"
+      fill_in "collection[finding_aid_link]", with: "teststring"
 
       click_on('Save')
 

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
 
     it do
       is_expected.to eq [:title, :holding_repository, :administrative_unit, :creator,
-                         :contributor, :abstract, :primary_language, :related_material,
+                         :contributor, :abstract, :primary_language, :finding_aid_link,
                          :institution, :local_call_number, :keywords, :subject_topics,
                          :subject_names, :subject_geo, :subject_time_periods, :note,
                          :rights_documentation, :sensitive_material, :internal_rights_note,
@@ -32,7 +32,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
 
     it do
       is_expected.to eq [
-        :administrative_unit, :contributor, :primary_language, :related_material, :institution,
+        :administrative_unit, :contributor, :primary_language, :finding_aid_link, :institution,
         :local_call_number, :keywords, :subject_topics, :subject_names, :subject_geo, :subject_time_periods,
         :note, :rights_documentation, :sensitive_material, :internal_rights_note, :contact_information,
         :staff_note, :system_of_record_ID, :legacy_ark
@@ -89,7 +89,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
 
     it do
       is_expected.to eq [:title, { holding_repository: [] }, { administrative_unit: [] }, { creator: [] }, { contributor: [] },
-                         :abstract, :primary_language, :related_material, :institution, :local_call_number, { keywords: [] },
+                         :abstract, :primary_language, :finding_aid_link, :institution, :local_call_number, { keywords: [] },
                          { subject_topics: [] }, { subject_names: [] }, { subject_geo: [] }, { subject_time_periods: [] },
                          { note: [] }, :rights_documentation, :sensitive_material, :internal_rights_note, :contact_information,
                          { staff_note: [] }, :system_of_record_ID, { legacy_ark: [] }, :primary_repository_ID,

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -109,21 +109,21 @@ RSpec.describe Collection do
     end
   end
 
-  describe "#related_material" do
+  describe "#finding_aid_link" do
     subject { described_class.new }
-    let(:related_material) { 'Free-text notes' }
+    let(:finding_aid_link) { 'http://findingaid.edu' }
 
     context "with new collection" do
-      its(:related_material) { is_expected.to be_falsey }
+      its(:finding_aid_link) { is_expected.to be_falsey }
     end
 
-    context "with a collection that has a related_material" do
+    context "with a collection that has a finding_aid_link" do
       subject do
         described_class.create.tap do |col|
-          col.related_material = related_material
+          col.finding_aid_link = finding_aid_link
         end
       end
-      its(:related_material) { is_expected.to eq related_material }
+      its(:finding_aid_link) { is_expected.to eq finding_aid_link }
     end
   end
 


### PR DESCRIPTION
Collections should have a finding_aid_link field instead of a
related_material field.

Connected to https://github.com/emory-libraries/dlp-curate/issues/450