### PR TITLE
Update MARC fixture to match sample data

### DIFF
--- a/spec/fixtures/csv_import/yellowbacks/yellowbacks_marc.xml
+++ b/spec/fixtures/csv_import/yellowbacks/yellowbacks_marc.xml
@@ -59,7 +59,6 @@
     <datafield tag="700" ind1="1" ind2=" ">
       <subfield code="a">Topp, Chester W.,</subfield>
       <subfield code="e">collector.</subfield>
-      <subfield code="5">GEU</subfield>
     </datafield>
     <datafield tag="710" ind1="2" ind2=" ">
       <subfield code="a">Chatto &amp; Windus (Firm),</subfield>
@@ -173,13 +172,11 @@
     <datafield tag="700" ind1="1" ind2=" ">
       <subfield code="a">Topp, Chester W.,</subfield>
       <subfield code="e">collector.</subfield>
-      <subfield code="5">GEU</subfield>
     </datafield>
     <datafield tag="710" ind1="2" ind2=" ">
       <subfield code="a">
         Chester W. Topp collection of Victorian yellowbacks and paperbacks (Emory University. MARBL)
       </subfield>
-      <subfield code="5">GEU</subfield>
     </datafield>
     <datafield tag="830" ind1=" " ind2="0">
       <subfield code="a">Books for the country.</subfield>
@@ -340,13 +337,11 @@
       <subfield code="a">Hughes, Ted,</subfield>
       <subfield code="d">1930-1998,</subfield>
       <subfield code="e">former owner.</subfield>
-      <subfield code="5">GEU</subfield>
     </datafield>
     <datafield tag="710" ind1="2" ind2=" ">
       <subfield code="a">
         Ted Hughes Library (Emory University. General Libraries)
       </subfield>
-      <subfield code="5">GEU</subfield>
     </datafield>
     <datafield tag="856" ind1="4" ind2="1">
       <subfield code="u">http://pid.emory.edu/ark:/25593/7stsg/IA</subfield>

--- a/spec/importers/yellowback_preprocessor_metadata_spec.rb
+++ b/spec/importers/yellowback_preprocessor_metadata_spec.rb
@@ -115,8 +115,8 @@ RSpec.describe YellowbackPreprocessor do
 
   it 'extracts contributors information from Alma' do
     expect(import_rows[shakespeare_start]['contributors']).to eq('Gollancz, Israel, 1864-1930.|' + # Shakespeare's comedy of The merchant of Venice
-                                                'Hughes, Ted, 1930-1998, former owner. GEU|' +
-                                                'Ted Hughes Library (Emory University. General Libraries) GEU')
+                                                'Hughes, Ted, 1930-1998, former owner.|' +
+                                                'Ted Hughes Library (Emory University. General Libraries)')
   end
 
   it 'extracts creator information from Alma' do


### PR DESCRIPTION
Emory has decided to remove subfield 5 (institution) from contributor
(field 700) entries.  This PR updates the fixtures to match the live
data going forward.