### PR TITLE
Ordering for Langmuir imports

### DIFF
--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -81,7 +81,10 @@ module Hyrax
           # Ensure we have an up-to-date copy of the members association, so that we append to the end of the list.
           work.reload unless work.new_record?
           file_set.visibility = work.visibility unless assign_visibility?(file_set_params)
-          work.ordered_members << file_set
+
+          arranger = FileArranger.new(work: work, file_set: file_set)
+          arranger.arrange
+
           work.representative = file_set if work.representative_id.blank?
           work.thumbnail = file_set if work.thumbnail_id.blank?
           # Save the work so the association between the work and the file_set is persisted (head_id)

--- a/app/importers/file_arranger.rb
+++ b/app/importers/file_arranger.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+##
+# This is used on a Work that does not already have members.
+#
+# Pass in the Work and the FileSet and put the logic for
+# their arrangement/oredering in the arrange method.
+#
+# This is intended to be used in the FileSetActor in the
+# attach_to_work method to ensure that importer files are
+# not attached in random order.
+class FileArranger
+  def initialize(work:, file_set:)
+    @work = work
+    @file_set = file_set
+  end
+
+  def arrange
+    case @file_set.label
+    when 'Front'
+      @work.ordered_members.insert_at(0, @file_set)
+    when 'Back'
+      # There may not be a Front so make the Back first
+      if @work.ordered_members.to_a.empty?
+        @work.ordered_members.insert_at(0, @file_set)
+      else
+        @work.ordered_members.insert_at(1, @file_set)
+      end
+    else
+      @work.ordered_members << @file_set
+    end
+  end
+end

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -2,10 +2,12 @@ FactoryBot.define do
   factory :file_set do
     transient do
       user { build(:user) }
+      title { nil }
       content { nil }
     end
     after(:build) do |fs, evaluator|
       fs.apply_depositor_metadata evaluator.user.user_key
+      fs.title = evaluator.title
     end
 
     after(:create) do |file, evaluator|

--- a/spec/importers/file_arranger_spec.rb
+++ b/spec/importers/file_arranger_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FileArranger do
+  let(:work) { FactoryBot.create(:work) }
+  let!(:file_set_front) { FactoryBot.create(:file_set, content: File.open(Rails.root.join('spec', 'fixtures', 'world.png')), title: ['Front']) }
+  let!(:file_set_back) { FactoryBot.create(:file_set, content: File.open(Rails.root.join('spec', 'fixtures', 'world.png')), title: ['Back']) }
+  let!(:file_set_neither) { FactoryBot.create(:file_set, content: File.open(Rails.root.join('spec', 'fixtures', 'world.png')), title: ['neither']) }
+
+  it 'inserts Front and Back in order' do
+    arranger = described_class.new(work: work, file_set: file_set_front)
+    arranger.arrange
+    arranger = described_class.new(work: work, file_set: file_set_back)
+    arranger.arrange
+    expect(work.ordered_members.to_a.first.title).to eq(['Front'])
+    expect(work.ordered_members.to_a[1].title).to eq(['Back'])
+  end
+
+  it 'inserts Back first if there is no front' do
+    arranger = described_class.new(work: work, file_set: file_set_back)
+    arranger.arrange
+    expect(work.ordered_members.to_a.first.title).to eq(['Back'])
+  end
+
+  it 'inserts like normal if there is no label' do
+    arranger = described_class.new(work: work, file_set: file_set_neither)
+    arranger.arrange
+    expect(work.ordered_members.to_a.first.title).to eq(['neither'])
+  end
+end


### PR DESCRIPTION
This adds a FileArranger that is used to order the
Langmuir files correctly. If the FileSet is labeled
'Front' it will be first in ordered_members and if
it is labeled 'Back' it will be second unless there
is only a 'Back'.
In the future this class should altered so that
it arranges the files based on the index in the filename.

Connected to curationexperts/in-house#269