### PR TITLE
Adds preservation_event for message digest calculation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,7 @@ Metrics/BlockLength:
         - 'config/initializers/hyrax.rb'
         - app/importers/curate_collection_importer.rb
         - lib/tasks/curate_collections.rake
+        - config/initializers/characterization_service.rb
 
 Metrics/ClassLength:
     Exclude:

--- a/config/initializers/characterization_service.rb
+++ b/config/initializers/characterization_service.rb
@@ -2,6 +2,7 @@
 # Adds 'append_original_checksum' method for adding three types of checksums
 # to the hashValue predicate
 Hydra::Works::CharacterizationService.class_eval do
+  include PreservationEvents
   # Assign values of the instance properties from the metadata mapping :prop => val
   def store_metadata(terms)
     terms.each_pair do |term, value|
@@ -16,11 +17,24 @@ Hydra::Works::CharacterizationService.class_eval do
   protected
 
     def append_original_checksum(value)
-      value.first.prepend("urn:md5:").to_s
+      event_start = DateTime.current
+      value.first&.prepend("urn:md5:").to_s
       sha256_digest = Digest::SHA256.file(object.file_path[0]).hexdigest
       sha256 = sha256_digest.prepend("urn:sha256:")
       sha1 = object.digest.first.to_s
-      value.push(sha1, sha256)
+      value.push(sha1) if sha1
+      value.push(sha256) if sha256
       object.send(:original_checksum=, value)
+      # slice the file_set ID from object.id and pass to digest_preservation_event if object is saved
+      digest_preservation_event(object.id.partition("/files").first, event_start, value) if object.id
+    end
+
+    def digest_preservation_event(file_set_id, event_start, value)
+      file_set = FileSet.find(file_set_id)
+      # create event for digest calculation/failure
+      event = { 'type' => 'Message Digest Calculation', 'start' => event_start, 'details' => value,
+                'software_version' => 'FITS v1.5.0, Fedora v4.7.5, Ruby Digest library', 'user' => file_set.depositor }
+      event['outcome'] = value.size == 3 ? 'Success' : 'Failure'
+      create_preservation_event(file_set, event)
     end
 end


### PR DESCRIPTION
* Modifies the checksum generation method in the characterization
service. Finds the file_set using the object (file) ID, and
then passes the file_set object along with the event hash,
to the create_preservation_event method in the PreservationEvents
module.
* Adds spec which tests the preservation_event is saved on the
file_set and tests expectations for preservation_event values.