### PR TITLE
Ensure migration collections have expected permissions

### DIFF
--- a/app/importers/curate_collection_importer.rb
+++ b/app/importers/curate_collection_importer.rb
@@ -46,7 +46,39 @@ class CurateCollectionImporter
       collection.primary_repository_ID = collection_attrs["primary_repository_ID"]
       collection.finding_aid_link = collection_attrs["finding_aid_link"]
       collection.save
+      add_repository_administrators_as_managers(collection)
     end
+  end
+
+  def find_or_create_permission_template(collection)
+    existing_hpt = Hyrax::PermissionTemplate.where(source_id: collection.id).try(:first)
+    return existing_hpt if existing_hpt
+    hpt = Hyrax::PermissionTemplate.new
+    hpt.source_id = collection.id
+    hpt.save
+    hpt
+  end
+
+  def repo_admins_have_manage_rights?(hpt)
+    existing_hpta = Hyrax::PermissionTemplateAccess.where(
+      permission_template_id: hpt.id,
+      agent_type: "group",
+      agent_id: "Repository Administrators",
+      access: "manage"
+    ).count
+    return true if existing_hpta.positive?
+    false
+  end
+
+  def add_repository_administrators_as_managers(collection)
+    hpt = find_or_create_permission_template(collection)
+    return if repo_admins_have_manage_rights?(hpt)
+    hpta = Hyrax::PermissionTemplateAccess.new
+    hpta.permission_template_id = hpt.id
+    hpta.agent_type = "group"
+    hpta.agent_id = "Repository Administrators"
+    hpta.access = "manage"
+    hpta.save
   end
 
   # Return an array of values. Use pipe (|) as the delimiter for values.

--- a/spec/system/migration_collections_spec.rb
+++ b/spec/system/migration_collections_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Depositing items into a migration collection', :perform_jobs, :clean, type: :system, js: true do
+  let(:library_collection_type) { Curate::CollectionType.find_or_create_library_collection_type }
+  let(:langmuir_csv_file) { Rails.root.join('config', 'collection_metadata', 'langmuir_collection.csv') }
+  let(:admin_user) { FactoryBot.create(:admin) }
+  let(:collection) do
+    Curate::CollectionType.find_or_create_library_collection_type
+    CurateCollectionImporter.new.import(langmuir_csv_file)
+    Collection.last
+  end
+
+  context 'logged in as an admin user' do
+    before do
+      allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on ci
+      login_as admin_user
+    end
+
+    it 'shows that Repository Administrators have rights on Library Collection objects' do
+      visit "/dashboard/collections/#{collection.id}/edit?locale=en#sharing"
+      expect(page).to have_content 'Repository Administrators'
+
+      hpt = Hyrax::PermissionTemplate.where(source_id: collection.id).first
+      hpta_count = Hyrax::PermissionTemplateAccess.where(
+        permission_template_id: hpt.id,
+        agent_type: "group",
+        agent_id: "Repository Administrators",
+        access: "manage"
+      ).count
+      expect(hpta_count).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
Ensure auto-created migration collections allow Repository
Administrators to deposit into them.

Connected to https://github.com/emory-libraries/dlp-curate/issues/469