### PR TITLE
Adds FileSet use category edit field to FileSetEditForm

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -17,7 +17,7 @@ module Hyrax
 
     class_attribute :show_presenter, :form_class
     self.show_presenter = Curate::FileSetPresenter
-    self.form_class = Hyrax::Forms::FileSetEditForm
+    self.form_class = Curate::Forms::FileSetEditForm
 
     # A little bit of explanation, CanCan(Can) sets the @file_set via the .load_and_authorize_resource
     # method. However the interface for various CurationConcern modules leverages the #curation_concern method

--- a/app/forms/curate/forms/file_set_edit_form.rb
+++ b/app/forms/curate/forms/file_set_edit_form.rb
@@ -1,0 +1,5 @@
+module Curate::Forms
+  class FileSetEditForm < Hyrax::Forms::FileSetEditForm
+    self.terms += [:pcdm_use]
+  end
+end

--- a/app/views/hyrax/file_sets/_form.html.erb
+++ b/app/views/hyrax/file_sets/_form.html.erb
@@ -1,0 +1,27 @@
+<!-- [Hyrax-overwrite] -->
+<!-- Adding fileset use category#L9 -->
+<%= simple_form_for [main_app, curation_concern], html: { multipart: true } do |f| %>
+  <fieldset class="required">
+    <span class="control-label">
+      <%= label_tag 'file_set[title][]', t('.title'),  class: "string optional" %>
+    </span>
+    <%= text_field_tag 'file_set[title][]', curation_concern.title.first, class: 'form-control', required: true %>
+    <!-- fileset-use category input field -->
+    <span class="control-label">
+      <%= label_tag 'file_set[pcdm_use]', t('.pcdm_use'),  class: "string optional" %>
+    </span>
+    <div>
+      <%= select_tag 'file_set[pcdm_use]', options_for_select(["#{FileSet::PRIMARY}", "#{FileSet::SUPPLEMENTAL}", "#{FileSet::PRESERVATION}"], curation_concern.pcdm_use), class: 'form-control' %>
+    </div>
+  </fieldset>
+
+  <div class="row">
+    <div class="col-md-12 form-actions">
+      <%= f.submit(
+        (curation_concern.persisted? ? t('.save') : t('.attach_to', parent: @parent.human_readable_type)),
+        class: 'btn btn-primary'
+      ) %>
+      <%= link_to t('.cancel'), parent_path(@parent), class: 'btn btn-link' %>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -230,6 +230,9 @@ en:
         admin_metadata_heading: "Admin Metadata"
         additional_admin_fields: "Additional admin fields"
         preservation_workflow_metadata_heading: "Preservation Workflow Metadata"
+    file_sets:
+      form:
+        pcdm_use: "FileSet use"
   simple_form:
     hints:
       admin_set:

--- a/spec/forms/curate/forms/file_set_edit_form_spec.rb
+++ b/spec/forms/curate/forms/file_set_edit_form_spec.rb
@@ -1,4 +1,7 @@
-RSpec.describe Hyrax::Forms::FileSetEditForm do
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Curate::Forms::FileSetEditForm do
   subject(:file_set) { described_class.new(FileSet.new) }
 
   describe '#terms' do
@@ -9,7 +12,7 @@ RSpec.describe Hyrax::Forms::FileSetEditForm do
          :based_near, :related_url,
          :visibility_during_embargo, :visibility_after_embargo, :embargo_release_date,
          :visibility_during_lease, :visibility_after_lease, :lease_expiration_date,
-         :visibility]
+         :visibility, :pcdm_use]
       )
     end
 
@@ -33,7 +36,8 @@ RSpec.describe Hyrax::Forms::FileSetEditForm do
         "visibility_after_embargo" => "open",
         "visibility_during_lease" => "open",
         "lease_expiration_date" => "2015-10-21",
-        "visibility_after_lease" => "restricted"
+        "visibility_after_lease" => "restricted",
+        "pcdm_use" => "Primary Content"
       )
     end
 
@@ -48,6 +52,7 @@ RSpec.describe Hyrax::Forms::FileSetEditForm do
       expect(file_set['visibility_during_lease']).to eq('open')
       expect(file_set['visibility_after_lease']).to eq('restricted')
       expect(file_set['lease_expiration_date']).to eq('2015-10-21')
+      expect(file_set['pcdm_use']).to eq('Primary Content')
     end
   end
 end

--- a/spec/system/edit_file_spec.rb
+++ b/spec/system/edit_file_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Showing a file:", integration: true, clean: true, type: :system 
   let(:user) { FactoryBot.create(:user) }
   let(:file_title) { 'Some kind of title' }
   let(:work) { FactoryBot.build(:work, user: user) }
-  let(:file_set) { FactoryBot.create(:file_set, user: user, title: [file_title]) }
+  let(:file_set) { FactoryBot.create(:file_set, user: user, title: [file_title], pcdm_use: "Primary Content") }
   let(:file) { File.open(fixture_path + '/sun.png') }
 
   before do
@@ -21,6 +21,18 @@ RSpec.describe "Showing a file:", integration: true, clean: true, type: :system 
       click_link 'Descriptions'
       fill_in('Title', with: 'My Test Work')
       find('input[name="commit"]').click
+    end
+  end
+
+  context 'when the user updates fileset use category' do
+    it 'updates the fileset use' do
+      expect(file_set.pcdm_use).to eq 'Primary Content'
+      visit edit_hyrax_file_set_path(file_set)
+      select 'Supplemental Content', from: 'FileSet use'
+      find('input[name="commit"]').click
+      file_set.reload
+      expect(page).to have_content 'Supplemental Content'
+      expect(file_set.pcdm_use).to eq 'Supplemental Content'
     end
   end
 end


### PR DESCRIPTION
* This commit changes the form_class for FileSet form
to now use our new form_class, Curate::Forms::FileSetEditForm
which inherits the Hyrax::Forms::FileSetEditForm class, therefore,
we get everything from the hyrax class but we also add our own terms
for Curate in the Curate::Forms::FileSetEditForm class.
* Also, removes existing spec for Hyrax's fileset edit form and
replaces an identical spec for Curate's fileset edit form with new
terms.
* Edits the edit_file system spec to make sure the FileSet use
category can actually be edited from the FileSet edit page.