### PR TITLE
Fix logic in failing AdminSetup test

### DIFF
--- a/spec/lib/admin_setup_spec.rb
+++ b/spec/lib/admin_setup_spec.rb
@@ -21,11 +21,13 @@ RSpec.describe AdminSetup, :clean do
     expect((w.admin_role.users.map(&:uid).include? admin_user_uid)).to eq true
   end
   it "returns all admins" do
+    existing_admins = w.admins.count
     s = %w[admin1 admin2 admin3]
     s.each do |t|
       w.make_admin(t)
     end
-    expect(w.admins.count).to eq 3
+    new_admins = w.admins.count - existing_admins
+    expect(new_admins).to eq 3
     expect(w.admins.pluck(:uid).include?(s.first)).to be true
   end
 end


### PR DESCRIPTION
The existing test counts the absolute number of admins created in the
test, but at some point the fixture introduced new admins.  I.E. the
total admin count in the test is the number of admins created by the
intial fixture PLUS the number created in the test.

This PR changes the test to check the delta during the test run instead
of the absolute value.

PREVIOUSLY
```
  1) AdminSetup returns all admins
     Failure/Error: expect(w.admins.count).to eq 3
     
       expected: 3
            got: 4
     
       (compared using ==)
     # ./spec/lib/admin_setup_spec.rb:28:in `block (2 levels) in <top (required)>'
```