### PR TITLE
Remove Primary Repository ID from collection form

### DIFF
--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -27,9 +27,9 @@ module Hyrax
                     :subject_names, :subject_geo, :subject_time_periods, :note,
                     :rights_documentation, :sensitive_material, :internal_rights_note,
                     :contact_information, :staff_note, :system_of_record_ID, :legacy_ark,
-                    :primary_repository_ID, :visibility]
+                    :visibility]
 
-      self.required_fields = [:title, :holding_repository, :creator, :abstract, :primary_repository_ID]
+      self.required_fields = [:title, :holding_repository, :creator, :abstract]
 
       self.single_valued_fields = [:title]
 
@@ -61,7 +61,7 @@ module Hyrax
 
       # Terms that appear above the accordion
       def primary_terms
-        [:title, :holding_repository, :creator, :abstract, :primary_repository_ID]
+        [:title, :holding_repository, :creator, :abstract]
       end
 
       # Terms that appear within the accordion

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
                          :subject_names, :subject_geo, :subject_time_periods, :note,
                          :rights_documentation, :sensitive_material, :internal_rights_note,
                          :contact_information, :staff_note, :system_of_record_ID, :legacy_ark,
-                         :primary_repository_ID, :visibility]
+                         :visibility]
     end
   end
 
@@ -24,7 +24,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
   describe "#primary_terms" do
     subject { form.primary_terms }
 
-    it { is_expected.to eq([:title, :holding_repository, :creator, :abstract, :primary_repository_ID]) }
+    it { is_expected.to eq([:title, :holding_repository, :creator, :abstract]) }
   end
 
   describe "#secondary_terms" do
@@ -92,7 +92,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
                          :abstract, :primary_language, :finding_aid_link, :institution, :local_call_number, { keywords: [] },
                          { subject_topics: [] }, { subject_names: [] }, { subject_geo: [] }, { subject_time_periods: [] },
                          { note: [] }, :rights_documentation, :sensitive_material, :internal_rights_note, :contact_information,
-                         { staff_note: [] }, :system_of_record_ID, { legacy_ark: [] }, :primary_repository_ID, :visibility,
+                         { staff_note: [] }, :system_of_record_ID, { legacy_ark: [] }, :visibility,
                          { permissions_attributes: [:type, :name, :access, :id, :_destroy] }]
     end
   end

--- a/spec/system/create_collection_spec.rb
+++ b/spec/system/create_collection_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe 'Creating a collection', :perform_jobs, clean: true, type: :syste
       fill_in 'Library', with: 'testing library'
       fill_in 'Creator', with: 'creator'
       fill_in 'Description/Abstract', with: 'test'
-      fill_in 'Persistent URL', with: 'https://example.org/collection'
       click_link('Additional fields')
       fill_in 'Finding aid link', with: 'https://example.org/collection'
       click_on 'Save'


### PR DESCRIPTION
Remove Primary Repository ID (label=Persistent URL) from the collection
edit form.

Connected to https://github.com/emory-libraries/dlp-curate/issues/406