### PR TITLE
Rename MetadataDetails#csv to resolve conflict with Zizia

### DIFF
--- a/app/controllers/metadata_details_controller.rb
+++ b/app/controllers/metadata_details_controller.rb
@@ -4,7 +4,7 @@ class MetadataDetailsController < ApplicationController
                                                 CurateGenericWorkAttributes.instance)
   end
 
-  def csv
+  def profile
     @csv = ::MetadataDetails.instance.to_csv(work_attributes:
                                               CurateGenericWorkAttributes.instance)
     send_data @csv, type: 'text/csv', filename: "metadata-profile-#{Date.current}.csv"

--- a/app/views/metadata_details/show.html.erb
+++ b/app/views/metadata_details/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, 'Importer Field Guide' %>
 <div class="guide-container">
-  <a class="btn btn-primary" href="/importer_documentation/csv">Download CSV</a>
+  <a class="btn btn-primary" href="/importer_documentation/profile">Download as CSV</a>
   <dl>
     <% @details.each do |detail| %>
       <h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   mount Blacklight::Engine => '/'
 
   get 'importer_documentation/guide', to: 'metadata_details#show'
-  get 'importer_documentation/csv', to: 'metadata_details#csv'
+  get 'importer_documentation/profile', to: 'metadata_details#profile'
   mount Zizia::Engine => '/'
 
   concern :searchable, Blacklight::Routes::Searchable.new

--- a/spec/controllers/metadata_details_spec.rb
+++ b/spec/controllers/metadata_details_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe MetadataDetailsController, type: :controller do
   end
 
   it 'has a downloadable csv' do
-    get :csv
+    get :profile
     expect(response.content_type).to eq('text/csv')
   end
 
   it 'includes expected headers' do
-    get :csv
+    get :profile
     first_row = response.body.lines.first
     expect(first_row).to include('csv_header')
     expect(first_row).to include('required_on_form')
@@ -31,7 +31,7 @@ RSpec.describe MetadataDetailsController, type: :controller do
     todays_date = "Wed, 03 Jul 1985".to_date
     allow(Date).to receive(:current) { todays_date }
 
-    get :csv
+    get :profile
     filename = response.headers['Content-Disposition']
     expect(filename).to include "1985-07-03"
   end


### PR DESCRIPTION
Both the local MetadtataDetails and Zizia previously provided a route for
`importer_documentation_csv_path`.

Zizia's provided the csv header template while MetadataDetails provides the
downloadable metadata profile.  This PR applies a new name to the MetadataDetails
method to avoid the conflict, allowing both paths to be accessed from the dashboard.