### PR TITLE
Adds `ordered_member_ids` to work form params

### DIFF
--- a/app/forms/hyrax/curate_generic_work_form.rb
+++ b/app/forms/hyrax/curate_generic_work_form.rb
@@ -66,7 +66,8 @@ module Hyrax
                     :visibility_during_lease,
                     :lease_expiration_date,
                     :visibility_after_lease,
-                    :visibility]
+                    :visibility,
+                    { ordered_member_ids: [] }]
       permitted << { preservation_workflow_attributes: [:id,
                                                         { workflow_type: [] }, { workflow_notes: [] },
                                                         { workflow_rights_basis: [] }, { workflow_rights_basis_note: [] },

--- a/spec/forms/hyrax/curate_generic_work_form_spec.rb
+++ b/spec/forms/hyrax/curate_generic_work_form_spec.rb
@@ -40,4 +40,45 @@ RSpec.describe Hyrax::CurateGenericWorkForm do
       expect(params[:creator]).to eq ['Me']
     end
   end
+
+  describe ".build_permitted_params" do
+    subject { described_class.build_permitted_params }
+
+    context "without mediated deposit" do
+      it {
+        is_expected.to include(:representative_id,
+                               :thumbnail_id,
+                               :admin_set_id,
+                               :visibility_during_embargo,
+                               :embargo_release_date,
+                               :visibility_after_embargo,
+                               :visibility_during_lease,
+                               :lease_expiration_date,
+                               :visibility_after_lease,
+                               :visibility,
+                               ordered_member_ids: [])
+      }
+    end
+  end
+
+  describe ".model_attributes" do
+    subject :permitted_params do
+      described_class.model_attributes(params)
+    end
+
+    let(:params) { ActionController::Parameters.new(attributes) }
+    let(:attributes) do
+      { visibility:         'open',
+        representative_id:  '456',
+        thumbnail_id:       '789',
+        rights_statement:   'http://rightsstatements.org/vocab/InC-EDU/1.0/',
+        ordered_member_ids: ['123', '456'] }
+    end
+
+    it 'permits parameters' do
+      expect(permitted_params['visibility']).to eq 'open'
+      expect(permitted_params['rights_statement']).to eq 'http://rightsstatements.org/vocab/InC-EDU/1.0/'
+      expect(permitted_params['ordered_member_ids']).to eq ['123', '456']
+    end
+  end
 end


### PR DESCRIPTION
* This commit adds the missing `ordered_member_ids` param to the list of permitted
params for the work form. This will fix the issue where we were unable to
reorder filesets for a work.
* Tests are also added for checking of permitted params and model attributes.