### PR TITLE
Selenium deprecations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,6 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw] unless ENV['CI'] # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'capybara', '~> 2.13'
   gem 'coveralls', require: false
-  gem 'database_cleaner'
   gem 'factory_bot_rails', '~> 4.11.1'
   gem 'ffaker'
   gem 'pry' unless ENV['CI']

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,6 @@ end
 group :development, :test do
   gem 'bixby' # bixby = rubocop rules for Hyrax apps
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw] unless ENV['CI'] # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'capybara', '~> 2.13'
   gem 'coveralls', require: false
   gem 'factory_bot_rails', '~> 4.11.1'
   gem 'ffaker'
@@ -62,10 +61,12 @@ group :development, :test do
   gem 'rails-controller-testing'
   gem 'rspec-its'
   gem 'rspec-rails'
+  gem 'selenium-webdriver'
   gem 'sqlite3', '~> 1.3.7'
   gem 'webdrivers', '~> 3.0'
 end
 
 group :test do
+  gem 'capybara'
   gem 'rspec_junit_formatter'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -868,13 +868,14 @@ GEM
     capistrano-sidekiq (0.20.0)
       capistrano (>= 3.9.0)
       sidekiq (>= 3.4)
-    capybara (2.18.0)
+    capybara (3.28.0)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
     carrierwave (1.3.1)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
@@ -1395,6 +1396,7 @@ GEM
       redis (>= 3.0.4)
     redlock (1.0.1)
       redis (>= 3.0.0, < 5.0)
+    regexp_parser (1.6.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -1610,7 +1612,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-rails-collection
   capistrano-sidekiq (~> 0.20.0)
-  capybara (~> 2.13)
+  capybara
   coffee-rails (~> 4.2)
   coveralls
   devise
@@ -1639,6 +1641,7 @@ DEPENDENCIES
   rspec-rails
   rspec_junit_formatter
   sass-rails (~> 5.0)
+  selenium-webdriver
   sidekiq (~> 5.2)
   solr_wrapper (>= 0.3)
   sqlite3 (~> 1.3.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -900,7 +900,6 @@ GEM
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
     crass (1.0.4)
-    database_cleaner (1.7.0)
     declarative (0.0.10)
     declarative-option (0.1.0)
     deprecation (1.0.0)
@@ -1614,7 +1613,6 @@ DEPENDENCIES
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
   coveralls
-  database_cleaner
   devise
   devise-guests (~> 0.6)
   dotenv-rails

--- a/spec/lib/admin_setup_spec.rb
+++ b/spec/lib/admin_setup_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 require 'admin_setup'
 
 RSpec.describe AdminSetup, :clean do
-  before(:context) { DatabaseCleaner.clean_with(:truncation) }
-
   # Change STDOUT to "/dev/null" to block all logging output
   let(:w) { described_class.new("#{fixture_path}/config/emory/admins.yml", STDOUT) }
   let(:admin_user_uid) { "adminuser001" }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -51,6 +51,12 @@ RSpec.configure do |config|
     ActiveFedora::Cleaner.clean!
   end
 
+  config.before(admin_set: true) do
+    admin_set_id = AdminSet.find_or_create_default_admin_set_id
+    Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id)
+    Hyrax::CollectionType.find_or_create_default_collection_type
+  end
+
   # include Noid::Rails::RSpec
   # config.before(:suite) { disable_production_minter! }
   # config.after(:suite)  { enable_production_minter! }

--- a/spec/system/create_collection_spec.rb
+++ b/spec/system/create_collection_spec.rb
@@ -3,16 +3,11 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.describe 'Creating a collection', :perform_jobs, clean: true, type: :system, js: true do
+RSpec.describe 'Creating a collection', :perform_jobs, clean: true, admin_set: true, type: :system, js: true do
   context 'logged in as an admin user' do
-    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
-    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
     let(:admin_user) { FactoryBot.create(:admin) }
 
     before do
-      admin_set_id
-      permission_template
-      Hyrax::CollectionType.find_or_create_default_collection_type
       login_as admin_user
     end
 

--- a/spec/system/show_collection_spec.rb
+++ b/spec/system/show_collection_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe 'viewing a collection', :clean, type: :system, js: true do
       :local_call_number,
       :sensitive_material,
       :internal_rights_note,
-      :contact_information,
       :system_of_record_ID,
       :primary_repository_ID
     ]
@@ -44,6 +43,7 @@ RSpec.describe 'viewing a collection', :clean, type: :system, js: true do
     visit "/collections/#{collection.id}"
     expect(page).to have_content 'Robert Langmuir African American Photograph Collection'
     expect(page).to have_content 'Created by: Langmuir, Robert, collector'
+    expect(page).to have_content 'Rose Library'
     singular_fields.each do |fieldname|
       expect(page).to have_content collection.send(fieldname)
     end


### PR DESCRIPTION
* Remove database_cleaner: now that we've switched to system specs it's no longer needed
* Upgrade capybara to address deprecation warnings in tests

Connected to https://github.com/curationexperts/in-house/issues/222
Connected to https://github.com/curationexperts/in-house/issues/196