### PR TITLE
Auto-generate metadata guide

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :development, :test do
   gem 'ffaker'
   gem 'pry' unless ENV['CI']
   gem 'pry-byebug' unless ENV['CI']
+  gem 'rails-controller-testing'
   gem 'rspec-its'
   gem 'rspec-rails'
   gem 'sqlite3', '~> 1.3.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1311,6 +1311,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.1.7)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.4)
+      actionpack (>= 5.0.1.x)
+      actionview (>= 5.0.1.x)
+      activesupport (>= 5.0.1.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -1630,6 +1634,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 3.7)
   rails (~> 5.1)
+  rails-controller-testing
   riiif (~> 2.0)
   rsolr (>= 1.0)
   rspec-its

--- a/app/controllers/metadata_details_controller.rb
+++ b/app/controllers/metadata_details_controller.rb
@@ -1,0 +1,6 @@
+class MetadataDetailsController < ApplicationController
+  def show
+    @details = ::MetadataDetails.instance.details(work_attributes:
+                                                CurateGenericWorkAttributes.instance)
+  end
+end

--- a/app/lib/curate_generic_work_attributes.rb
+++ b/app/lib/curate_generic_work_attributes.rb
@@ -12,9 +12,13 @@
 # programmatically, but without using any unnecessary memory.
 class CurateGenericWorkAttributes
   include Singleton
-  attr_reader :attributes
+  attr_reader :attributes, :properties, :validators, :local_attributes
 
   def initialize
-    @attributes ||= CurateGenericWork.new.local_attributes
+    work ||= CurateGenericWork.new
+    @local_attributes || work.local_attributes
+    @attributes ||= work.local_attributes
+    @properties ||= work.send(:properties)
+    @validators ||= work.send(:_validators)
   end
 end

--- a/app/lib/metadata_details.rb
+++ b/app/lib/metadata_details.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+class MetadataDetails
+  include Singleton
+
+  def details(work_attributes:)
+    validators = work_attributes.validators
+    work_attributes.properties.sort.map do |p|
+      Hash[
+                                            p[0],
+                                            predicate: p[1].predicate.to_s,
+                                            multiple: p[1].try(:multiple?).to_s,
+                                            type: type_to_s(p[1].type),
+                                            validator: validator_to_string(validator: validators[p[0].to_sym][0]),
+                                            label: I18n.t("simple_form.labels.defaults.#{p[0]}")
+                                          ]
+    end.reduce({}, :merge)
+  end
+
+  private
+
+    def type_to_s(type)
+      return 'Not specified' unless type.present?
+      type.to_s
+    end
+
+    def validator_to_string(validator:)
+      case validator
+      when ActiveModel::Validations::PresenceValidator
+        'required'
+      when UrlValidator
+        'Must be a URL'
+      else
+        'No validation present in the model.'
+      end
+    end
+end

--- a/app/views/metadata_details/show.html.erb
+++ b/app/views/metadata_details/show.html.erb
@@ -1,0 +1,34 @@
+<% content_for :title, 'Importer Field Guide' %>
+
+<% @details.each do |detail| %>
+  <dl>
+    <h2>
+      <dt>
+        <%= detail[0] %>
+      </dt>
+    </h2>
+    <dd>
+      <div>
+        <b>Predicate:</b>
+        <a href="<%= detail[1][:predicate] %>"/><%= detail[1][:predicate] %></a>
+
+      </div>
+      <div>
+        <b>Type:</b>
+        <%= detail[1][:type] %>
+      </div>
+      <div>
+        <b>Validation:</b>
+        <%= detail[1][:validator] %>
+      </div>
+      <div>
+        <b>Multiple:</b>
+        <%= detail[1][:multiple] %>
+      </div>
+      <div>
+        <b>Edit Form Label:</b>
+        <%= detail[1][:label] %>
+      </div>
+    </dd>
+  </ul>
+<% end  %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,10 @@ require 'sidekiq/web'
 Rails.application.routes.draw do
   mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
   mount Blacklight::Engine => '/'
+
+  get 'importer_documentation/guide', to: 'metadata_details#show'
   mount Zizia::Engine => '/'
+
   concern :searchable, Blacklight::Routes::Searchable.new
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do

--- a/spec/controllers/metadata_details_spec.rb
+++ b/spec/controllers/metadata_details_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# [Hyrax-overwrite] Adds tests for additional files
+require 'rails_helper'
+
+RSpec.describe MetadataDetailsController, type: :controller do
+  describe 'GET show'
+  it 'has 200 code for show' do
+    get :show
+    expect(response.status).to eq(200)
+  end
+
+  it 'has details' do
+    get :show
+    details = assigns(:details)
+    expect(details['title'][:predicate]).to eq('http://purl.org/dc/terms/title')
+  end
+end

--- a/spec/lib/metadata_details_spec.rb
+++ b/spec/lib/metadata_details_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MetadataDetails do
+  let(:work_attributes) { CurateGenericWorkAttributes.instance }
+  let(:metadata_details) { described_class.instance }
+
+  it 'has a predicate' do
+    expect(metadata_details.details(work_attributes: work_attributes)['title'][:predicate]).to eq("http://purl.org/dc/terms/title")
+  end
+
+  it 'has a label' do
+    expect(metadata_details.details(work_attributes: work_attributes)['title'][:label]).to eq("Title")
+  end
+
+  it 'has a type' do
+    expect(metadata_details.details(work_attributes: work_attributes)['title'][:type]).to eq("string")
+  end
+
+  it 'has multiple' do
+    expect(metadata_details.details(work_attributes: work_attributes)['institution'][:multiple]).to eq("false")
+  end
+
+  it 'has the validator' do
+    expect(metadata_details.details(work_attributes: work_attributes)['title'][:validator]).to eq("required")
+  end
+end

--- a/spec/system/importer_guide_spec.rb
+++ b/spec/system/importer_guide_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe 'viewing the importer guide', type: :system do
 
   it 'displays without error' do
     visit '/importer_documentation/guide'
-    expect(page.title).to be_in(['Guide Importer Documentation // Curate', 'Zizia'])
+    expect(page.title).to eq('Show Metadata Detail // Curate')
   end
 end


### PR DESCRIPTION
This adds a class that assembles a `Hash` containing
information about the metadata in the application and
displays it as the field guide in the importer.

The information included in the hash is the attribute name,
the RDF predicate, the label used in the form, validation used
in the model, the type of the value, and whether or not
the field is singular or multiple.