### PR TITLE
Add a downloadable CSV to the metadata guide

### DIFF
--- a/app/controllers/metadata_details_controller.rb
+++ b/app/controllers/metadata_details_controller.rb
@@ -3,4 +3,10 @@ class MetadataDetailsController < ApplicationController
     @details = ::MetadataDetails.instance.details(work_attributes:
                                                 CurateGenericWorkAttributes.instance)
   end
+
+  def csv
+    @csv = ::MetadataDetails.instance.to_csv(work_attributes:
+                                              CurateGenericWorkAttributes.instance)
+    send_data @csv, type: 'text/csv', filename: 'metadata.csv'
+  end
 end

--- a/app/lib/metadata_details.rb
+++ b/app/lib/metadata_details.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'csv'
+
 class MetadataDetails
   include Singleton
 
@@ -6,14 +8,27 @@ class MetadataDetails
     validators = work_attributes.validators
     work_attributes.properties.sort.map do |p|
       Hash[
-                                            p[0],
-                                            predicate: p[1].predicate.to_s,
-                                            multiple: p[1].try(:multiple?).to_s,
-                                            type: type_to_s(p[1].type),
-                                            validator: validator_to_string(validator: validators[p[0].to_sym][0]),
-                                            label: I18n.t("simple_form.labels.defaults.#{p[0]}")
+        p[0],
+        attribute: p[0],
+        predicate: p[1].predicate.to_s,
+        multiple: p[1].try(:multiple?).to_s,
+        type: type_to_s(p[1].type),
+        validator: validator_to_string(validator: validators[p[0].to_sym][0]),
+        label: I18n.t("simple_form.labels.defaults.#{p[0]}")
                                           ]
     end.reduce({}, :merge)
+  end
+
+  def to_csv(work_attributes:)
+    details_hash = details(work_attributes: work_attributes)
+    headers = [:attribute, :predicate, :multiple, :type, :validator, :label]
+    csv_string = CSV.generate do |csv|
+      csv << headers
+      details_hash.each do |detail|
+        csv << headers.map { |h| detail[1][h] }
+      end
+    end
+    csv_string
   end
 
   private

--- a/app/views/metadata_details/show.html.erb
+++ b/app/views/metadata_details/show.html.erb
@@ -1,34 +1,36 @@
 <% content_for :title, 'Importer Field Guide' %>
-
-<% @details.each do |detail| %>
+<div class="guide-container">
+  <a class="btn btn-primary" href="/importer_documentation/csv">Download CSV</a>
   <dl>
-    <h2>
-      <dt>
-        <%= detail[0] %>
-      </dt>
-    </h2>
-    <dd>
-      <div>
-        <b>Predicate:</b>
-        <a href="<%= detail[1][:predicate] %>"/><%= detail[1][:predicate] %></a>
+    <% @details.each do |detail| %>
+        <h2>
+          <dt>
+            <%= detail[0] %>
+          </dt>
+        </h2>
+        <dd>
+          <div>
+            <b>Predicate:</b>
+            <a href="<%= detail[1][:predicate] %>"/><%= detail[1][:predicate] %></a>
 
-      </div>
-      <div>
-        <b>Type:</b>
-        <%= detail[1][:type] %>
-      </div>
-      <div>
-        <b>Model Validation:</b>
-        <%= detail[1][:validator] %>
-      </div>
-      <div>
-        <b>Multiple:</b>
-        <%= detail[1][:multiple] %>
-      </div>
-      <div>
-        <b>Edit Form Label:</b>
-        <%= detail[1][:label] %>
-      </div>
-    </dd>
-  </ul>
-<% end  %>
+          </div>
+          <div>
+            <b>Type:</b>
+            <%= detail[1][:type] %>
+          </div>
+          <div>
+            <b>Model Validation:</b>
+            <%= detail[1][:validator] %>
+          </div>
+          <div>
+            <b>Multiple:</b>
+            <%= detail[1][:multiple] %>
+          </div>
+          <div>
+            <b>Edit Form Label:</b>
+            <%= detail[1][:label] %>
+          </div>
+        </dd>
+      <% end  %>
+  </dl>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   mount Blacklight::Engine => '/'
 
   get 'importer_documentation/guide', to: 'metadata_details#show'
+  get 'importer_documentation/csv', to: 'metadata_details#csv'
   mount Zizia::Engine => '/'
 
   concern :searchable, Blacklight::Routes::Searchable.new

--- a/spec/controllers/metadata_details_spec.rb
+++ b/spec/controllers/metadata_details_spec.rb
@@ -14,4 +14,9 @@ RSpec.describe MetadataDetailsController, type: :controller do
     details = assigns(:details)
     expect(details['title'][:predicate]).to eq('http://purl.org/dc/terms/title')
   end
+
+  it 'has a downloadable csv' do
+    get :csv
+    expect(response.content_type).to eq('text/csv')
+  end
 end

--- a/spec/lib/metadata_details_spec.rb
+++ b/spec/lib/metadata_details_spec.rb
@@ -25,4 +25,12 @@ RSpec.describe MetadataDetails do
   it 'has the validator' do
     expect(metadata_details.details(work_attributes: work_attributes)['title'][:validator]).to eq("required")
   end
+
+  it 'can produce a CSV with the right headers' do
+    expect(metadata_details.to_csv(work_attributes: work_attributes)).to match(/attribute,predicate/)
+  end
+
+  it 'can produce a CSV with the right data' do
+    expect(metadata_details.to_csv(work_attributes: work_attributes)).to match(/access_right,http:\/\/purl.org\/dc\/terms\/accessRights/)
+  end
 end


### PR DESCRIPTION
This provides a link to a CSV representation
of the information displayed in the guide.