### PR TITLE
changes links to preservation master file

### DIFF
--- a/app/views/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_image.html.erb
@@ -5,8 +5,8 @@
                     class: "representative-media",
                     alt: "",
                     role: "presentation" %>
-      <%= link_to @display_file.file_name.first,
-                  hyrax.download_path(file_set, use: @display_use),
+      <%= link_to t('hyrax.file_set.show.downloadable_content.image_link'),
+                  hyrax.download_path(file_set),
                   data: { label: file_set.id },
                   target: :_blank,
                   id: "file_download" %>

--- a/app/views/hyrax/file_sets/media_display/_office_document.html.erb 
+++ b/app/views/hyrax/file_sets/media_display/_office_document.html.erb 
@@ -5,8 +5,8 @@
                     class: "representative-media",
                     alt: "",
                     role: "presentation" %>
-      <%= link_to @display_file.file_name.first,
-                  hyrax.download_path(file_set, use: @display_use),
+      <%= link_to t('hyrax.file_set.show.downloadable_content.office_link'),
+                  hyrax.download_path(file_set),
                   target: :_blank,
                   id: "file_download",
                   data: { label: file_set.id } %>

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb 
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb 
@@ -5,8 +5,8 @@
                     class: "representative-media",
                     alt: "",
                     role: "presentation" %>
-      <%= link_to @display_file.file_name.first,
-                  hyrax.download_path(file_set, use: @display_use),
+      <%= link_to t('hyrax.file_set.show.downloadable_content.pdf_link'),
+                  hyrax.download_path(file_set),
                   target: :_blank,
                   id: "file_download",
                   data: { label: file_set.id } %>


### PR DESCRIPTION
Restores the original Download functionality from the View FileSet page, so that the link says "Download" and the link to download points to the Preservation Master File (not to one of the additional files).

Closes #684 