### PR TITLE
Adds preferred file arg to job_io_wrapper_spec

### DIFF
--- a/spec/models/job_io_wrapper_spec.rb
+++ b/spec/models/job_io_wrapper_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe JobIoWrapper, type: :model do
     let(:pmf)           { File.open(fixture_path + '/book_page/0003_preservation_master.tif') }
     let(:inf)           { File.open(fixture_path + '/book_page/0003_intermediate.jp2') }
     let(:uploaded_file) { Hyrax::UploadedFile.new(user: user, file_set_uri: file_set.uri, preservation_master_file: pmf, intermediate_file: inf) }
-    let(:args)          { { file_set: file_set, user: user, file: uploaded_file.preservation_master_file, relation: :preservation_master_file } }
-    let(:args2)         { { file_set: file_set, user: user, file: uploaded_file.intermediate_file, relation: :intermediate_file } }
+    let(:args)          { { file_set: file_set, user: user, file: uploaded_file.preservation_master_file, relation: :preservation_master_file, preferred: :preservation_master_file } }
+    let(:args2)         { { file_set: file_set, user: user, file: uploaded_file.intermediate_file, relation: :intermediate_file, preferred: :intermediate_file } }
 
     before do
       # ingest_file success


### PR DESCRIPTION
This commit adds preferred file arg to create_with_varied_file_handling
method since this a required arg with no default. The job_io_wrapper_spec
was failing because of the missing arg.