### PR TITLE
Add custom visibility levels

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,8 @@ AllCops:
         - 'tmp/**/*'
         - 'vendor/**/*'
         - 'node_modules/**/*'
+        - config/initializers/access_right.rb
+        - config/initializers/visibility.rb
         - lib/tasks/sample_data.rake
 
 Style/FrozenStringLiteralComment:

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -1,0 +1,94 @@
+<% if f.object.embargo_release_date %>
+  <%= render 'form_permission_under_embargo', f: f %>
+<% elsif f.object.lease_expiration_date %>
+  <%= render 'form_permission_under_lease', f: f %>
+<% else %>
+    <fieldset>
+      <legend class="legend-save-work"><%= t('.visibility') %></legend>
+      <ul class="visibility">
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, data: { 'target': '#collapsePublic' } %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) %>
+            <br />
+            <%= t('hyrax.visibility.open.note_html', type: f.object.human_readable_type) %>
+            <div class="collapse" id="collapsePublic">
+              <%= t('hyrax.visibility.open.warning_html', label: visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)) %>
+            </div>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) %>
+            <br />
+            <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, data: { 'target': '#collapseEmbargo' } %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO) %>
+            <br />
+            <%= t('hyrax.visibility.embargo.note_html') %>
+            <div class="collapse" id="collapseEmbargo">
+              <div class="form-inline">
+                <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+                <%= t('hyrax.works.form.visibility_until') %>
+                <%= f.date_field :embargo_release_date, wrapper: :inline, value: f.object.embargo_release_date || Date.tomorrow, class: 'datepicker form-control' %>
+                <%= f.input :visibility_after_embargo, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+              </div>
+            </div>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE, data: { 'target': '#collapseLease' } %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE) %>
+            <br />
+            <%= t('hyrax.visibility.lease.note_html') %>
+            <div class="collapse" id="collapseLease">
+              <div class="form-inline">
+                <%= f.input :visibility_during_lease, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+                <%= t('hyrax.works.form.visibility_until') %>
+                <%= f.date_field :lease_expiration_date, wrapper: :inline, value: f.object.lease_expiration_date || Date.tomorrow, class: 'datepicker form-control' %>
+                <%= f.input :visibility_after_lease, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+              </div>
+            </div>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) %>
+            <br >
+            <%= t('hyrax.visibility.restricted.note_html') %>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, 'low_res' %>
+            <%= visibility_badge(:low_res) %>
+            <br />
+            <%= t('hyrax.visibility.low_res.note_html') %>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, 'emory_low' %>
+            <%= visibility_badge(:emory_low) %>
+            <br />
+            <%= t('hyrax.visibility.emory_low.note_html') %>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, 'rose_high' %>
+            <%= visibility_badge(:rose_high) %>
+            <br />
+            <%= t('hyrax.visibility.rose_high.note_html') %>
+          </label>
+        </li>
+      </ul>
+    </fieldset>
+<% end %>

--- a/config/initializers/access_right.rb
+++ b/config/initializers/access_right.rb
@@ -1,0 +1,93 @@
+module Hydra
+  module AccessControls
+    class AccessRight
+      # What these groups are called in the Hydra rights assertions:
+      PERMISSION_TEXT_VALUE_PUBLIC = 'public'.freeze
+      PERMISSION_TEXT_VALUE_AUTHENTICATED = 'registered'.freeze
+
+      # The values that get drawn to the page
+      VISIBILITY_TEXT_VALUE_PUBLIC = 'open'.freeze
+      VISIBILITY_TEXT_VALUE_EMBARGO = 'embargo'.freeze
+      VISIBILITY_TEXT_VALUE_LEASE = 'lease'.freeze
+      VISIBILITY_TEXT_VALUE_AUTHENTICATED = 'authenticated'.freeze
+      VISIBILITY_TEXT_VALUE_PRIVATE = 'restricted'.freeze
+
+      # Custom curate levels
+      VISIBILITY_TEXT_VALUE_LOW_RES = 'low_res'.freeze
+      VISIBILITY_TEXT_VALUE_EMORY_LOW = 'emory_low'.freeze
+      VISIBILITY_TEXT_VALUE_ROSE_HIGH = 'rose_high'.freeze
+
+      # @param permissionable [#visibility, #permissions]
+      # @example
+      #   file = GenericFile.find('sufia:1234')
+      #   access = Sufia::AccessRight.new(file)
+      def initialize(permissionable)
+        @permissionable = permissionable
+      end
+
+      attr_reader :permissionable
+      delegate :persisted?, :permissions, :visibility, to: :permissionable
+      protected :persisted?, :permissions, :visibility
+
+
+      def open_access?
+        return true if has_visibility_text_for?(VISIBILITY_TEXT_VALUE_PUBLIC)
+        # We don't want to know if its under embargo, simply does it have a date.
+        # In this way, we can properly inform the label input
+        persisted_open_access_permission? && !permissionable.embargo_release_date.present?
+      end
+
+      def open_access_with_embargo_release_date?
+        return false unless permissionable_is_embargoable?
+        return true if has_visibility_text_for?(VISIBILITY_TEXT_VALUE_EMBARGO)
+        # We don't want to know if its under embargo, simply does it have a date.
+        # In this way, we can properly inform the label input
+        persisted_open_access_permission? && permissionable.embargo_release_date.present?
+      end
+
+      def authenticated_only?
+        return false if open_access?
+        has_permission_text_for?(PERMISSION_TEXT_VALUE_AUTHENTICATED) ||
+          has_visibility_text_for?(VISIBILITY_TEXT_VALUE_AUTHENTICATED)
+      end
+
+      alias :authenticated_only_access? :authenticated_only?
+
+      def private?
+        return false if open_access?
+        return false if authenticated_only?
+        return false if open_access_with_embargo_release_date?
+        true
+      end
+
+      alias :private_access? :private?
+
+      private
+
+        def persisted_open_access_permission?
+          if persisted?
+            has_permission_text_for?(PERMISSION_TEXT_VALUE_PUBLIC)
+          else
+            visibility.to_s == ''
+          end
+        end
+
+        def on_or_after_any_embargo_release_date?
+          return true unless permissionable.embargo_release_date
+          permissionable.embargo_release_date.to_date < Date.today
+        end
+
+        def permissionable_is_embargoable?
+          permissionable.respond_to?(:embargo_release_date)
+        end
+
+        def has_visibility_text_for?(text)
+          visibility == text
+        end
+
+        def has_permission_text_for?(text)
+          !!permissions.detect { |perm| perm.agent_name == text }
+        end
+    end
+  end
+end

--- a/config/initializers/permission_badge.rb
+++ b/config/initializers/permission_badge.rb
@@ -1,0 +1,44 @@
+module Hyrax
+  class PermissionBadge
+    include ActionView::Helpers::TagHelper
+
+    VISIBILITY_LABEL_CLASS = {
+      authenticated: "label-info",
+      embargo: "label-warning",
+      lease: "label-warning",
+      open: "label-success",
+      restricted: "label-danger",
+      low_res: "label-success",
+      emory_low: "label-info",
+      rose_high: "label-warning"
+    }.freeze
+
+    # @param visibility [String] the current visibility
+    def initialize(visibility)
+      @visibility = visibility
+    end
+
+    # Draws a span tag with styles for a bootstrap label
+    def render
+      content_tag(:span, text, class: "label #{dom_label_class}")
+    end
+
+    private
+
+      def dom_label_class
+        VISIBILITY_LABEL_CLASS.fetch(@visibility.to_sym)
+      end
+
+      def text
+        if registered?
+          Institution.name
+        else
+          I18n.t("hyrax.visibility.#{@visibility}.text")
+        end
+      end
+
+      def registered?
+        @visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      end
+  end
+end

--- a/config/initializers/visibility.rb
+++ b/config/initializers/visibility.rb
@@ -1,0 +1,98 @@
+module Hydra::AccessControls
+  module Visibility
+    extend ActiveSupport::Concern
+
+    def visibility=(value)
+      return if value.nil?
+      # only set explicit permissions
+      case value
+      when AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+        public_visibility!
+      when AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+        registered_visibility!
+      when AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+        private_visibility!
+      when AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES
+        low_res_visibility!
+      when AccessRight::VISIBILITY_TEXT_VALUE_EMORY_LOW
+        emory_low_visibility!
+      when AccessRight::VISIBILITY_TEXT_VALUE_ROSE_HIGH
+        rose_high_visibility!
+      else
+        raise ArgumentError, "Invalid visibility: #{value.inspect}"
+      end
+    end
+
+    def visibility
+      if read_groups.include? AccessRight::PERMISSION_TEXT_VALUE_PUBLIC
+        AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      elsif read_groups.include? AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED
+        AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      elsif read_groups.include? AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES
+        AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES
+      elsif read_groups.include? AccessRight::VISIBILITY_TEXT_VALUE_EMORY_LOW
+        AccessRight::PERMISSION_TEXT_VALUE_EMORY_LOW
+      elsif read_groups.include? AccessRight::VISIBILITY_TEXT_VALUE_ROSE_HIGH
+        AccessRight::VISIBILITY_TEXT_VALUE_ROSE_HIGH
+      else
+        AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      end
+    end
+
+    def visibility_changed?
+      !!@visibility_will_change
+    end
+
+    private
+
+      # Override represented_visibility if you want to add another visibility that is
+      # represented as a read group (e.g. on-campus)
+      # @return [Array] a list of visibility types that are represented as read groups
+      def represented_visibility
+        [AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED,
+         AccessRight::PERMISSION_TEXT_VALUE_PUBLIC,
+        AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES,
+        AccessRight::VISIBILITY_TEXT_VALUE_EMORY_LOW,
+        AccessRight::VISIBILITY_TEXT_VALUE_ROSE_HIGH]
+      end
+
+      def visibility_will_change!
+        @visibility_will_change = true
+      end
+
+      def public_visibility!
+        visibility_will_change! unless visibility == AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+        remove_groups = represented_visibility - [AccessRight::PERMISSION_TEXT_VALUE_PUBLIC]
+        set_read_groups([AccessRight::PERMISSION_TEXT_VALUE_PUBLIC], remove_groups)
+      end
+
+      def registered_visibility!
+        visibility_will_change! unless visibility == AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+        remove_groups = represented_visibility - [AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED]
+        set_read_groups([AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED], remove_groups)
+      end
+
+      def low_res_visibility!
+         visibility_will_change! unless visibility == AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES
+         remove_groups = represented_visibility - [AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES]
+         set_read_groups([AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES], remove_groups)
+      end
+
+      def emory_low_visibility!
+        visibility_will_change! unless visibility == AccessRight::VISIBILITY_TEXT_VALUE_EMORY_LOW
+        remove_groups = represented_visibility - [AccessRight::VISIBILITY_TEXT_VALUE_EMORY_LOW]
+        set_read_groups([AccessRight::VISIBILITY_TEXT_VALUE_EMORY_LOW], remove_groups)
+      end
+
+      def rose_high_visibility!
+        visibility_will_change! unless visibility == AccessRight::VISIBILITY_TEXT_VALUE_ROSE_HIGH
+        remove_groups = represented_visibility - [AccessRight::VISIBILITY_TEXT_VALUE_ROSE_HIGH]
+        set_read_groups([AccessRight::VISIBILITY_TEXT_VALUE_ROSE_HIGH], remove_groups)
+      end
+
+      def private_visibility!
+        visibility_will_change! unless visibility == AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+        set_read_groups([], represented_visibility)
+      end
+  end
+end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -187,6 +187,21 @@ en:
           title: "title (Title)"
           transfer_engineer: "transfer_engineer (Transfer Engineer)"
   hyrax:
+    visibility:
+      public:
+        note_html: 'Public access high resolution'
+        text: 'Public high resolution'
+      low_res:
+        note_html: 'LowRes'
+        text: 'LowRes'
+      emory_low:
+        note_html: 'Emory Low Resolution'
+        text: 'Emory Low'
+      rose_high:
+        note_html: 'Rose High Resolution'
+        text: 'Rose High Resolution'
+
+
     relationships_parent_row:
       label: "In Parent Work:"
     base:

--- a/spec/system/create_curate_generic_work_spec.rb
+++ b/spec/system/create_curate_generic_work_spec.rb
@@ -110,11 +110,13 @@ RSpec.describe 'Create a CurateGenericWork', integration: true, clean: true, typ
       visit("/concern/curate_generic_works/#{cgw.id}/edit")
 
       find('body').click
-      choose('curate_generic_work_visibility_open')
+      choose('curate_generic_work_visibility_low_res')
+      choose('curate_generic_work_visibility_emory_low')
+      choose('curate_generic_work_visibility_rose_high')
       click_on('Save')
 
       cgw.reload
-      expect(cgw.visibility).to eq 'open'
+      expect(cgw.visibility).to eq 'rose_high'
     end
 
     scenario "verify work authenticated visibility" do


### PR DESCRIPTION
This allows you to choose additional
visibilty levels that are synonomous
with private.

On the edit form these will be labeled
with the new name and you can programmatically
create them.

On the show view these will display as private. In
the future, the show view should reflect the actual
granularity we want the permission levels to have.

Connected to curationexperts/in-house#274