### PR TITLE
Provide a deduplication_key for yellowback manifests

### DIFF
--- a/app/importers/yellowback_preprocessor.rb
+++ b/app/importers/yellowback_preprocessor.rb
@@ -23,8 +23,8 @@ class YellowbackPreprocessor # rubocop:disable Metrics/ClassLength
 
   HEADER_FIELDS = [
     # Context fields to help humans compare this file to sources
+    'deduplication_key',
     'pl_row',
-    'work_id',
     'CSV title',
     'type',
     # Fields extracted from the csv pull list
@@ -90,8 +90,8 @@ class YellowbackPreprocessor # rubocop:disable Metrics/ClassLength
 
     def context_fields(csv_index, row, type)
       [
+        row['emory_ark'], # deduplication_key
         csv_index + 2, # pl_row  (original row number from pull list)
-        row['emory_ark'], # work_id
         row['CSV Title'], # title
         type # row type (work | fileset)
       ]

--- a/spec/importers/yellowback_preprocessor_file_spec.rb
+++ b/spec/importers/yellowback_preprocessor_file_spec.rb
@@ -39,6 +39,11 @@ RSpec.describe YellowbackPreprocessor do
     expect(import_rows[moths2_start]['title']).to eq('The common moths of England [Copy 3]') # The common moths of England
   end
 
+  it 'provides a deduplication key', :aggregate_failures do
+    expect(import_rows[shakespeare_start]['deduplication_key']).to eq('7stsg') # Shakespeare's comedy of The merchant of Venice
+    expect(import_rows[twain_start]['deduplication_key']).to eq('4c1gx') # Choice bits from Mark Twain
+  end
+
   it 'adds filesets for PDFs', :aggregate_failures do
     shakespeare_pdf = import_rows[shakespeare_start + pdf_offset] # Shakespeare's comedy of The merchant of Venice
     expect(shakespeare_pdf['type']).to eq('fileset')

--- a/spec/importers/yellowback_preprocessor_metadata_spec.rb
+++ b/spec/importers/yellowback_preprocessor_metadata_spec.rb
@@ -50,12 +50,12 @@ RSpec.describe YellowbackPreprocessor do
   end
 
   it 'maps the ark as the unique work_id' do
-    expect(import_rows[shakespeare_start]['work_id']).to eq('7stsg') # Shakespeare's comedy of The merchant of Venice
+    expect(import_rows[shakespeare_start]['deduplication_key']).to eq('7stsg') # Shakespeare's comedy of The merchant of Venice
   end
 
   it 'correctly assigns work_id for mulitple volumes' do # The common moths of England
-    expect(import_rows[moths1_start]['work_id']).to eq('7st4v') # copy 2
-    expect(import_rows[moths2_start]['work_id']).to eq('7st50') # copy 2
+    expect(import_rows[moths1_start]['deduplication_key']).to eq('7st4v') # copy 2
+    expect(import_rows[moths2_start]['deduplication_key']).to eq('7st50') # copy 2
   end
 
   # Pull List tests ############################################


### PR DESCRIPTION
Use the emory_ark as the deduplication key for yellowbacks since the other
fields likely to be unique like the MMSID can be duplicated when more than
one copy of the same yellowback volume exists. The ARK is the only ID that
is unique for each copy of yellowback.  See "The common moths of England" in
the test fixture for an example.