### PR TITLE
adds fixity check button on file_set show page

### DIFF
--- a/app/controllers/hyrax/fixity_checks_controller.rb
+++ b/app/controllers/hyrax/fixity_checks_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# [Hyrax-overwrite]
+# Adds redirect on L#28 in create action
+module Hyrax
+  class FixityChecksController < ApplicationController
+    before_action :authenticate_user!
+
+    # request here with param :file_set_id will trigger a fixity check if
+    # needed, and respond with a JSON hash that looks something like:
+    #
+    #     { "file_id" => [
+    #         {
+    #           "checked_uri" => "http://127.0.0.1:8986/rest/test/12/57/9s/28/12579s28n/files/3ff48171-f625-48bb-a73d-b1ba16dde530/fcr:versions/version1",
+    #           "passed" => true,
+    #           "expected_result" => "urn:sha1:03434..."
+    #           "created_at" => "2017-05-16T15:32:50.961Z"
+    #         }
+    #       ]
+    #     }
+    def create
+      # render json: fixity_check_service.fixity_check
+      result = fixity_check_service.fixity_check
+      notice = if result.values.first[0]['passed'] == true
+                 'Ran fixity check successfully'
+               else
+                 'There was an issue running fixity check'
+               end
+      redirect_to main_app.hyrax_file_set_path(params[:file_set_id]), notice: notice
+    end
+
+    private
+
+      def fixity_check_service
+        # We are calling `async_jobs: false` to ensure we get a fixity result to
+        # return even if there are no 'fresh' ones on record. Otherwise, we'd
+        # have to sometimes return a 'in progress' status for some bytestreams,
+        # which is a possible future enhancement.
+        @fixity_check_service ||=
+          FileSetFixityCheckService.new(::FileSet.find(params[:file_set_id]), async_jobs: false)
+      end
+  end
+end

--- a/app/controllers/hyrax/fixity_checks_controller.rb
+++ b/app/controllers/hyrax/fixity_checks_controller.rb
@@ -19,13 +19,8 @@ module Hyrax
     #     }
     def create
       # render json: fixity_check_service.fixity_check
-      result = fixity_check_service.fixity_check
-      notice = if result.values.first[0]['passed'] == true
-                 'Ran fixity check successfully'
-               else
-                 'There was an issue running fixity check'
-               end
-      redirect_to main_app.hyrax_file_set_path(params[:file_set_id]), notice: notice
+      fixity_check_service.fixity_check
+      redirect_to main_app.hyrax_file_set_path(params[:file_set_id]), notice: 'Ran fixity check'
     end
 
     private

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -4,6 +4,7 @@
     <div class="col-xs-12 col-sm-4">
       <%= media_display @presenter %>
       <%= render 'show_actions', presenter: @presenter %>
+      <div><%= button_to 'Run Fixity check', file_set_fixity_checks_path(file_set_id: @presenter.id), method: :post, class: 'btn btn-primary' %></div>
       <%= render 'single_use_links', presenter: @presenter if @presenter.editor? %>
     </div>
     <div itemscope itemtype="<%= @presenter.itemtype %>" class="col-xs-12 col-sm-8">

--- a/spec/controllers/hyrax/fixity_checks_controller_spec.rb
+++ b/spec/controllers/hyrax/fixity_checks_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+# [Hyrax-overwrite]
+# We have removed json_response tests from here since we are
+# no longer rendering json in our create method
+require 'rails_helper'
+
+RSpec.describe Hyrax::FixityChecksController do
+  routes { Hyrax::Engine.routes }
+  let(:user) { FactoryBot.create(:user) }
+  let(:file_set) { FactoryBot.create(:file_set, user: user) }
+  let(:binary) { File.open(fixture_path + '/world.png') }
+  let(:file) { Hydra::Derivatives::IoDecorator.new(binary, 'image/png', 'world.png') }
+
+  before { Hydra::Works::UploadFileToFileSet.call(file_set, file) }
+
+  context "when signed in" do
+    describe "POST create" do
+      before do
+        sign_in user
+        post :create, params: { file_set_id: file_set }, xhr: true
+      end
+
+      it "returns result and redirects to file_set page" do
+        expect(response).to be_success
+        expect(response.redirect_url).to include "/concern/file_sets/#{file_set.id}"
+      end
+    end
+  end
+
+  context "when not signed in" do
+    describe "POST create" do
+      it "returns json with the result" do
+        post :create, params: { file_set_id: file_set }, xhr: true
+        expect(response.code).to eq '401'
+      end
+    end
+  end
+end

--- a/spec/system/show_file_spec.rb
+++ b/spec/system/show_file_spec.rb
@@ -42,4 +42,15 @@ RSpec.describe "Showing a file:", integration: true, clean: true, type: :system 
       expect(find('#fileset-category').text).to include('Primary Content')
     end
   end
+
+  context 'when fixity check is run' do
+    before do
+      visit hyrax_file_set_path(file_set)
+      click_on 'Run Fixity check'
+    end
+
+    it 'shows result of fixity check' do
+      expect(page).to have_content 'passed 3 Files with 3 total versions checked'
+    end
+  end
 end


### PR DESCRIPTION
* This commit adds a button for running fixity check on demand.
* We modify the create method in the FixityChecksController since
we no longer need to render json, but redirect to the file_set show
page with the result from the fixity check.