### PR TITLE
Do not raise warnings for expected headers

### DIFF
--- a/app/importers/curate_mapper.rb
+++ b/app/importers/curate_mapper.rb
@@ -54,7 +54,7 @@ class CurateMapper < Zizia::HashMapper
 
   # What columns are allowed in the CSV
   def self.allowed_headers
-    CURATE_TERMS_MAP.values + ['filename']
+    CURATE_TERMS_MAP.values + ['filename', 'type', 'intermediate_file', 'fileset_label', 'preservation_master_file']
   end
 
   # Given a field name, return the CSV header

--- a/spec/system/import_langmuir_from_csv_spec.rb
+++ b/spec/system/import_langmuir_from_csv_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe 'Importing records from a Langmuir CSV', :perform_jobs, :clean, t
       expect(page).to have_content(/This import will create or update (17|20) records./)
       # There is a link so the user can cancel.
       expect(page).to have_link 'Cancel', href: '/csv_imports/new?locale=en'
+
+      # We get warnings about unsupported fields
+      expect(page).to have_content('The field name "rights - digitization basis note" is not supported.')
+      expect(page).not_to have_content('The field name "type" is not supported')
+      expect(page).not_to have_content('The field name "intermediate_file" is not supported')
+      expect(page).not_to have_content('The field name "fileset_label" is not supported')
+      expect(page).not_to have_content('The field name "preservation_master_file" is not supported')
+
       # After reading the warnings, the user decides
       # to continue with the import.
       click_on 'Start Import'


### PR DESCRIPTION
Add expected headers to the allowed_headers method so they do not raise
warnings.

Connected to https://github.com/curationexperts/in-house/issues/401