### PR TITLE
Index human-readable metadata fields for Lux

### DIFF
--- a/app/indexers/curate_generic_work_indexer.rb
+++ b/app/indexers/curate_generic_work_indexer.rb
@@ -13,6 +13,8 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
     super.tap do |solr_doc|
       solr_doc['preservation_workflow_terms_sim'] = preservation_workflow_terms
       solr_doc['human_readable_content_type_tesim'] = [human_readable_content_type]
+      solr_doc['human_readable_rights_statement_tesim'] = [human_readable_rights_statement]
+      solr_doc['human_readable_re_use_license_tesim'] = [human_readable_re_use_license]
     end
   end
 
@@ -23,5 +25,15 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
   def human_readable_content_type
     return unless object.content_type
     FormatLabelService.instance.label(uri: object.content_type)
+  end
+
+  def human_readable_rights_statement
+    return unless object.rights_statement
+    FormatLabelService.instance.label(uri: object.rights_statement)
+  end
+
+  def human_readable_re_use_license
+    return unless object.re_use_license
+    FormatLabelService.instance.label(uri: object.re_use_license)
   end
 end

--- a/app/indexers/curate_generic_work_indexer.rb
+++ b/app/indexers/curate_generic_work_indexer.rb
@@ -28,12 +28,12 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
   end
 
   def human_readable_rights_statement
-    return unless object.rights_statement
-    FormatLabelService.instance.label(uri: object.rights_statement)
+    return [] if object.rights_statement.empty?
+    RightsStatementLabelService.instance.label(uri: object.rights_statement.first)
   end
 
   def human_readable_re_use_license
     return unless object.re_use_license
-    FormatLabelService.instance.label(uri: object.re_use_license)
+    LicensesLabelService.instance.label(uri: object.re_use_license)
   end
 end

--- a/app/models/curate_generic_work.rb
+++ b/app/models/curate_generic_work.rb
@@ -120,7 +120,9 @@ class CurateGenericWork < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :grant_information, predicate: "http://metadata.emory.edu/vocab/cor-terms#grantOrFundingNote"
+  property :grant_information, predicate: "http://metadata.emory.edu/vocab/cor-terms#grantOrFundingNote" do |index|
+    index.as :stored_searchable
+  end
 
   property :holding_repository, predicate: "http://id.loc.gov/vocabulary/relators/rps", multiple: false do |index|
     index.as :stored_searchable, :facetable
@@ -142,7 +144,9 @@ class CurateGenericWork < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :issue, predicate: "http://purl.org/ontology/bibo/issue", multiple: false
+  property :issue, predicate: "http://purl.org/ontology/bibo/issue", multiple: false do |index|
+    index.as :stored_searchable
+  end
 
   property :keywords, predicate: "http://schema.org/keywords" do |index|
     index.as :stored_searchable

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -92,4 +92,12 @@ class SolrDocument
   def human_readable_content_type
     self['human_readable_content_type_tesim']
   end
+
+  def human_readable_rights_statement
+    self['human_readable_rights_statement_tesim']
+  end
+
+  def human_readable_re_use_license
+    self['human_readable_re_use_license_tesim']
+  end
 end

--- a/app/services/licenses_label_service.rb
+++ b/app/services/licenses_label_service.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class LicensesLabelService
+  include Singleton
+
+  def label(uri:)
+    Qa::Authorities::Local.subauthority_for('licenses').all.select { |t| t['id'] == uri }[0]['label']
+  end
+end

--- a/spec/factories/curate_generic_works.rb
+++ b/spec/factories/curate_generic_works.rb
@@ -88,7 +88,7 @@ FactoryBot.define do
       primary_repository_ID { 'http://example.com' }
       publisher { 'emory' }
       publisher_version { '1' }
-      re_use_license { 'true' }
+      re_use_license { 'https://creativecommons.org/licenses/by/4.0/' }
       related_datasets { ['http://example.com'] }
       related_material_notes { ['More stuff'] }
       related_publications { ['https://example.com'] }

--- a/spec/models/curate_generic_work_spec.rb
+++ b/spec/models/curate_generic_work_spec.rb
@@ -1326,13 +1326,16 @@ RSpec.describe CurateGenericWork do
         primary_language: 'English',
         abstract: 'This is point number 1',
         copyright_date: Date.new(2018, 1, 12),
-        content_type: 'http://id.loc.gov/vocabulary/resourceTypes/txt' }
+        content_type: 'http://id.loc.gov/vocabulary/resourceTypes/txt',
+        rights_statement: 'http://rightsstatements.org/vocab/InC/1.0/',
+        re_use_license: 'https://creativecommons.org/licenses/by/4.0/' }
     end
     let(:curate_generic_work) { FactoryBot.build(:work, **params) }
     let(:solr_doc) { curate_generic_work.to_solr }
 
     it "returns the SolrDoc with metadata" do
-      expect(solr_doc.keys).to include('title_tesim', 'primary_language_tesim', 'abstract_tesim', 'copyright_date_dtsim', 'content_type_tesim')
+      expect(solr_doc.keys).to include('title_tesim', 'primary_language_tesim',
+      'abstract_tesim', 'copyright_date_dtsim', 'content_type_tesim', 'rights_statement_tesim', 're_use_license_tesim')
 
       # Check title (multi-valued)
       expect(solr_doc['title_tesim']).to match_array params[:title]
@@ -1351,6 +1354,18 @@ RSpec.describe CurateGenericWork do
 
       # Check content_type_tesim also saved as human_readable_content_type
       expect(solr_doc['human_readable_content_type_tesim']).to eq ['Text']
+
+      # Check rights_statement_tesim also saved as url
+      expect(solr_doc['rights_statement_tesim']).to contain_exactly params[:rights_statement]
+
+      # Check rights_statement_tesim also saved as human_readable_rights_statement
+      expect(solr_doc['human_readable_rights_statement_tesim']).to eq ['In Copyright']
+
+      # Check re_use_license_tesim also saved as url
+      expect(solr_doc['re_use_license_tesim']).to contain_exactly params[:re_use_license]
+
+      # Check re_use_license_tesim also saved as human_readable_re_use_license
+      expect(solr_doc['human_readable_re_use_license_tesim']).to eq ['Creative Commons BY Attribution 4.0 International']
     end
   end
 

--- a/spec/models/curate_generic_work_spec.rb
+++ b/spec/models/curate_generic_work_spec.rb
@@ -1327,7 +1327,7 @@ RSpec.describe CurateGenericWork do
         abstract: 'This is point number 1',
         copyright_date: Date.new(2018, 1, 12),
         content_type: 'http://id.loc.gov/vocabulary/resourceTypes/txt',
-        rights_statement: 'http://rightsstatements.org/vocab/InC/1.0/',
+        rights_statement: ['http://rightsstatements.org/vocab/InC/1.0/'],
         re_use_license: 'https://creativecommons.org/licenses/by/4.0/' }
     end
     let(:curate_generic_work) { FactoryBot.build(:work, **params) }
@@ -1356,7 +1356,7 @@ RSpec.describe CurateGenericWork do
       expect(solr_doc['human_readable_content_type_tesim']).to eq ['Text']
 
       # Check rights_statement_tesim also saved as url
-      expect(solr_doc['rights_statement_tesim']).to contain_exactly params[:rights_statement]
+      expect(solr_doc['rights_statement_tesim']).to contain_exactly params[:rights_statement].first
 
       # Check rights_statement_tesim also saved as human_readable_rights_statement
       expect(solr_doc['human_readable_rights_statement_tesim']).to eq ['In Copyright']

--- a/spec/models/curate_generic_work_spec.rb
+++ b/spec/models/curate_generic_work_spec.rb
@@ -1334,8 +1334,10 @@ RSpec.describe CurateGenericWork do
     let(:solr_doc) { curate_generic_work.to_solr }
 
     it "returns the SolrDoc with metadata" do
-      expect(solr_doc.keys).to include('title_tesim', 'primary_language_tesim',
-      'abstract_tesim', 'copyright_date_dtsim', 'content_type_tesim', 'rights_statement_tesim', 're_use_license_tesim')
+      expect(solr_doc.keys).to include(
+        'title_tesim', 'primary_language_tesim', 'abstract_tesim', 'copyright_date_dtsim',
+        'content_type_tesim', 'rights_statement_tesim', 're_use_license_tesim'
+      )
 
       # Check title (multi-valued)
       expect(solr_doc['title_tesim']).to match_array params[:title]


### PR DESCRIPTION
* In order to support required metadata display in Lux, `:rights_statement` and `:re_use_license` now have human-readable versions indexed in the Solr document on the Curate side. The `LicensesLabelService` is created to support human-readable versions of `:re_use_license`.
* `:grant_information` and `:issue` are now indexed as `:stored_searchable` in order to be made available for Lux.