### PR TITLE
Get valid CSV headers directly from CurateMapper

### DIFF
--- a/app/importers/curate_mapper.rb
+++ b/app/importers/curate_mapper.rb
@@ -53,7 +53,7 @@ class CurateMapper < Zizia::HashMapper
 
   # What columns are allowed in the CSV
   def self.allowed_headers
-    CURATE_TERMS_MAP.values
+    CURATE_TERMS_MAP.values + ['filename']
   end
 
   def fields

--- a/app/uploaders/zizia/csv_manifest_validator.rb
+++ b/app/uploaders/zizia/csv_manifest_validator.rb
@@ -53,50 +53,6 @@ module Zizia
         Zizia::HyraxBasicMetadataMapper.new.delimiter
       end
 
-      def valid_headers
-        %w[
-          abstract
-          administrative_unit
-          content_genre
-          contact_information
-          content_type
-          copyright_date
-          creator
-          data_classification
-          date_created
-          date_digitized
-          date_issued
-          extent
-          holding_repository
-          institution
-          internal_rights_note
-          keywords
-          legacy_ark
-          legacy_identifier
-          legacy_rights
-          local_call_number
-          note
-          place_of_production
-          primary_language
-          publisher
-          rights_holder
-          rights_statement
-          rights_statement_text
-          sensitive_material
-          sensitive_material_note
-          subject_geo
-          subject_names
-          subject_topics
-          sublocation
-          table_of_contents
-          title
-          transfer_engineer
-          uniform_title
-          visibility
-          filename
-        ]
-      end
-
       def parse_csv
         @rows = CSV.read(csv_file.path)
         @headers = @rows.first || []
@@ -129,6 +85,7 @@ module Zizia
 
       # Warn the user if we find any unexpected headers.
       def unrecognized_headers
+        valid_headers = Zizia.config.metadata_mapper_class.allowed_headers
         normalized_valid_headers = valid_headers.map { |a| a.downcase.strip }
         extra_headers = @transformed_headers - normalized_valid_headers
         extra_headers.each do |header|

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,3 +1,5 @@
+Webdrivers.cache_time = 3
+
 # Setup chrome headless driver
 Capybara.server = :puma, { Silent: true }
 


### PR DESCRIPTION
* Use Zizia config to determine what Mapper class to use
* Look at that mapper class and get the allowed headers instead of
maintaining a separate list of valid headers
* Set newly required config for webdrivers

Connected to https://github.com/curationexperts/in-house/issues/229