### PR TITLE
Update Capistrano stages to use systemd for sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ group :development do
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
   gem 'capistrano-rails-collection'
-  gem 'capistrano-sidekiq', '~> 0.20.0'
+  gem 'capistrano-sidekiq'
   gem 'fcrepo_wrapper'
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'solr_wrapper', '>= 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -933,9 +933,9 @@ GEM
       capistrano-bundler (~> 1.1)
     capistrano-rails-collection (0.1.0)
       capistrano-rails (~> 1.1)
-    capistrano-sidekiq (0.20.0)
+    capistrano-sidekiq (1.0.3)
       capistrano (>= 3.9.0)
-      sidekiq (>= 3.4)
+      sidekiq (>= 3.4, < 6.0)
     capybara (3.29.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -1398,7 +1398,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
-    rake (13.0.0)
+    rake (13.0.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -1672,7 +1672,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-rails-collection
-  capistrano-sidekiq (~> 0.20.0)
+  capistrano-sidekiq
   capybara
   coffee-rails (~> 4.2)
   coveralls

--- a/config/deploy/cd.rb
+++ b/config/deploy/cd.rb
@@ -1,2 +1,5 @@
 # frozen_string_literal: true
+
 server 'curate-cd.curationexperts.com', user: 'deploy', roles: [:web, :app, :db, :ubuntuapp, :collection]
+set :init_system, :systemd # see https://github.com/seuros/capistrano-sidekiq#integration-with-systemd
+set :service_unit_name, "sidekiq.service"

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,2 +1,4 @@
 # frozen_string_literal: true
 server 'curate-qa.curationexperts.com', user: 'deploy', roles: [:web, :app, :db, :ubuntuapp]
+set :init_system, :systemd # see https://github.com/seuros/capistrano-sidekiq#integration-with-systemd
+set :service_unit_name, "sidekiq.service"


### PR DESCRIPTION
Emory does not appear to be using systemd and dce is on our servers,
so we need to supply some additional parameters to the stage file to
let sidekiq know how to restart appropriately.

For more details see:
https://github.com/seuros/capistrano-sidekiq#integration-with-systemd

NOTE: the PR explicitly sets the service name to be backwards compatible with the name created by the DCE sidekiq ansible role.  By default the capistrano-sidekiq gem now adds the state name as a suffix, we may want to move to the default configuration in the future, but I wanted to stay backward compatible in case we have any monitoring set up for the old service name.