### PR TITLE
Change genre and contributor in Yellowback preprocessor

### DIFF
--- a/app/importers/yellowback_preprocessor.rb
+++ b/app/importers/yellowback_preprocessor.rb
@@ -40,7 +40,7 @@ class YellowbackPreprocessor # rubocop:disable Metrics/ClassLength
     'system_of_record_ID',
     # Fields extracted from Alma MARC records
     'conference_name',
-    'contributor',
+    'contributors',
     'copyright_date',
     'creator',
     'date_created',
@@ -48,7 +48,7 @@ class YellowbackPreprocessor # rubocop:disable Metrics/ClassLength
     'date_issued',
     'edition',
     'extent',
-    'genre',
+    'content_genres',
     'local_call_number',
     'place_of_production',
     'primary_language',
@@ -115,7 +115,7 @@ class YellowbackPreprocessor # rubocop:disable Metrics/ClassLength
     def alma_mappings(record, row) # rubocop:disable Metrics/MethodLength
       [
         conference_name(record),
-        contributor(record),
+        contributors(record),
         copyright_date(record),
         creator(record),
         date_created(record),
@@ -123,7 +123,7 @@ class YellowbackPreprocessor # rubocop:disable Metrics/ClassLength
         date_issued(record),
         edition(record),
         extent(record),
-        genre(record),
+        content_genres(record),
         local_call_number(record),
         place_of_production(record),
         primary_language(record),
@@ -202,7 +202,7 @@ class YellowbackPreprocessor # rubocop:disable Metrics/ClassLength
       extract_datafields(marc_record, '611')
     end
 
-    def contributor(marc_record)
+    def contributors(marc_record)
       [extract_datafields(marc_record, '700'),
        extract_datafields(marc_record, '710')].join('|')
     end
@@ -245,7 +245,7 @@ class YellowbackPreprocessor # rubocop:disable Metrics/ClassLength
       extract_datafields(marc_record, '300')
     end
 
-    def genre(marc_record)
+    def content_genres(marc_record)
       extract_datafields(marc_record, '655')
     end
 

--- a/spec/importers/yellowback_preprocessor_metadata_spec.rb
+++ b/spec/importers/yellowback_preprocessor_metadata_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 require 'rails_helper'
 
@@ -112,8 +113,8 @@ RSpec.describe YellowbackPreprocessor do
     expect(import_rows[shakespeare_start]['copyright_date']).to eq('1898') # Shakespeare's comedy of The merchant of Venice
   end
 
-  it 'extracts contributor information from Alma' do
-    expect(import_rows[shakespeare_start]['contributor']).to eq('Gollancz, Israel, 1864-1930.|' + # Shakespeare's comedy of The merchant of Venice
+  it 'extracts contributors information from Alma' do
+    expect(import_rows[shakespeare_start]['contributors']).to eq('Gollancz, Israel, 1864-1930.|' + # Shakespeare's comedy of The merchant of Venice
                                                 'Hughes, Ted, 1930-1998, former owner. GEU|' +
                                                 'Ted Hughes Library (Emory University. General Libraries) GEU')
   end
@@ -146,12 +147,12 @@ RSpec.describe YellowbackPreprocessor do
     expect(import_rows[moths1_start]['extent']).to eq('154 pages, 12 leaves of plates : illustrations ; 17 cm.') # The common moths of England
   end
 
-  it 'extracts genre from Alma' do
-    expect(import_rows[twain_start]['genre']).to eq('Yellowbacks.') # Choice bits from Mark Twain
+  it 'extracts content_genres from Alma' do
+    expect(import_rows[twain_start]['content_genres']).to eq('Yellowbacks.') # Choice bits from Mark Twain
   end
 
-  it 'leaves genre blank if no value exists Alma' do
-    expect(import_rows[shakespeare_start]['genre']).to be_nil # Shakespeare's comedy of The merchant of Venice
+  it 'leaves content_genres blank if no value exists Alma' do
+    expect(import_rows[shakespeare_start]['content_genres']).to be_nil # Shakespeare's comedy of The merchant of Venice
   end
 
   it 'extracts local_call_number from Alma' do


### PR DESCRIPTION
Curate uses `content_genres` and `contributors` in its metadata
model.

Connected to https://github.com/curationexperts/in-house/issues/464
Connected to https://github.com/curationexperts/in-house/issues/465