### PR TITLE
Use deduplication key for CSV collection imports

### DIFF
--- a/spec/fixtures/csv_import/collections/collections.csv
+++ b/spec/fixtures/csv_import/collections/collections.csv
@@ -1,12 +1,12 @@
-title,finding_aid_link,institution,holding_repository,administrative_unit,contact_information,abstract,primary_language,local_call_number,keywords,subject_topics,subject_names,subject_geo,subject_time_periods,creator,contributors,notes,rights_documentation,internal_rights_note,sensitive_material,staff_notes,system_of_record_ID,emory_ark,primary_repository_ID,manage,deposit,view
-Robert Langmuir African American Photograph Collection,http://findingaid.org/langmuir,Emory University,"Stuart A. Rose Manuscript, Archives, and Rare Book Library","Stuart A. Rose Manuscript, Archives, and Rare Book Library","Rose Library
+title,deduplication_key,finding_aid_link,institution,holding_repository,administrative_unit,contact_information,abstract,primary_language,local_call_number,keywords,subject_topics,subject_names,subject_geo,subject_time_periods,creator,contributors,notes,rights_documentation,internal_rights_note,sensitive_material,staff_notes,system_of_record_ID,emory_ark,primary_repository_ID,manage,deposit,view
+Robert Langmuir African American Photograph Collection,local_call_number,http://findingaid.org/langmuir,Emory University,"Stuart A. Rose Manuscript, Archives, and Rare Book Library","Stuart A. Rose Manuscript, Archives, and Rare Book Library","Rose Library
 Woodruff Library
 Emory University 
 540 Asbury Circle
 Atlanta, GA 30322 
 rose.library@emory.edu
 404-727-6887",Collection of photographs depicting African American life and culture collected by Robert Langmuir.,English,MSS1218,Keyword 1 | Keyword 2,African American children--Photographs | African American families--Photographs | African American photographers | African American men--Photographs | African American women--Photographs | African Americans--Southern States--Photographs | Photography--United States--History--19th century | Photography--United States--History--20th century,Name 1 | Name 2,Place 1 | Place 2,Era 1 | Era 2,"Langmuir, Robert, collector",Fake Contributor,Fake Note,http://rightsstatements.org/vocab/InC-NC/1.0/,Fake Internal Rights Note,No,Fake Staff Note,Fake System of Record ID,Fake legacy ark,Fake primary repository ID,admin,,
-Chester W. Topp collection of Victorian yellowbacks and paperbacks,,Emory University,"Stuart A. Rose Manuscript, Archives, and Rare Book Library","Stuart A. Rose Manuscript, Archives, and Rare Book Library","Rose Library
+Chester W. Topp collection of Victorian yellowbacks and paperbacks,local_call_number,,Emory University,"Stuart A. Rose Manuscript, Archives, and Rare Book Library","Stuart A. Rose Manuscript, Archives, and Rare Book Library","Rose Library
 Woodruff Library
 Emory University 
 540 Asbury Circle

--- a/spec/fixtures/csv_import/collections/collections.csv
+++ b/spec/fixtures/csv_import/collections/collections.csv
@@ -6,7 +6,7 @@ Emory University
 Atlanta, GA 30322 
 rose.library@emory.edu
 404-727-6887",Collection of photographs depicting African American life and culture collected by Robert Langmuir.,English,MSS1218,Keyword 1 | Keyword 2,African American children--Photographs | African American families--Photographs | African American photographers | African American men--Photographs | African American women--Photographs | African Americans--Southern States--Photographs | Photography--United States--History--19th century | Photography--United States--History--20th century,Name 1 | Name 2,Place 1 | Place 2,Era 1 | Era 2,"Langmuir, Robert, collector",Fake Contributor,Fake Note,http://rightsstatements.org/vocab/InC-NC/1.0/,Fake Internal Rights Note,No,Fake Staff Note,Fake System of Record ID,Fake legacy ark,Fake primary repository ID,admin,,
-Chester W. Topp collection of Victorian yellowbacks and paperbacks,local_call_number,,Emory University,"Stuart A. Rose Manuscript, Archives, and Rare Book Library","Stuart A. Rose Manuscript, Archives, and Rare Book Library","Rose Library
+Chester W. Topp collection of Victorian yellowbacks and paperbacks,title,,Emory University,"Stuart A. Rose Manuscript, Archives, and Rare Book Library","Stuart A. Rose Manuscript, Archives, and Rare Book Library","Rose Library
 Woodruff Library
 Emory University 
 540 Asbury Circle

--- a/spec/importers/curate_collection_importer_spec.rb
+++ b/spec/importers/curate_collection_importer_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe CurateCollectionImporter, :clean do
     cci.import(collections_csv, "/dev/null")
     Collection.where(local_call_number: "MSS1218").first
   end
+  let(:yellowbacks_collection) do
+    Collection.where(local_call_number: "YELLOWBACKS").first
+  end
 
   it 'makes collection objects' do
     cci.import(collections_csv, "/dev/null")
@@ -58,9 +61,13 @@ RSpec.describe CurateCollectionImporter, :clean do
 
   it 'does not override existing collection metadata' do
     langmuir_collection.reload
-    langmuir_collection.title = ["New Title"]
+    langmuir_collection.title = ["New Langmuir Title"]
     langmuir_collection.save
+    yellowbacks_collection.reload
+    yellowbacks_collection.abstract = "New Yellowbacks Abstract"
+    yellowbacks_collection.save
     cci.import(collections_csv, "/dev/null")
-    expect(Collection.where(local_call_number: "MSS1218").first.title).to eq ["New Title"]
+    expect(Collection.where(local_call_number: "MSS1218").first.title).to eq ["New Langmuir Title"]
+    expect(Collection.where(local_call_number: "YELLOWBACKS").first.abstract).to eq "New Yellowbacks Abstract"
   end
 end


### PR DESCRIPTION
Because `local_call_number` is an optional field on collections, a designated `deduplication_key` is now used to prevent collections from being imported more than once from a CSV. Changes made to collection metadata in the UI will persist when an attempt is made to re-import the collection.

Resolves: #665