### PR TITLE
Ensure deposit permissions are set for the collection

### DIFF
--- a/app/importers/collection_permission_ensurer.rb
+++ b/app/importers/collection_permission_ensurer.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class CollectionPermissionEnsurer
+  AGENT_ID = 'admin'
+  AGENT_TYPE = 'group'
+
+  def initialize(collection:, access_permissions:)
+    access_permissions.each do |access_permission|
+      hpt = find_or_create_permission_template(collection)
+      next if repo_admins_have_manage_rights?(hyrax_permission_template: hpt, access_permission: access_permission)
+      hpta = Hyrax::PermissionTemplateAccess.new
+      hpta.permission_template_id = hpt.id
+      hpta.agent_type = AGENT_TYPE
+      hpta.agent_id = AGENT_ID
+      hpta.access = access_permission
+      hpta.save
+    end
+  end
+
+    private
+
+      def find_or_create_permission_template(collection)
+        existing_hpt = Hyrax::PermissionTemplate.where(source_id: collection.id).try(:first)
+        return existing_hpt if existing_hpt
+        hpt = Hyrax::PermissionTemplate.new
+        hpt.source_id = collection.id
+        hpt.save
+        hpt
+      end
+
+      def repo_admins_have_manage_rights?(hyrax_permission_template:, access_permission:)
+        existing_hpta = Hyrax::PermissionTemplateAccess.where(
+          permission_template_id: hyrax_permission_template.id,
+          agent_type: AGENT_TYPE,
+          agent_id: AGENT_ID,
+          access: access_permission
+        ).count
+        return true if existing_hpta.positive?
+        false
+      end
+end

--- a/app/importers/curate_collection_importer.rb
+++ b/app/importers/curate_collection_importer.rb
@@ -46,39 +46,8 @@ class CurateCollectionImporter
       collection.primary_repository_ID = collection_attrs["primary_repository_ID"]
       collection.finding_aid_link = collection_attrs["finding_aid_link"]
       collection.save
-      add_repository_administrators_as_managers(collection)
+      CollectionPermissionEnsurer.new(collection: collection, access_permissions: ['manage', 'deposit'])
     end
-  end
-
-  def find_or_create_permission_template(collection)
-    existing_hpt = Hyrax::PermissionTemplate.where(source_id: collection.id).try(:first)
-    return existing_hpt if existing_hpt
-    hpt = Hyrax::PermissionTemplate.new
-    hpt.source_id = collection.id
-    hpt.save
-    hpt
-  end
-
-  def repo_admins_have_manage_rights?(hpt)
-    existing_hpta = Hyrax::PermissionTemplateAccess.where(
-      permission_template_id: hpt.id,
-      agent_type: "group",
-      agent_id: "Repository Administrators",
-      access: "manage"
-    ).count
-    return true if existing_hpta.positive?
-    false
-  end
-
-  def add_repository_administrators_as_managers(collection)
-    hpt = find_or_create_permission_template(collection)
-    return if repo_admins_have_manage_rights?(hpt)
-    hpta = Hyrax::PermissionTemplateAccess.new
-    hpta.permission_template_id = hpt.id
-    hpta.agent_type = "group"
-    hpta.agent_id = "Repository Administrators"
-    hpta.access = "manage"
-    hpta.save
   end
 
   # Return an array of values. Use pipe (|) as the delimiter for values.

--- a/spec/importers/collection_permission_ensurer_spec.rb
+++ b/spec/importers/collection_permission_ensurer_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CollectionPermissionEnsurer, :clean do
+  let(:collection) { Collection.new }
+  let(:ensurer) { described_class.new(collection: collection, access_permissions: ['manage', 'deposit']) }
+
+  it 'sets the access permssions specified in the permissons array' do
+    ensurer
+    expect(Hyrax::PermissionTemplateAccess.where(agent_id: 'admin').count).to eq(2)
+  end
+end

--- a/spec/system/migration_collections_spec.rb
+++ b/spec/system/migration_collections_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Depositing items into a migration collection', :perform_jobs, :c
       hpta_count = Hyrax::PermissionTemplateAccess.where(
         permission_template_id: hpt.id,
         agent_type: "group",
-        agent_id: "Repository Administrators",
+        agent_id: "admin",
         access: "manage"
       ).count
       expect(hpta_count).to eq 1


### PR DESCRIPTION
Manage permissions are being set, but deposit permissions
also need to be set so that admins can add to collections
from the UI. As written the UI only checks for the deposit
permission.

See: https://github.com/samvera/hyrax/blob/659e34356bace5e75358ad85b843d16b48771147/app/controllers/hyrax/my/works_controller.rb#L23