### PR TITLE
content_type can be a string or a URI

### DIFF
--- a/spec/importers/curate_mapper_spec.rb
+++ b/spec/importers/curate_mapper_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe CurateMapper do
   let(:metadata) do
     {
       "title" => "what an awesome title", # title
-      "content_type" => 'still image'
+      "content_type" => 'still image',
+      "visibility" => "Emory Network"
     }
   end
 
@@ -38,6 +39,17 @@ RSpec.describe CurateMapper do
         }
       end
       it "maps content_type to a uri" do
+        expect(mapper.content_type).to eq "http://id.loc.gov/vocabulary/resourceTypes/img"
+      end
+    end
+    context "when the CSV has a uri instead of a string" do
+      let(:metadata) do
+        {
+          "title" => "my title",
+          "content_type" => 'http://id.loc.gov/vocabulary/resourceTypes/img'
+        }
+      end
+      it "maps content_type to the uri" do
         expect(mapper.content_type).to eq "http://id.loc.gov/vocabulary/resourceTypes/img"
       end
     end


### PR DESCRIPTION
Earlier versions of the Langmuir csv had content_type as a string. Now
we are shifting expectations to a URI. Leave the option to provide a
string in place in case it's needed later.

Connected to https://github.com/curationexperts/in-house/issues/213