### PR TITLE
Fix Honeybadger Env

### DIFF
--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -1,6 +1,6 @@
 ---
 api_key: <%= ENV['HONEYBADGER_API_KEY'] %>
-env: <% ENV['HOSTNAME'].partition('.')[0] %>
+env: <%= Socket.gethostname.partition('.')[0] %>
 
 breadcrumbs:
     enabled: true


### PR DESCRIPTION
Use Socket.gethostname rather than an ENV var, which seems to not get read reliably.