### PR TITLE
Humanize additional date formats for Lux

### DIFF
--- a/app/services/date_service.rb
+++ b/app/services/date_service.rb
@@ -21,16 +21,29 @@ class DateService
 
   def handle_date_range(date)
     years = date.split("\/")
-    return "within the #{handle_unspecified_digit(years[0])} or #{handle_unspecified_digit(years[1])}" if date.end_with?('X')
-    return "between #{years[0].tr('?', '')} and #{years[1].tr('?', '')}" if date.end_with?('?')
+    return date if years.length > 2
+    return "within the #{handle_unspecified_digit(years[0])} or #{handle_unspecified_digit(years[1])}" if date.end_with?("X")
+    return "between #{years[0].tr('?', '')} and #{years[1].tr('?', '')}" if date.end_with?("?")
+    return Date.edtf(date).humanize unless Date.edtf(date).nil?
+    date
   end
 
   def handle_ymd_format(date)
-    return Date.edtf(date).humanize unless date.start_with?("X") || Date.edtf(date).nil?
     date_units = date.split("-")
+    return handle_ym_format(date) if date_units.length == 2
+    return Date.edtf(date).humanize unless date.start_with?("X") || Date.edtf(date).nil?
     # The edtf-humanize gem expects a valid 4-digit year when handling dates in YMD format
     placeholder_date = Date.edtf("0000-#{date_units[1]}-#{date_units[2]}")
     return placeholder_date.humanize[/[^,]+/] + ", year unknown" unless placeholder_date.nil?
+    date
+  end
+
+  def handle_ym_format(date)
+    if date.end_with?("~")
+      placeholder_date = Date.edtf(date.tr("~", ""))
+      return placeholder_date.humanize + " approx." unless placeholder_date.nil?
+    end
+    return Date.edtf(date).humanize unless Date.edtf(date).nil?
     date
   end
 

--- a/spec/services/date_service_spec.rb
+++ b/spec/services/date_service_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe DateService do
       expect(service.human_readable_date('1934?')).to eq('1934 approx.')
     end
 
+    it 'provides a string for known year ranges' do
+      expect(service.human_readable_date('1981/1985')).to eq('1981 to 1985')
+    end
+
     it 'provides a string for year ranges with unspecified digits' do
       expect(service.human_readable_date('194X/195X')).to eq('within the 1940s or 1950s')
     end
@@ -37,7 +41,15 @@ RSpec.describe DateService do
       expect(service.human_readable_date('XXXX-09-07')).to eq('September 7, year unknown')
     end
 
-    it 'provides a string for dates with unexpected YMD formatting' do
+    it 'provides a string for dates with known month and year but unknown day' do
+      expect(service.human_readable_date('1962-02')).to eq('February 1962')
+    end
+
+    it 'provides a string for dates uncertain month and year but unknown day' do
+      expect(service.human_readable_date('1940-02~')).to eq('February 1940 approx.')
+    end
+
+    it 'leaves dates with unexpected formatting unaltered' do
       expect(service.human_readable_date('2019-XX-07')).to eq('2019-XX-07')
     end
   end


### PR DESCRIPTION
- Dates with only month and year and uncertain dates ending in "~" are now made human-readable for Lux
- See [Lux issue 177](https://github.com/emory-libraries/dlp-lux/issues/177)