### PR TITLE
Capture the screenshots Circle creates for system test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,9 @@ jobs:
                 root: coverage
                 paths: codeclimate.*.json
 
+            - store_artifacts:
+                path: tmp/screenshots
+
             - deploy:
                 command: curl -k https://coveralls.io/webhook?repo_token=${COVERALLS_REPO_TOKEN} -d "payload[build_num]=${CIRCLE_BUILD_NUM}&payload[status]=done"
 


### PR DESCRIPTION
When a system test fails, capybara will take a screenshot of the failure. When this happens in Circle, this PR uploads them as artifacts. As an example, see the two screenshots from a failed run of this PR: https://app.circleci.com/jobs/github/emory-libraries/dlp-curate/5142/artifacts