### PR TITLE
Style missing data on the metadata field guide

### DIFF
--- a/app/assets/stylesheets/curate.scss
+++ b/app/assets/stylesheets/curate.scss
@@ -17,3 +17,7 @@
 	display: block;
 	height: 20px;
 }
+
+.missing {
+  color: grey;
+}

--- a/app/helpers/metadata_details_helper.rb
+++ b/app/helpers/metadata_details_helper.rb
@@ -1,0 +1,6 @@
+module MetadataDetailsHelper
+  def css_class(value)
+    return "missing" if value == "not configured"
+    return "missing" if value.match?(/translation missing/)
+  end
+end

--- a/app/views/metadata_details/show.html.erb
+++ b/app/views/metadata_details/show.html.erb
@@ -27,11 +27,15 @@
       </div>
       <div>
         <b>Edit Form Label:</b>
+        <span class=<%= css_class(detail[1][:label])%>>
         <%= detail[1][:label] %>
+        </span>
       </div>
       <div>
         <b>Import header:</b>
+        <span class=<%= css_class(detail[1][:csv_header])%>>
         <%= detail[1][:csv_header] %>
+        </span>
       </div>
     </dd>
   </ul>


### PR DESCRIPTION
Make it easier to find missing import headers and form labels by putting
the missing data indicators in a different color.

Connected to https://github.com/curationexperts/in-house/issues/226