### PR TITLE
Include additional fields in CSV for the metadata guide

### DIFF
--- a/app/lib/metadata_details.rb
+++ b/app/lib/metadata_details.rb
@@ -23,7 +23,7 @@ class MetadataDetails
 
   def to_csv(work_attributes:)
     details_hash = details(work_attributes: work_attributes)
-    headers = [:attribute, :predicate, :multiple, :type, :validator, :label]
+    headers = [:attribute, :predicate, :multiple, :type, :validator, :label, :csv_header, :required_on_form]
     csv_string = CSV.generate do |csv|
       csv << headers
       details_hash.each do |detail|

--- a/spec/controllers/metadata_details_spec.rb
+++ b/spec/controllers/metadata_details_spec.rb
@@ -19,4 +19,11 @@ RSpec.describe MetadataDetailsController, type: :controller do
     get :csv
     expect(response.content_type).to eq('text/csv')
   end
+
+  it 'includes expected headers' do
+    get :csv
+    first_row = response.body.lines.first
+    expect(first_row).to include('csv_header')
+    expect(first_row).to include('required_on_form')
+  end
 end


### PR DESCRIPTION
Adds two new fields to the dowloadable CSV metadata profile:
* csv_header: the column header for import manifests
* required_on_form: whether the field is required on the edit form