### PR TITLE
Update visibility badges to match Emory expectations

### DIFF
--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -6,6 +6,8 @@
     <fieldset>
       <legend class="legend-save-work"><%= t('.visibility') %></legend>
       <ul class="visibility">
+
+        <!-- Public -->
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, data: { 'target': '#collapsePublic' } %>
@@ -17,14 +19,58 @@
             </div>
           </label>
         </li>
+
+        <!-- Public Low View -->
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES) %>
+            <br />
+            <%= t('hyrax.visibility.low_res.note_html') %>
+          </label>
+        </li>
+
+        <!-- Authenticated / Emory High Download -->
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
             <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) %>
             <br />
-            <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
+            <%= t('hyrax.visibility.authenticated.note_html') %>
           </label>
         </li>
+
+        <!-- Emory Low Download -->
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMORY_LOW %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMORY_LOW) %>
+            <br />
+            <%= t('hyrax.visibility.emory_low.note_html') %>
+          </label>
+        </li>
+
+        <!-- Rose High Resolution -->
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_ROSE_HIGH %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_ROSE_HIGH) %>
+            <br />
+            <%= t('hyrax.visibility.rose_high.note_html') %>
+          </label>
+        </li>
+
+        <!-- Restricted / Private -->
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) %>
+            <br >
+            <%= t('hyrax.visibility.restricted.note_html') %>
+          </label>
+        </li>
+
+        <!-- Embargo -->
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, data: { 'target': '#collapseEmbargo' } %>
@@ -41,6 +87,8 @@
             </div>
           </label>
         </li>
+
+        <!-- Lease -->
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE, data: { 'target': '#collapseLease' } %>
@@ -55,38 +103,6 @@
                 <%= f.input :visibility_after_lease, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
               </div>
             </div>
-          </label>
-        </li>
-        <li class="radio">
-          <label>
-            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
-            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) %>
-            <br >
-            <%= t('hyrax.visibility.restricted.note_html') %>
-          </label>
-        </li>
-        <li class="radio">
-          <label>
-            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES %>
-            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES) %>
-            <br />
-            <%= t('hyrax.visibility.low_res.note_html') %>
-          </label>
-        </li>
-        <li class="radio">
-          <label>
-            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMORY_LOW %>
-            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMORY_LOW) %>
-            <br />
-            <%= t('hyrax.visibility.emory_low.note_html') %>
-          </label>
-        </li>
-        <li class="radio">
-          <label>
-            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_ROSE_HIGH %>
-            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_ROSE_HIGH) %>
-            <br />
-            <%= t('hyrax.visibility.rose_high.note_html') %>
           </label>
         </li>
       </ul>

--- a/config/initializers/prepends.rb
+++ b/config/initializers/prepends.rb
@@ -1,5 +1,7 @@
 require_relative '../prepends/custom_access_rights'
 require_relative '../prepends/custom_visibility'
+require_relative '../prepends/custom_permission_badge'
 
 Hydra::AccessControls::AccessRight.prepend(CustomAccessRights)
 Hydra::AccessControls::Visibility.prepend(CustomVisibility)
+Hyrax::PermissionBadge.prepend(CustomPermissionBadge)

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -188,19 +188,24 @@ en:
           transfer_engineer: "transfer_engineer (Transfer Engineer)"
   hyrax:
     visibility:
-      public:
-        note_html: 'Public access high resolution'
-        text: 'Public high resolution'
+      open:
+        note_html: 'Public access with full resolution view & download'
+        text: 'Public'
       low_res:
-        note_html: 'LowRes'
-        text: 'LowRes'
+        note_html: 'Public access with restricted resolution view-only'
+        text: 'Public Low View'
       emory_low:
-        note_html: 'Emory Low Resolution'
-        text: 'Emory Low'
+        note_html: 'Emory users with restricted resolution view & download'
+        text: 'Emory Low Download'
       rose_high:
-        note_html: 'Rose High Resolution'
-        text: 'Rose High Resolution'
-
+        note_html: 'Rose Library reading room access only'
+        text: 'Rose High View'
+      authenticated:
+        note_html: 'Emory users with full resolution view & download'
+        text: 'Emory High Download'
+      restricted:
+        note_html: 'Administrator and Owner access only'
+        text: 'Private'
 
     relationships_parent_row:
       label: "In Parent Work:"

--- a/config/prepends/custom_permission_badge.rb
+++ b/config/prepends/custom_permission_badge.rb
@@ -1,0 +1,11 @@
+module CustomPermissionBadge
+  private
+
+    # We are overriding this method from Hyrax because we do not want to display the
+    # institution name in the Authenticated permission badge
+    def text
+      I18n.t("hyrax.visibility.#{@visibility}.text")
+    rescue
+      @visibility.to_s
+    end
+end

--- a/spec/system/create_curate_generic_work_spec.rb
+++ b/spec/system/create_curate_generic_work_spec.rb
@@ -104,12 +104,52 @@ RSpec.describe 'Create a CurateGenericWork', integration: true, clean: true, typ
       expect(find('div.ui-menu-item-wrapper', match: :first).text).to eq 'Test3'
     end
 
+    scenario "work visibility uses expected labels", js: true do
+      visit("/concern/curate_generic_works/#{cgw.id}/edit")
+
+      # Private / Restricted
+      private_input = find("ul.visibility").find("input#curate_generic_work_visibility_restricted")
+      private_label = private_input.sibling("span").text
+      expect(private_label).to eq "Private"
+      private_text = private_input.find(:xpath, "..").text.split("\n")[1]
+      expect(private_text).to eq "Administrator and Owner access only"
+
+      # Public Low View
+      public_low_view_input = find("ul.visibility").find("input#curate_generic_work_visibility_low_res")
+      public_low_view_label = public_low_view_input.sibling("span").text
+      expect(public_low_view_label).to eq "Public Low View"
+      public_low_view_text = public_low_view_input.find(:xpath, "..").text.split("\n")[1]
+      expect(public_low_view_text).to eq "Public access with restricted resolution view-only"
+
+      # Emory High Download
+      emory_high_network_input = find("ul.visibility").find("input#curate_generic_work_visibility_authenticated")
+      emory_high_network_label = emory_high_network_input.sibling("span").text
+      expect(emory_high_network_label).to eq "Emory High Download"
+      emory_high_network_text = emory_high_network_input.find(:xpath, "..").text.split("\n")[1]
+      expect(emory_high_network_text).to eq "Emory users with full resolution view & download"
+
+      # Emory Low Download
+      emory_low_input = find("ul.visibility").find("input#curate_generic_work_visibility_emory_low")
+      emory_low_label = emory_low_input.sibling("span").text
+      expect(emory_low_label).to eq "Emory Low Download"
+      emory_low_text = emory_low_input.find(:xpath, "..").text.split("\n")[1]
+      expect(emory_low_text).to eq "Emory users with restricted resolution view & download"
+
+      # Rose High View
+      rose_high_input = find("ul.visibility").find("input#curate_generic_work_visibility_rose_high")
+      rose_high_label = rose_high_input.sibling("span").text
+      expect(rose_high_label).to eq "Rose High View"
+      rose_high_text = rose_high_input.find(:xpath, "..").text.split("\n")[1]
+      expect(rose_high_text).to eq "Rose Library reading room access only"
+    end
+
     scenario "verify work visibility can be edited" do
       expect(cgw.visibility).to eq 'restricted'
 
       visit("/concern/curate_generic_works/#{cgw.id}/edit")
 
       find('body').click
+
       choose('curate_generic_work_visibility_low_res')
       choose('curate_generic_work_visibility_emory_low')
       choose('curate_generic_work_visibility_rose_high')


### PR DESCRIPTION
Update visibility badges to match specifications from Curate user group

Connected to https://github.com/curationexperts/in-house/issues/448