### PR TITLE
Revises where file_replication/submission event happens

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -114,3 +114,7 @@ RSpec/MessageChain:
         - 'spec/services/characterization_service_spec.rb'
         - 'spec/actors/hyrax/actors/file_actor_spec.rb'
         - 'spec/system/show_file_spec.rb'
+
+RSpec/AnyInstance:
+    Exclude:
+        - 'spec/models/job_io_wrapper_spec.rb'

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -24,9 +24,7 @@ module Hyrax
         # If the file set doesn't have a title or label assigned, set a default.
         file_set.label ||= label_for(file)
         file_set.title = [file_set.label] if file_set.title.blank?
-        event_start = DateTime.current
         return false unless file_set.save # Need to save to get an id
-        file_set_preservation_event(file_set, event_start)
         if from_url
           # If ingesting from URL, don't spawn an IngestJob; instead
           # reach into the FileActor and run the ingest with the file instance in
@@ -173,13 +171,6 @@ module Hyrax
           work.representative = nil if work.representative_id == file_set.id
           work.rendering_ids -= [file_set.id]
           work.save!
-        end
-
-        # create preservation_event for fileset creation (method in PreservationEvents module)
-        def file_set_preservation_event(file_set, event_start)
-          event = { 'type' => 'Replication (FileSet created)', 'start' => event_start, 'outcome' => 'Success', 'details' => 'File replicated to cross-region S3 storage',
-                    'software_version' => 'Fedora v4.7.5', 'user' => user.uid }
-          create_preservation_event(file_set, event)
         end
       # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/CyclomaticComplexity

--- a/config/initializers/job_io_wrapper.rb
+++ b/config/initializers/job_io_wrapper.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+# [Hyrax-model-overwrite]
+# ingest_file method in the JobIoWrapper method is modified. We save the response
+# from the `file_actor.ingest_file` method call. If false is returned from L#16 in
+# `config/intializers/file_actor.rb` then a failure event is created, else success
+# event.
+
+JobIoWrapper.class_eval do
+  include PreservationEvents
+
+  def ingest_file
+    event_start = DateTime.current
+    file_name = file.path.to_s.split("/").last
+    result = file_actor.ingest_file(self)
+    if result == false
+      outcome = 'Failure'
+      details = "File not replicated to cross-region S3 storage: #{file_name}"
+    else
+      outcome = 'Success'
+      details = "File replicated to cross-region S3 storage: #{file_name}"
+    end
+    file_set_preservation_event(file_set, event_start, outcome, details)
+  end
+
+  private
+
+    # create preservation_event for fileset creation (method in PreservationEvents module)
+    def file_set_preservation_event(file_set, event_start, outcome, details)
+      event = { 'type' => 'File submission', 'start' => event_start, 'outcome' => outcome, 'details' => details,
+                'software_version' => 'Fedora v4.7.5', 'user' => user.uid }
+      create_preservation_event(file_set, event)
+    end
+end

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -54,18 +54,5 @@ RSpec.describe Hyrax::Actors::FileSetActor, :clean do
         expect(file_set.label).to eql(label)
       end
     end
-
-    context 'when a fileset is saved' do
-      before do
-        actor.create_content(file)
-      end
-
-      it 'adds a new preservation_event for fileset creation' do
-        expect(file_set.preservation_event.first.event_type).to eq ['Replication (FileSet created)']
-        expect(file_set.preservation_event.first.outcome).to eq ['Success']
-        expect(file_set.preservation_event.first.initiating_user).to eq [user.uid]
-        expect(file_set.preservation_event.count).to eq 1
-      end
-    end
   end
 end

--- a/spec/models/job_io_wrapper_spec.rb
+++ b/spec/models/job_io_wrapper_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+# [Hyrax-model-spec-overwrite]
+# We are only testing the `ingest_file` method here.
+
+require 'rails_helper'
+
+RSpec.describe JobIoWrapper, type: :model do
+  describe "#ingest_file" do
+    let(:user)          { FactoryBot.build(:user) }
+    let(:file_set)      { FactoryBot.create(:file_set) }
+    let(:pmf)           { File.open(fixture_path + '/book_page/0003_preservation_master.tif') }
+    let(:inf)           { File.open(fixture_path + '/book_page/0003_intermediate.jp2') }
+    let(:uploaded_file) { Hyrax::UploadedFile.new(user: user, file_set_uri: file_set.uri, preservation_master_file: pmf, intermediate_file: inf) }
+    let(:args)          { { file_set: file_set, user: user, file: uploaded_file.preservation_master_file, relation: :preservation_master_file } }
+    let(:args2)         { { file_set: file_set, user: user, file: uploaded_file.intermediate_file, relation: :intermediate_file } }
+
+    before do
+      # ingest_file success
+      described_class.create_with_varied_file_handling!(args).ingest_file
+      # here we are mocking a `false` response from `file_actor.ingest_file`
+      Hyrax::Actors::FileActor.any_instance.stub(:ingest_file).and_return(false)
+      # ingest_file failure since `false` was returned
+      described_class.create_with_varied_file_handling!(args2).ingest_file
+      file_set.reload
+    end
+
+    it "saves preservation_events with proper outcomes" do
+      expect(file_set.preservation_event.count).to eq 2
+      expect(file_set.preservation_event.pluck(:event_details)).to include ['File not replicated to cross-region S3 storage: 0003_intermediate.jp2']
+      expect(file_set.preservation_event.pluck(:event_details)).to include ['File replicated to cross-region S3 storage: 0003_preservation_master.tif']
+      expect(file_set.preservation_event.pluck(:outcome)).to include ['Failure']
+      expect(file_set.preservation_event.pluck(:outcome)).to include ['Success']
+    end
+  end
+end


### PR DESCRIPTION
* This commit removes the replication event from the file_set_actor
since we are no longer logging when the file_set saves.
* We are now creating an event on file ingest in the job_io_wrapper
model. We look for what is returned from the file_actor.ingest_file
method. If `false` is returned and the file is not attached to the file_set,
we create a failure event, else a success event.

Notes:
* ingest_file method in the JobIoWrapper method is modified. We save the response
from the `file_actor.ingest_file` method call. If false is returned from L#16 in
`config/intializers/file_actor.rb` then a failure event is created, else success
event.

Output in fedora:
For success event (on fileset):
![image](https://user-images.githubusercontent.com/17075287/69373236-62675b80-0c71-11ea-8176-18c83677d7fe.png)

For failure event (on fileset):
![image](https://user-images.githubusercontent.com/17075287/69373258-6eebb400-0c71-11ea-9864-077778715044.png)
