### PR TITLE
Warn on missing required headers

### DIFF
--- a/app/importers/curate_mapper.rb
+++ b/app/importers/curate_mapper.rb
@@ -125,9 +125,10 @@ class CurateMapper < Zizia::HashMapper
   # "Stuart A. Rose Manuscript, Archives and Rare Book Library" vs
   # "Stuart A. Rose Manuscript, Archives, and Rare Book Library"
   def administrative_unit
-    active_terms = Qa::Authorities::Local.subauthority_for('administrative_unit').all.select { |term| term[:active] }
     csv_term = @metadata["administrative_unit"]
+    return nil unless csv_term
     normalized_csv_term = csv_term.downcase.gsub(/[^a-z0-9\s]/i, '')
+    active_terms = Qa::Authorities::Local.subauthority_for('administrative_unit').all.select { |term| term[:active] }
     valid_option = active_terms.select { |s| s["id"].downcase.gsub(/[^a-z0-9\s]/i, '') == normalized_csv_term }.try(:first)
     return valid_option["id"] if valid_option
     raise "Invalid administrative_unit value: #{csv_term}"
@@ -136,6 +137,7 @@ class CurateMapper < Zizia::HashMapper
   # Iterate through all values for data_classification and ensure they are all
   # valid options according to Questioning Authority
   def data_classification
+    return nil unless @metadata["data_classification"]
     csv_terms = @metadata["data_classification"]&.split(DELIMITER)
     active_terms = Qa::Authorities::Local.subauthority_for('data_classification').all.select { |term| term[:active] }
     data_classification_values = []
@@ -148,6 +150,7 @@ class CurateMapper < Zizia::HashMapper
   end
 
   def rights_statement
+    return nil unless @metadata["rights_statement"]
     active_terms = Qa::Authorities::Local.subauthority_for('rights_statements').all.select { |term| term[:active] }
     csv_term = @metadata["rights_statement"]
     valid_uri_option = active_terms.select { |s| s["id"] == csv_term }.try(:first)

--- a/app/uploaders/zizia/csv_manifest_validator.rb
+++ b/app/uploaders/zizia/csv_manifest_validator.rb
@@ -28,6 +28,7 @@ module Zizia
       return unless @rows
 
       missing_headers
+      missing_headers_required_by_edit_form
       duplicate_headers
       unrecognized_headers
       missing_values
@@ -68,8 +69,16 @@ module Zizia
         end
       end
 
+      def missing_headers_required_by_edit_form
+        required_headers = REQUIRED_FIELDS_ON_FORM.map(&:to_s)
+        required_headers.each do |header|
+          next if @transformed_headers.include?(header)
+          @warnings << "Missing column: #{header}. This field is required by the edit form."
+        end
+      end
+
       def required_headers
-        ['title', 'filename', 'content_type']
+        ['title']
       end
 
       def duplicate_headers

--- a/spec/fixtures/csv_import/csv_files_with_problems/missing_fields_required_on_edit_form.csv
+++ b/spec/fixtures/csv_import/csv_files_with_problems/missing_fields_required_on_edit_form.csv
@@ -1,0 +1,2 @@
+legacy_identifier,filename,title,visibility
+dams:152815|MSS1218_B001_I002,fake_filename.jpg,"Advertising, High Boy cigarettes : short African American woman lighting the cigarette of an African American man",Emory Network

--- a/spec/uploaders/zizia/csv_manifest_validator_spec.rb
+++ b/spec/uploaders/zizia/csv_manifest_validator_spec.rb
@@ -53,9 +53,22 @@ RSpec.describe Zizia::CsvManifestValidator, type: :model do
 
     it 'has an error for every missing header' do
       validator.validate
-      expected_errors = ["title", "content_type"]
+      expected_errors = ["title"]
       expected_errors.each do |error|
         matches = validator.errors.map { |e| e.match(error) }
+        expect(matches.compact).not_to be_empty
+      end
+    end
+  end
+
+  context 'a CSV that is missing headers required by the edit form' do
+    let(:csv_file) { File.join(fixture_path, 'csv_import', 'csv_files_with_problems', 'missing_fields_required_on_edit_form.csv') }
+
+    it 'has a warning for every missing header' do
+      validator.validate
+      expected_warnings = REQUIRED_FIELDS_ON_FORM.map(&:to_s) - ["title"]
+      expected_warnings.each do |warning|
+        matches = validator.warnings.map { |e| e.match(warning) }
         expect(matches.compact).not_to be_empty
       end
     end


### PR DESCRIPTION
When there are headers that are required by the edit form, but are
missing from the uploaded CSV, warn the user.

Connected to https://github.com/curationexperts/in-house/issues/237