### PR TITLE
Standardize local fedora and solr

### DIFF
--- a/.fcrepo_wrapper
+++ b/.fcrepo_wrapper
@@ -1,4 +1,6 @@
-# Place any default configuration for solr_wrapper here
+# Place any default configuration for fcrepo_wrapper here
 port: 8984
+version: 4.7.5
+download_dir: /var/tmp
 enable_jms: false
 fcrepo_home_dir: tmp/fcrepo4-development-data

--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,6 +1,7 @@
 # Place any default configuration for solr_wrapper here
 version: 7.7.1
-# port: 8983
+port: 8983
+download_dir: /var/tmp
 instance_dir: tmp/solr-development
 collection:
   persist: true

--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,5 +1,0 @@
-# Place any default configuration for solr_wrapper here
-# port: 8983
-collection:
-  dir: solr/conf/
-  name: blacklight-core

--- a/config/fcrepo_wrapper_test.yml
+++ b/config/fcrepo_wrapper_test.yml
@@ -1,4 +1,6 @@
 #config/fcrepo_wrapper_test.yml.sample
 port: 8986
+version: 4.7.5
+download_dir: /var/tmp
 enable_jms: false
 fcrepo_home_dir: tmp/fcrepo4-test-data

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -2,6 +2,7 @@
 # version: 6.1.0
 port: 8985
 instance_dir: tmp/solr-test
+download_dir: /var/tmp
 collection:
     persist: false
     dir: solr/config


### PR DESCRIPTION
* Use fedora 4.7.5 to match production
* Remove redundant solr config file to reduce confusion
* Add download_dir directive so we don't have to re-download over and
over again when our local rails tmp directory gets blown away