### PR TITLE
Dynamically generate a list of singular fields used by the import mapper

### DIFF
--- a/app/importers/curate_mapper.rb
+++ b/app/importers/curate_mapper.rb
@@ -107,7 +107,6 @@ class CurateMapper < Zizia::HashMapper
       "sublocation",
       "system_of_record_ID",
       "transfer_engineer",
-      "rights_holders",
       "table_of_contents",
       "uniform_title"
     ]

--- a/app/importers/curate_mapper.rb
+++ b/app/importers/curate_mapper.rb
@@ -78,38 +78,14 @@ class CurateMapper < Zizia::HashMapper
     [@metadata["Filename"]]
   end
 
-  # Samvera generally assumes that all fields are multi-valued. Curate has many
-  # fields that are assumed to be singular, however. List them here for an easy
-  # way to check whether a field is multi-valued when retrieving it.
+  # Samvera generally assumes that all fields are multi-valued. Curate, however,
+  # has many fields that are defined to be singular. This method returns the array
+  # of single-value fields for an easy way to check whether a field is single-valued
+  # or multi-valued when mapping it.
   def singular_fields
-    [
-      "abstract",
-      "conference_name",
-      "contact_information",
-      "copyright_date",
-      "date_created",
-      "date_digitized",
-      "date_issued",
-      "deduplication_key",
-      "edition",
-      "extent",
-      "holding_repository",
-      "local_call_number",
-      "institution",
-      "internal_rights_note",
-      "legacy_rights",
-      "place_of_production",
-      "primary_language",
-      "publisher",
-      "sensitive_material",
-      "sensitive_material_note",
-      "series_title",
-      "sublocation",
-      "system_of_record_ID",
-      "transfer_engineer",
-      "table_of_contents",
-      "uniform_title"
-    ]
+    work = CurateGenericWork.new
+    properties = work.send(:properties)
+    properties.select { |_k, v| v.respond_to? :multiple? }.select { |_k, v| !v.multiple? }.keys
   end
 
   # Match a visibility string to the value below; default to restricted

--- a/spec/importers/curate_mapper_spec.rb
+++ b/spec/importers/curate_mapper_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe CurateMapper do
 
   context "#rights_holders" do
     it "maps the rights_holders field" do
-      expect(mapper.rights_holders).to eq "Unknown"
+      expect(mapper.rights_holders).to eq ["Unknown"]
     end
   end
 


### PR DESCRIPTION
Refactors the `CurateMapper#singular_fields` method to dynamically generate the list.  This eliminates the need to keep the mapper and the model in sync manually in this way.

As a side effect, a number of previously missing singular fields will be available if new fields are added to the mapper:
```
["administrative_unit", "arkivo_checksum", "author_notes", "conference_dates", "content_type",  
"date_modified", "date_uploaded", "depositor", "geographic_unit", "isbn", "issn", "issue",  
"on_behalf_of", "owner", "page_range_end", "page_range_start", "parent_title",  
"primary_repository_ID", "proxy_depositor", "publisher_version", "re_use_license",  
"rights_documentation", "scheduled_rights_review", "scheduled_rights_review_note", "sponsor",  
"state", "technical_note", "volume"]
```