### PR TITLE
Revise characterization preservation events

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -18,7 +18,8 @@ class CharacterizeJob < Hyrax::ApplicationJob
     Hydra::Works::CharacterizationService.run(file_set.characterization_proxy, filepath)
     event = {
       'type' => 'Characterization', 'start' => event_start, 'outcome' => 'Success',
-      'details' => 'Metadata extracted, format identified, and files validated', 'software_version' => 'Curate v.1', 'user' => file_set.depositor
+      'details' => 'Technical metadata extracted from file, format identified, and file validated',
+      'software_version' => 'FITS v1.5.0', 'user' => file_set.depositor
     }
     create_preservation_event(file_set, event)
     Rails.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -16,11 +16,9 @@ class CharacterizeJob < Hyrax::ApplicationJob
     raise "#{file_set.class.characterization_proxy} was not found for FileSet #{file_set.id}" unless file_set.characterization_proxy?
     filepath = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id) unless filepath && File.exist?(filepath)
     Hydra::Works::CharacterizationService.run(file_set.characterization_proxy, filepath)
-    event = {
-      'type' => 'Characterization', 'start' => event_start, 'outcome' => 'Success',
-      'details' => 'Technical metadata extracted from file, format identified, and file validated',
-      'software_version' => 'FITS v1.5.0', 'user' => file_set.depositor
-    }
+    event = { 'type' => 'Characterization', 'start' => event_start, 'outcome' => 'Success',
+              'details' => 'Technical metadata extracted from file, format identified, and file validated',
+              'software_version' => 'FITS v1.5.0', 'user' => file_set.depositor }
     create_preservation_event(file_set, event)
     Rails.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
     file_set.characterization_proxy.save!


### PR DESCRIPTION
The event hash for characterization preservation events now includes the FITS software version as well as revised details.

Resolves: #737