### PR TITLE
Update visibility mapping

### DIFF
--- a/app/importers/curate_mapper.rb
+++ b/app/importers/curate_mapper.rb
@@ -44,6 +44,7 @@ class CurateMapper < Zizia::HashMapper
       'authenticated' => Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED,
       'registered' => Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED,
       'emory' => Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED,
+      'emory network' => Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED,
       'open' => Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
       'public' => Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     }.freeze

--- a/spec/importers/curate_mapper_spec.rb
+++ b/spec/importers/curate_mapper_spec.rb
@@ -19,7 +19,22 @@ RSpec.describe CurateMapper do
     expect(Zizia.config.metadata_mapper_class).to eq described_class
   end
 
-  context "content_type" do
+  context "#visibility" do
+    context "Emory Network" do
+      let(:metadata) do
+        {
+          "title" => "my title",
+          "content_type" => "http://id.loc.gov/vocabulary/resourceTypes/img",
+          "visibility" => "Emory Network"
+        }
+      end
+      it "gives authenticated" do
+        expect(mapper.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      end
+    end
+  end
+
+  context "#content_type" do
     context "when the string matches exactly" do
       let(:metadata) do
         {


### PR DESCRIPTION
I'm guessing that "Emory Network" should map to "authenticated".
We should double-check this with Emily, but I think this should be good
enough to allow us to start iterating on the metadata import.

Connected to https://github.com/curationexperts/in-house/issues/213