### PR TITLE
Edits work creation preservation_events

### DIFF
--- a/app/actors/hyrax/actors/curate_generic_work_actor.rb
+++ b/app/actors/hyrax/actors/curate_generic_work_actor.rb
@@ -29,18 +29,15 @@ module Hyrax
         event_start = DateTime.current # record event_start timestamp
         apply_creation_data_to_curation_concern(env)
         apply_save_data_to_curation_concern(env)
-        # Create our three required events
-        work_creation = { 'type' => 'Object Validation (Work created)', 'start' => event_start, 'outcome' => 'Success', 'details' => 'Valid submission package submitted',
-                          'software_version' => 'Curate v.1', 'user' => env.user.uid }
-        work_policy = { 'type' => 'Policy Assignment', 'start' => event_start, 'outcome' => 'Success', 'details' => 'Policy was assigned', 'software_version' => 'Curate v.1',
-                        'user' => env.user.uid }
-        work_metadata = { 'type' => 'Metadata Extraction', 'start' => event_start, 'outcome' => 'Success', 'details' => 'Descriptive, Rights, and Administrative metadata extracted from CSV',
-                          'software_version' => 'Curate v.1', 'user' => env.user.uid }
         save(env) && next_actor.create(env) && run_callbacks(:after_create_concern, env)
+        # Create our three required events
+        work_creation = { 'type' => 'Validation', 'start' => event_start, 'outcome' => 'Success', 'details' => 'Submission package validated',
+                          'software_version' => 'Curate v.1', 'user' => env.user.uid }
+        work_policy = { 'type' => 'Policy Assignment', 'start' => event_start, 'outcome' => 'Success',
+                        'details' => "Policy was assigned. Visibility/access controls assigned: #{env.curation_concern.visibility}", 'software_version' => 'Curate v.1', 'user' => env.user.uid }
         # Create preservation events
         create_preservation_event(env.curation_concern, work_creation)
         create_preservation_event(env.curation_concern, work_policy)
-        create_preservation_event(env.curation_concern, work_metadata)
       end
     end
   end

--- a/spec/actors/hyrax/actors/curate_generic_work_actor_spec.rb
+++ b/spec/actors/hyrax/actors/curate_generic_work_actor_spec.rb
@@ -31,10 +31,11 @@ RSpec.describe Hyrax::Actors::CurateGenericWorkActor do
         expect(Hyrax.config.callback).to receive(:run)
           .with(:after_create_concern, curation_concern, user)
         middleware.create(env)
-        expect(curation_concern.preservation_event.pluck(:event_type)).to include ['Object Validation (Work created)']
+        expect(curation_concern.preservation_event.pluck(:event_type)).to include ['Validation']
         expect(curation_concern.preservation_event.first.outcome).to eq ['Success']
         expect(curation_concern.preservation_event.first.initiating_user).to eq [user.uid]
-        expect(curation_concern.preservation_event.count).to eq 3
+        expect(curation_concern.preservation_event.pluck(:event_details)).to include ['Policy was assigned. Visibility/access controls assigned: restricted']
+        expect(curation_concern.preservation_event.count).to eq 2
       end
     end
   end


### PR DESCRIPTION
* This commit removes the metadata_extraction event for the time being.
* Also, event hashes are now created after save.
* It adds visibility of the curation_concern to policy_assignment
event_details.
* Edits the spec to match revised work events.