### PR TITLE
Add Import header to metadata guide

### DIFF
--- a/app/importers/curate_mapper.rb
+++ b/app/importers/curate_mapper.rb
@@ -56,6 +56,11 @@ class CurateMapper < Zizia::HashMapper
     CURATE_TERMS_MAP.values
   end
 
+  # Given a field name, return the CSV header
+  def self.csv_header(field)
+    CURATE_TERMS_MAP[field.to_sym]
+  end
+
   def fields
     # The fields common to all object types
     common_fields = CURATE_TERMS_MAP.keys

--- a/app/lib/metadata_details.rb
+++ b/app/lib/metadata_details.rb
@@ -11,12 +11,17 @@ class MetadataDetails
                                             multiple: p[1].try(:multiple?).to_s,
                                             type: type_to_s(p[1].type),
                                             validator: validator_to_string(validator: validators[p[0].to_sym][0]),
-                                            label: I18n.t("simple_form.labels.defaults.#{p[0]}")
+                                            label: I18n.t("simple_form.labels.defaults.#{p[0]}"),
+                                            csv_header: csv_header(p[0])
                                           ]
     end.reduce({}, :merge)
   end
 
   private
+
+    def csv_header(field)
+      Zizia.config.metadata_mapper_class.csv_header(field) || "not configured"
+    end
 
     def type_to_s(type)
       return 'Not specified' unless type.present?

--- a/app/views/metadata_details/show.html.erb
+++ b/app/views/metadata_details/show.html.erb
@@ -29,6 +29,10 @@
         <b>Edit Form Label:</b>
         <%= detail[1][:label] %>
       </div>
+      <div>
+        <b>Import header:</b>
+        <%= detail[1][:csv_header] %>
+      </div>
     </dd>
   </ul>
 <% end  %>

--- a/spec/lib/metadata_details_spec.rb
+++ b/spec/lib/metadata_details_spec.rb
@@ -25,4 +25,13 @@ RSpec.describe MetadataDetails do
   it 'has the validator' do
     expect(metadata_details.details(work_attributes: work_attributes)['title'][:validator]).to eq("required")
   end
+
+  context "find csv headers for each field" do
+    it 'finds the csv header when the field is mapped' do
+      expect(metadata_details.details(work_attributes: work_attributes)['title'][:csv_header]).to eq("title")
+    end
+    it 'indicates when field is not configured' do
+      expect(metadata_details.details(work_attributes: work_attributes)['date_modified'][:csv_header]).to eq("not configured")
+    end
+  end
 end


### PR DESCRIPTION
For each field, look up its corresponding import header in the
configured Zizia mapper class.

Connected to https://github.com/curationexperts/in-house/issues/226