### PR TITLE
Adds fixity_check preservation_event

### DIFF
--- a/app/jobs/fixity_check_job.rb
+++ b/app/jobs/fixity_check_job.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+# [Hyrax-overwrite]
+# Adds fixity_check preservation_event
+class FixityCheckJob < Hyrax::ApplicationJob
+  include PreservationEvents
+  # A Job class that runs a fixity check (using ActiveFedora::FixityService,
+  # which contacts fedora and requests a fixity check), and stores the results
+  # in an ActiveRecord ChecksumAuditLog row. It also prunes old ChecksumAuditLog
+  # rows after creating a new one, to keep old ones you don't care about from
+  # filling up your db.
+  #
+  # The uri passed in is a fedora URI that fedora can run fixity check on.
+  # It's normally a version URI like:
+  #     http://localhost:8983/fedora/rest/test/a/b/c/abcxyz/content/fcr:versions/version1
+  #
+  # But could theoretically be any URI fedora can fixity check on, like a file uri:
+  #     http://localhost:8983/fedora/rest/test/a/b/c/abcxyz/content
+  #
+  # The file_set_id and file_id are used only for logging context in the
+  # ChecksumAuditLog, and determining what old ChecksumAuditLogs can
+  # be pruned.
+  #
+  # If calling async as a background job, return value is irrelevant, but
+  # if calling sync with `perform_now`, returns the ChecksumAuditLog
+  # record recording the check.
+  #
+  # @param uri [String] uri - of the specific file/version to fixity check
+  # @param file_set_id [FileSet] the id for FileSet parent object of URI being checked.
+  # @param file_id [String] File#id, used for logging/reporting.
+  def perform(uri, file_set_id:, file_id:)
+    uri = uri.to_s # sometimes we get an RDF::URI gah
+    log = run_check(file_set_id, file_id, uri)
+
+    if log.failed? && Hyrax.config.callback.set?(:after_fixity_check_failure)
+      file_set = ::FileSet.find(file_set_id)
+      Hyrax.config.callback.run(:after_fixity_check_failure,
+                                file_set,
+                                checksum_audit_log: log)
+    end
+
+    log
+  end
+
+  private
+
+    def run_check(file_set_id, file_id, uri)
+      event_start = DateTime.current
+      service = ActiveFedora::FixityService.new(uri)
+      begin
+        fixity_ok = service.check
+        expected_result = service.expected_message_digest
+      rescue Ldp::NotFound
+        # Either the #check or #expected_message_digest could raise this exception
+        error_msg = 'resource not found'
+      end
+
+      log = ChecksumAuditLog.create_and_prune!(passed: fixity_ok, file_set_id: file_set_id, checked_uri: uri, file_id: file_id, expected_result: expected_result)
+      file_set_preservation_event(log, file_set_id, file_id, event_start)
+      # Note that the after_fixity_check_failure will be called if the fixity check fail. This
+      # logging is for additional information related to the failure. Wondering if we should
+      # also include the error message?
+      logger.error "FIXITY CHECK FAILURE: Fixity failed for #{uri} #{error_msg}: #{log}" unless fixity_ok
+      log
+    end
+
+    def logger
+      Hyrax.logger
+    end
+
+    def file_set_preservation_event(log, file_set_id, file_id, event_start)
+      fixity_file_set = ::FileSet.find(file_set_id)
+      fixity_file = Hydra::PCDM::File.find(file_id)
+      event = { 'type' => 'Fixity Check', 'start' => event_start,
+                'software_version' => 'Fedora v4.7.5', 'user' => fixity_file_set.depositor }
+      if log.passed == true
+        event['outcome'] = 'Success'
+        event['details'] = "Fixity intact for file: #{fixity_file&.original_name}: sha1:#{fixity_file&.checksum&.value}"
+      else
+        event['outcome'] = 'Failure'
+        event['details'] = "Fixity check failed for: #{fixity_file&.original_name}: sha1:#{fixity_file&.checksum&.value}"
+      end
+      create_preservation_event(fixity_file_set, event)
+    end
+end

--- a/spec/jobs/fixity_check_job_spec.rb
+++ b/spec/jobs/fixity_check_job_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+# [Hyrax-overwrite]
+# Adds tests for fixity_check preservation_event
+require 'rails_helper'
+
+RSpec.describe FixityCheckJob do
+  let(:user) { FactoryBot.create(:user) }
+
+  let(:file_set) do
+    FactoryBot.create(:file_set, user: user).tap do |file|
+      Hydra::Works::AddFileToFileSet.call(file, File.open(fixture_path + '/world.png'), :preservation_master_file, versioning: true)
+    end
+  end
+  let(:file_id) { file_set.preservation_master_file.id }
+
+  describe "called with perform_now" do
+    let(:log_record) { described_class.perform_now(uri, file_set_id: file_set.id, file_id: file_id) }
+
+    describe 'fixity check the content' do
+      let(:uri) { file_set.preservation_master_file.uri }
+
+      it 'passes' do
+        expect(log_record).to be_passed
+      end
+      it "returns a ChecksumAuditLog" do
+        expect(log_record).to be_kind_of ChecksumAuditLog
+        expect(log_record.checked_uri).to eq uri
+        expect(log_record.file_id).to eq file_id
+        expect(log_record.file_set_id).to eq file_set.id
+      end
+    end
+
+    describe 'fixity check a version of the content' do
+      let(:uri) { Hyrax::VersioningService.latest_version_of(file_set.preservation_master_file).uri }
+
+      it 'passes' do
+        expect(log_record).to be_passed
+      end
+      it "returns a ChecksumAuditLog" do
+        expect(log_record).to be_kind_of ChecksumAuditLog
+      end
+    end
+
+    describe 'fixity check an invalid version of the content' do
+      let(:uri) { Hyrax::VersioningService.latest_version_of(file_set.preservation_master_file).uri + 'bogus' }
+
+      it 'fails' do
+        expect(log_record).to be_failed
+      end
+      it "returns a ChecksumAuditLog" do
+        expect(log_record).to be_kind_of ChecksumAuditLog
+      end
+    end
+
+    describe 'creates fixity_check preservation_events' do
+      let(:file1) { File.open(fixture_path + '/sun.png') }
+      let(:file2) { File.open(fixture_path + '/image.jp2') }
+      let(:uri1)  { file_set.preservation_master_file.uri }
+      let(:uri2)  { file_set.service_file.uri }
+      let(:uri3)  { file_set.intermediate_file.uri }
+
+      before do
+        Hydra::Works::AddFileToFileSet.call(file_set, file1, :service_file)
+        Hydra::Works::AddFileToFileSet.call(file_set, file2, :intermediate_file)
+        described_class.perform_now(uri1, file_set_id: file_set.id, file_id: file_set.preservation_master_file.id)
+        described_class.perform_now(uri2, file_set_id: file_set.id, file_id: file_set.service_file.id)
+      end
+
+      context 'when all fixity_checks pass for a file_set' do
+        before do
+          described_class.perform_now(uri3, file_set_id: file_set.id, file_id: file_set.intermediate_file.id)
+          file_set.reload
+        end
+
+        it 'creates three success fixity_check preservation_events' do
+          expect(file_set.preservation_event.pluck(:event_details)).to include ["Fixity intact for file: world.png: sha1:#{file_set.preservation_master_file.checksum.value}"]
+          expect(file_set.preservation_event.pluck(:event_details)).to include ["Fixity intact for file: sun.png: sha1:#{file_set.preservation_master_file.checksum.value}"]
+          expect(file_set.preservation_event.pluck(:event_details)).to include ["Fixity intact for file: image.jp2: sha1:#{file_set.preservation_master_file.checksum.value}"]
+        end
+      end
+
+      context 'when fixity_check fails for a file' do
+        let(:cal) { ChecksumAuditLog.create!(passed: false, file_set_id: file_set.id, file_id: file_set.intermediate_file.id) }
+        before do
+          allow(ChecksumAuditLog).to receive(:create_and_prune!).and_return(cal)
+          described_class.perform_now(uri3, file_set_id: file_set.id, file_id: file_set.intermediate_file.id)
+          file_set.reload
+        end
+
+        it 'creates one failure and two success fixity_check preservation_events' do
+          expect(file_set.preservation_event.pluck(:event_details)).to include ["Fixity check failed for: image.jp2: sha1:#{file_set.preservation_master_file.checksum.value}"]
+          expect(file_set.preservation_event.pluck(:event_details)).to include ["Fixity intact for file: world.png: sha1:#{file_set.preservation_master_file.checksum.value}"]
+          expect(file_set.preservation_event.pluck(:event_details)).to include ["Fixity intact for file: sun.png: sha1:#{file_set.preservation_master_file.checksum.value}"]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Adds fixity_check preservation_event to run_check method in
FixityCheckJob. Takes the ChecksumAuditLog for a file and checks
for the `passed` attribute. If true, creates success event else
failure event.