### PR TITLE
Update Zizia to 5.1 and save deduplication_key on PreIngestWorks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby] # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'uglifier', '>= 1.3.0'
 gem 'webpacker', '~> 4.x'
-gem 'zizia', '~> 5.1'
+gem 'zizia', git: 'https://github.com/curationexperts/zizia.git', ref: '48008'
 
 group :development do
   gem 'cap-ec2-emory', github: 'emory-libraries/cap-ec2'

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby] # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'uglifier', '>= 1.3.0'
 gem 'webpacker', '~> 4.x'
-gem 'zizia', '~> 5.0'
+gem 'zizia', '~> 5.1'
 
 group :development do
   gem 'cap-ec2-emory', github: 'emory-libraries/cap-ec2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1715,7 +1715,7 @@ DEPENDENCIES
   webdrivers (~> 3.0)
   webpacker (~> 4.x)
   xray-rails
-  zizia (~> 5.0)
+  zizia (~> 5.1)
 
 RUBY VERSION
    ruby 2.5.5p157

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,16 @@
 GIT
+  remote: https://github.com/curationexperts/zizia.git
+  revision: 48008d46b9e97dea7fa0773827cbf348034bbc17
+  ref: 48008
+  specs:
+    zizia (5.1.0)
+      active-fedora
+      carrierwave
+      kaminari
+      rails (~> 5.1.4)
+      rails-controller-testing
+
+GIT
   remote: https://github.com/emory-libraries/cap-ec2.git
   revision: aa48832ed4a33944b8e5498b43af0a9c4866fca1
   specs:
@@ -1651,12 +1663,6 @@ GEM
       nokogiri (~> 1.8)
     xray-rails (0.3.2)
       rails (>= 3.1.0)
-    zizia (5.1.0)
-      active-fedora
-      carrierwave
-      kaminari
-      rails (~> 5.1.4)
-      rails-controller-testing
 
 PLATFORMS
   ruby
@@ -1715,7 +1721,7 @@ DEPENDENCIES
   webdrivers (~> 3.0)
   webpacker (~> 4.x)
   xray-rails
-  zizia (~> 5.1)
+  zizia!
 
 RUBY VERSION
    ruby 2.5.5p157

--- a/app/importers/modular_importer.rb
+++ b/app/importers/modular_importer.rb
@@ -33,7 +33,7 @@ class ModularImporter
     log_start_import
     importer = Zizia::Importer.new(parser: Zizia::CsvParser.new(file: file), record_importer: CurateRecordImporter.new(attributes: attrs))
     importer.records.each do |record|
-      pre_ingest_work = Zizia::PreIngestWork.new(csv_import_detail_id: csv_import_detail.id)
+      pre_ingest_work = Zizia::PreIngestWork.new(csv_import_detail_id: csv_import_detail.id, deduplication_key: record.mapper.metadata['deduplication_key'])
       @row += 1
       if record.mapper.metadata['preservation_master_file']
         @row += 1

--- a/app/importers/modular_importer.rb
+++ b/app/importers/modular_importer.rb
@@ -33,7 +33,10 @@ class ModularImporter
     log_start_import
     importer = Zizia::Importer.new(parser: Zizia::CsvParser.new(file: file), record_importer: CurateRecordImporter.new(attributes: attrs))
     importer.records.each do |record|
-      pre_ingest_work = Zizia::PreIngestWork.new(csv_import_detail_id: csv_import_detail.id, deduplication_key: record.mapper.metadata['deduplication_key'])
+      pre_ingest_work = Zizia::PreIngestWork.find_or_create_by(deduplication_key: record.mapper.metadata['deduplication_key'])
+      csv_import_detail << pre_ingest_work
+      csv_import_detail.save
+
       @row += 1
       if record.mapper.metadata['preservation_master_file']
         @row += 1
@@ -53,6 +56,7 @@ class ModularImporter
       end
       pre_ingest_work.save
     end
+
     importer.import
     file.close
   end

--- a/spec/system/importer_preprocessed_langmuir_spec.rb
+++ b/spec/system/importer_preprocessed_langmuir_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe 'Importing preprocessed langmuir', :clean, perform_enqueued: [Att
       expect(CurateGenericWork.first.representative.title).to eq(['Front'])
       expect(CurateGenericWork.where(title: '*frisky*').first.representative.title).to eq(['Side 1'])
       expect(CurateGenericWork.where(title: '*frisky*').first.ordered_members.to_a.last.title).to eq(['Side 4'])
+      expect(Zizia::PreIngestWork.last['deduplication_key']).to be_kind_of(String)
     end
   end
 end


### PR DESCRIPTION
This saves the `deduplication_key` on
`PreIngestWork`s when running an import.

Connected to https://github.com/curationexperts/in-house/issues/442