### PR TITLE
Add year_for_lux field to Solr document

### DIFF
--- a/app/indexers/curate_generic_work_indexer.rb
+++ b/app/indexers/curate_generic_work_indexer.rb
@@ -21,6 +21,7 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
       solr_doc['human_readable_date_created_tesim'] = [human_readable_date_created]
       solr_doc['human_readable_date_issued_tesim'] = [human_readable_date_issued]
       solr_doc['year_issued_isim'] = year_issued
+      solr_doc['year_for_lux_isim'] = year_for_lux
       solr_doc['human_readable_data_collection_dates_tesim'] = human_readable_data_collection_dates
       solr_doc['human_readable_conference_dates_tesim'] = [human_readable_conference_dates]
       solr_doc['human_readable_copyright_date_tesim'] = [human_readable_copyright_date]
@@ -81,5 +82,11 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
     integer_years = YearParser.integer_years(object.date_issued)
     return nil if integer_years.blank?
     integer_years
+  end
+
+  def year_for_lux
+    years = [year_created, year_issued].flatten.compact.uniq.sort
+    return nil if years.empty?
+    years
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -128,4 +128,8 @@ class SolrDocument
   def year_issued
     self['year_issued_isim']
   end
+
+  def year_for_lux
+    self['year_for_lux_isim']
+  end
 end

--- a/spec/indexers/curate_generic_work_spec.rb
+++ b/spec/indexers/curate_generic_work_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe CurateGenericWorkIndexer do
       it 'indexes the year created' do
         expect(solr_document['year_created_isim']).to eq [1940]
       end
+
+      it 'indexes year for lux' do
+        expect(solr_document['year_for_lux_isim']).to eq [1940]
+      end
     end
 
     context 'when date_created field is blank' do
@@ -29,6 +33,10 @@ RSpec.describe CurateGenericWorkIndexer do
 
       it 'doesn\'t index the year created' do
         expect(solr_document['year_created_isim']).to eq nil
+      end
+
+      it 'doesn\'t index year for lux' do
+        expect(solr_document['year_for_lux_isim']).to eq nil
       end
     end
   end
@@ -45,6 +53,10 @@ RSpec.describe CurateGenericWorkIndexer do
       it 'indexes the year issued' do
         expect(solr_document['year_issued_isim']).to eq [1940]
       end
+
+      it 'indexes year for lux' do
+        expect(solr_document['year_for_lux_isim']).to eq [1940]
+      end
     end
 
     context 'when date_issued field is blank' do
@@ -56,6 +68,40 @@ RSpec.describe CurateGenericWorkIndexer do
 
       it 'doesn\'t index the year issued' do
         expect(solr_document['year_issued_isim']).to eq nil
+      end
+
+      it 'doesn\'t index year for lux' do
+        expect(solr_document['year_for_lux_isim']).to eq nil
+      end
+    end
+  end
+
+  describe 'year for lux' do
+    context 'when date_created and date_issued fields have the same year' do
+      let(:attributes) do
+        {
+          id:           '123',
+          date_created: '1940-10-15',
+          date_issued:  '1940-11-15'
+        }
+      end
+
+      it 'deduplicates the year fields' do
+        expect(solr_document['year_for_lux_isim']).to eq [1940]
+      end
+    end
+
+    context 'when date_created and date_issued fields have different years' do
+      let(:attributes) do
+        {
+          id:           '123',
+          date_created: '1940-10-15',
+          date_issued:  '1941-01-15'
+        }
+      end
+
+      it 'saves both years and saves them in order' do
+        expect(solr_document['year_for_lux_isim']).to eq [1940, 1941]
       end
     end
   end

--- a/spec/models/curate_generic_work_spec.rb
+++ b/spec/models/curate_generic_work_spec.rb
@@ -1391,6 +1391,9 @@ RSpec.describe CurateGenericWork do
       # Check date_issued_tesim also saved as year_issued_isim
       expect(solr_doc['year_issued_isim']).to eq [1930, 1931, 1932, 1933, 1934, 1935, 1936, 1937, 1938, 1939]
 
+      # Check year_created_isim and year_issued_isim also saved as year_for_lux_isim
+      expect(solr_doc['year_for_lux_isim']).to eq [1930, 1931, 1932, 1933, 1934, 1935, 1936, 1937, 1938, 1939]
+
       # Check data_collection_dates_tesim also saved as date entered
       expect(solr_doc['data_collection_dates_tesim']).to contain_exactly params[:data_collection_dates].first
 


### PR DESCRIPTION
The `year_for_lux` field combines and deduplicates `year_created` and `year_issued` for Lux faceting.