### PR TITLE
Refactor MetadataDetails to simplify object structure

### DIFF
--- a/app/lib/metadata_details.rb
+++ b/app/lib/metadata_details.rb
@@ -4,11 +4,10 @@ require 'csv'
 class MetadataDetails
   include Singleton
 
-  def details(work_attributes:) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def details(work_attributes:) # rubocop:disable Metrics/AbcSize
     validators = work_attributes.validators
     work_attributes.properties.sort.map do |p|
       Hash[
-        p[0],
         attribute: p[0],
         predicate: p[1].predicate.to_s,
         multiple: p[1].try(:multiple?).to_s,
@@ -19,16 +18,16 @@ class MetadataDetails
         required_on_form: required_on_form_to_s(p[0]),
         usage: METADATA_USAGE[p[0]]
       ]
-    end.reduce({}, :merge)
+    end
   end
 
   def to_csv(work_attributes:)
-    details_hash = details(work_attributes: work_attributes)
-    headers = [:attribute, :predicate, :multiple, :type, :validator, :label, :csv_header, :required_on_form, :usage]
+    attribute_list = details(work_attributes: work_attributes)
+    headers = extract_headers(attribute_list[0])
     csv_string = CSV.generate do |csv|
       csv << headers
-      details_hash.each do |detail|
-        csv << headers.map { |h| detail[1][h] }
+      attribute_list.each do |attribute|
+        csv << headers.map { |h| attribute[h] }
       end
     end
     csv_string
@@ -38,6 +37,13 @@ class MetadataDetails
 
     def csv_header(field)
       Zizia.config.metadata_mapper_class.csv_header(field) || "not configured"
+    end
+
+    def extract_headers(attribute_hash)
+      headers = attribute_hash.keys.sort
+      headers = [:attribute] + (headers - [:attribute])     # force :attribute to the beginning of the list
+      headers = (headers - [:usage]) + [:usage]             # force :usage to the end of the list becuause it's so long
+      headers
     end
 
     def required_on_form_to_s(attribute)

--- a/app/views/metadata_details/show.html.erb
+++ b/app/views/metadata_details/show.html.erb
@@ -5,43 +5,43 @@
     <% @details.each do |detail| %>
       <h2>
         <dt>
-          <%= detail[0] %>
+          <%= detail[:attribute] %>
         </dt>
       </h2>
       <dd>
         <div>
           <b>Predicate:</b>
-          <a href="<%= detail[1][:predicate] %>"/><%= detail[1][:predicate] %></a>
+          <a href="<%= detail[:predicate] %>"><%= detail[:predicate] %></a>
         </div>
         <div>
           <b>Type:</b>
-          <%= detail[1][:type] %>
+          <%= detail[:type] %>
         </div>
         <div>
           <b>Validation:</b>
-          <%= detail[1][:validator] %>
+          <%= detail[:validator] %>
         </div>
         <div>
           <b>Multiple:</b>
-          <%= detail[1][:multiple] %>
+          <%= detail[:multiple] %>
         </div>
         <div>
           <b>Edit Form Label:</b>
-          <%= detail[1][:label] %>
+          <%= detail[:label] %>
         </div>
         <div>
           <b>Import header:</b>
-          <span class=<%= css_class(detail[1][:csv_header])%>>
-            <%= detail[1][:csv_header] %>
+          <span class=<%= css_class(detail[:csv_header])%>>
+            <%= detail[:csv_header] %>
           </span>
         </div>
         <div>
           <b>Required on Edit Form:</b>
-          <%= detail[1][:required_on_form] %>
+          <%= detail[:required_on_form] %>
         </div>
         <div class=metadata_usage>
           <b>Usage:</b>
-          <%= detail[1][:usage] %>
+          <%= detail[:usage] %>
         </div>
       </dd>
     <% end  %>

--- a/spec/controllers/metadata_details_spec.rb
+++ b/spec/controllers/metadata_details_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe MetadataDetailsController, type: :controller do
   it 'has details' do
     get :show
     details = assigns(:details)
-    expect(details['title'][:predicate]).to eq('http://purl.org/dc/terms/title')
+    title = details.find { |h| h[:attribute] == 'title' }
+    expect(title[:predicate]).to eq('http://purl.org/dc/terms/title')
   end
 
   it 'has a downloadable csv' do


### PR DESCRIPTION
Removes one level of structure from metadata details.
Hopefully it simplifies and clarifies the code to access and display details.