### PR TITLE
Only show importer link to admins

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -19,8 +19,8 @@
   <%= menu.nav_link(hyrax.leases_path) do %>
     <span class="fa fa-flag" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.leases.index.manage_leases') %></span>
   <% end %>
-<% end %>
 
-<%= menu.nav_link('/csv_imports/new',  data: { turbolinks: false }) do %>
-  <span class="fa fa-upload"></span> <span class="sidebar-action-text">Import Content From a CSV</span>
+  <%= menu.nav_link('/csv_imports/new',  data: { turbolinks: false }) do %>
+    <span class="fa fa-upload"></span> <span class="sidebar-action-text">Import Content From a CSV</span>
+  <% end %>
 <% end %>

--- a/spec/system/admin_dashboard_spec.rb
+++ b/spec/system/admin_dashboard_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe 'Admin dashboard', integration: true, clean: true, type: :system 
     scenario 'does not have settings tab' do
       expect(page).not_to have_link 'Settings'
     end
+
+    scenario 'does not have import csv link' do
+      expect(page).not_to have_link 'Import Content From a CSV'
+    end
   end
 
   context 'as an admin user' do
@@ -28,6 +32,10 @@ RSpec.describe 'Admin dashboard', integration: true, clean: true, type: :system 
 
     scenario 'does have settings tab' do
       expect(page).to have_link 'Settings'
+    end
+
+    scenario 'does  have an import csv link' do
+      expect(page).to have_link 'Import Content From a CSV'
     end
 
     # TODO: Add more admin tests, for eg: stats page, when work is created


### PR DESCRIPTION
This changes the sidebar so that it only shows
the import CSV link to admin users.

Connected to curationexperts/in-house#414