### PR TITLE
Regenerate derivatives

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,7 @@ Metrics/BlockLength:
         - lib/tasks/curate_collections.rake
         - config/initializers/characterization_service.rb
         - config/initializers/job_io_wrapper.rb
+        - lib/tasks/derivatives.rake
 
 Metrics/ClassLength:
     Exclude:

--- a/lib/tasks/derivatives.rake
+++ b/lib/tasks/derivatives.rake
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+namespace :derivatives do
+  desc "Regenerate derivatives for all works"
+  task regenerate_all: :environment do
+    Hyrax.config.curation_concerns.each do |work_type|
+      total = 0
+
+      work_type.all.each do |work|
+        regenerate_derivatives(work)
+        total += 1
+      end
+
+      puts "Queued jobs to regenerate derivatives for #{total} #{work_type} works(s)"
+    end
+  end
+
+  desc "Regenerate derivatives for a single work, e.g. rake derivatives:regenerate['c821gj76b']"
+  task :regenerate, [:id] => :environment do |_task, args|
+    id = args[:id]
+    abort "ERROR: no work id specified, aborting" unless id
+    abort "ERROR: cannot find work with id #{id}, aborting" unless ActiveFedora::Base.exists?(id)
+
+    work = ActiveFedora::Base.find(id)
+    regenerate_derivatives(work)
+    puts "Queued background jobs to regenerate derivatives for record: #{id}"
+  end
+
+  def regenerate_derivatives(work)
+    work.file_sets.each do |fs|
+      puts " processing FileSet #{fs.id}"
+      asset_path = fs.original_file.uri.to_s
+      asset_path = asset_path[asset_path.index(fs.id.to_s)..-1]
+      CreateDerivativesJob.perform_later(fs, asset_path)
+    end
+  end
+end


### PR DESCRIPTION
Add a rake task to regenerate derivatives via the command line.
Options include regenerating for a single work or for all works in the
repository.

Connected to https://github.com/emory-libraries/dlp-lux/issues/63