### PR TITLE
Adds fixity_check rake task

### DIFF
--- a/app/jobs/fixity_check_job.rb
+++ b/app/jobs/fixity_check_job.rb
@@ -68,16 +68,18 @@ class FixityCheckJob < Hyrax::ApplicationJob
     end
 
     def file_set_preservation_event(log, file_set_id, file_id, event_start)
+      @logger = Logger.new(STDOUT)
       fixity_file_set = ::FileSet.find(file_set_id)
       fixity_file = Hydra::PCDM::File.find(file_id)
-      event = { 'type' => 'Fixity Check', 'start' => event_start,
-                'software_version' => 'Fedora v4.7.5', 'user' => fixity_file_set.depositor }
+      event = { 'type' => 'Fixity Check', 'start' => event_start, 'software_version' => 'Fedora v4.7.5', 'user' => fixity_file_set.depositor }
       if log.passed == true
         event['outcome'] = 'Success'
         event['details'] = "Fixity intact for file: #{fixity_file&.original_name}: sha1:#{fixity_file&.checksum&.value}"
+        @logger.info "Ran fixity check successfully on #{fixity_file&.original_name}"
       else
         event['outcome'] = 'Failure'
         event['details'] = "Fixity check failed for: #{fixity_file&.original_name}: sha1:#{fixity_file&.checksum&.value}"
+        @logger.error "Fixity check failure: Fixity failed for #{fixity_file&.original_name}"
       end
       create_preservation_event(fixity_file_set, event)
     end

--- a/lib/tasks/fixity_check.rake
+++ b/lib/tasks/fixity_check.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+namespace :curate do
+  namespace :file_sets do
+    desc "Perform fixity checking on file_sets"
+    task fixity_check: :environment do
+      FileSet.all.each do |file_set|
+        Hyrax::FileSetFixityCheckService.new(file_set, max_days_between_fixity_checks: 90).fixity_check
+      end
+    end
+  end
+end

--- a/spec/jobs/fixity_check_job_spec.rb
+++ b/spec/jobs/fixity_check_job_spec.rb
@@ -3,7 +3,7 @@
 # Adds tests for fixity_check preservation_event
 require 'rails_helper'
 
-RSpec.describe FixityCheckJob do
+RSpec.describe FixityCheckJob, :clean do
   let(:user) { FactoryBot.create(:user) }
 
   let(:file_set) do


### PR DESCRIPTION
* We are adding a new rake task to run fixity_check on all file_sets.
Max days between check has been set to 90. We are checking for all
versions of a file for all files in a given file_set. Also, a logger
output has been added.