### PR TITLE
Improve logging 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby] # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'uglifier', '>= 1.3.0'
 gem 'webpacker', '~> 4.x'
-gem 'zizia', '~> 2.1.0.alpha.08'
+gem 'zizia', '~> 3.0.0.alpha.01'
 
 group :development do
   gem 'cap-ec2-emory', github: 'emory-libraries/cap-ec2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1318,7 +1318,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.4)
+    rails-html-sanitizer (1.2.0)
       loofah (~> 2.2, >= 2.2.2)
     rails_autolink (1.1.6)
       rails (> 3.1)
@@ -1464,9 +1464,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.0.1)
+    sassc (2.1.0)
       ffi (~> 1.9)
-      rake
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
@@ -1547,7 +1546,7 @@ GEM
       tins (~> 1.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    thor (0.19.4)
+    thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
     tins (1.21.1)
@@ -1589,7 +1588,7 @@ GEM
       nokogiri (~> 1.8)
     xray-rails (0.3.2)
       rails (>= 3.1.0)
-    zizia (2.1.0.alpha.08)
+    zizia (3.0.0.alpha.01)
       active-fedora
       carrierwave
       rails (~> 5.1.7)
@@ -1653,7 +1652,7 @@ DEPENDENCIES
   webdrivers (~> 3.0)
   webpacker (~> 4.x)
   xray-rails
-  zizia (~> 2.1.0.alpha.08)
+  zizia (~> 3.0.0.alpha.01)
 
 RUBY VERSION
    ruby 2.5.5p157

--- a/app/importers/modular_importer.rb
+++ b/app/importers/modular_importer.rb
@@ -23,7 +23,7 @@ class ModularImporter
 
     file = File.open(@csv_file)
 
-    Zizia.config.default_info_stream << "event: start_import, batch_id: #{@csv_import.id}, collection_id: #{@collection_id}, user: #{@user_email}"
+    Rails.logger.info "[zizia] event: start_import, batch_id: #{@csv_import.id}, collection_id: #{@collection_id}, user: #{@user_email}"
     Zizia::Importer.new(parser: Zizia::CsvParser.new(file: file), record_importer: Zizia::HyraxRecordImporter.new(attributes: attrs)).import
     file.close
   end

--- a/app/logging/log_formatter.rb
+++ b/app/logging/log_formatter.rb
@@ -1,0 +1,9 @@
+class LogFormatter
+  def call(severity, time, progname, msg = '')
+    return '' if msg.blank?
+
+    return "timestamp='#{time}' level=#{severity} progname='#{progname}' message='#{msg}'}\n" if progname.present?
+
+    "timestamp='#{time}' level=#{severity} message='#{msg}'\n"
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative 'boot'
 
 require 'rails/all'
+require_relative '../app/logging/log_formatter'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -12,7 +13,7 @@ module DlpCurate
 
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
-    config.logger = ActiveSupport::Logger.new("log/#{Rails.env}.log")
+    config.log_formatter = LogFormatter.new
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ module DlpCurate
 
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
+    config.logger = ActiveSupport::Logger.new("log/#{Rails.env}.log")
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,5 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+Rails.logger.datetime_format = "%Y-%m-%d %H:%M:%S"
+Rails.logger.level = Logger::INFO

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,6 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  config.log_level = :info
 
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that

--- a/config/initializers/zizia.rb
+++ b/config/initializers/zizia.rb
@@ -1,5 +1,3 @@
 Zizia.config do |config|
   config.metadata_mapper_class = CurateMapper
-  config.default_info_stream = Rails.logger
-  config.default_error_stream = Rails.logger
 end


### PR DESCRIPTION
Before we do these long migrations, let's get the logging system cleaned up so we'll easily be able to measure performance metrics and track import jobs.

* Upgrade to zizia 3.x, which uses the Rails logger instead of a custom logging solution
* Format the dlp-curate Rails logger so it includes a timestamp
* Turn logging level down to INFO for a better signal-to-noise ratio

Connected to https://github.com/curationexperts/dlp-curate/issues/16