### PR TITLE
Add visibility to guide

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,6 +78,10 @@ Metrics/MethodLength:
         - app/indexers/curate/file_set_indexer.rb
         - app/jobs/characterize_job.rb
 
+Metrics/ModuleLength:
+    Exclude:
+        - app/lib/metadata_definitions.rb
+
 Layout/AlignHash:
     Exclude:
         - app/models/curate_generic_work.rb

--- a/app/lib/metadata_definitions.rb
+++ b/app/lib/metadata_definitions.rb
@@ -98,4 +98,18 @@ module MetadataDefinitions
       usage: Zizia::MetadataUsage.instance.usage['pcdm_use']
     }
   end
+
+  def visibility_definition
+    {
+      attribute:  'visibility',
+      predicate:  'n/a',
+      multiple: 	'false',
+      type:       'String',
+      validator: 	'Required, must exist in the application\'s controlled vocabulary for visiblity levels.',
+      label: 	    'Visibility',
+      csv_header: 'visibility',
+      required_on_form: 	'true',
+      usage: Zizia::MetadataUsage.instance.usage['visibility']
+    }
+  end
 end

--- a/app/lib/metadata_details.rb
+++ b/app/lib/metadata_details.rb
@@ -5,16 +5,16 @@ class MetadataDetails
   include Singleton
   include MetadataDefinitions
 
+  ADDITIONAL_DETAILS = [:intermediate_file_definition, :service_file_definition, :extracted_definition,
+                        :pcdm_use_definition, :fileset_label_definition, :transcript_definition,
+                        :visibility_definition].freeze
+
   def details(work_attributes:)
     validators = work_attributes.validators
     detail_list = work_attributes.properties.sort.map { |p| definition_hash_for(p, validators) }
     detail_list << preservation_master_file_definition
-    detail_list << intermediate_file_definition
-    detail_list << service_file_definition
-    detail_list << extracted_definition
-    detail_list << transcript_definition
-    detail_list << pcdm_use_definition
-    detail_list << fileset_label_definition
+    ADDITIONAL_DETAILS.each { |detail| detail_list << send(detail) }
+    detail_list
   end
 
   def to_csv(work_attributes:)

--- a/config/zizia/usage.yml
+++ b/config/zizia/usage.yml
@@ -93,4 +93,5 @@ title:                  "The name of the resource being described. The title may
 transcript: "Path to a file that contains a transcript"
 transfer_engineer:      "Name of the person who digitized/reformatted the master files for the object (not necessarily the additional/supplemental files)"
 uniform_title:          "The standardized version of a title, established when a work has been issued under varying names"
+visibility: "The desired visiblity setting for the work and it's files. You can use: Private, Restricted, Authenticated, Registered, Emory, Emory Network, Open, Public, Public Low View, Emory Low Download, or Rose High View."
 volume:                 "The volume indication for the material"

--- a/spec/controllers/metadata_details_spec.rb
+++ b/spec/controllers/metadata_details_spec.rb
@@ -94,6 +94,13 @@ RSpec.describe MetadataDetailsController, type: :controller do
       expect(definition.field('usage')).to include 'Path to a file that contains a transcript'
     end
 
+    it 'includes visibility' do
+      get :profile
+      profile_table = CSV.parse(response.body, headers: :first_row)
+      definition = profile_table.find { |r| r.field('attribute') == 'visibility' }
+      expect(definition.field('usage')).to include "Private, Restricted, Authenticated, Registered, Emory, Emory Network, Open, Public, Public Low View, Emory Low Download, or Rose High View."
+    end
+
     it 'includes fileset_label' do
       get :profile
       profile_table = CSV.parse(response.body, headers: :first_row)


### PR DESCRIPTION
This adds `visibility` to the guide and includes the
availble options in the the `usage.yml` file.

Connected to https://github.com/curationexperts/in-house/issues/484