### PR TITLE
Adds rake task to reindex file_sets and regen thumbs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -114,6 +114,7 @@ RSpec/MessageChain:
         - 'spec/services/characterization_service_spec.rb'
         - 'spec/actors/hyrax/actors/file_actor_spec.rb'
         - 'spec/system/show_file_spec.rb'
+        - 'spec/lib/index_file_set_spec.rb'
 
 RSpec/AnyInstance:
     Exclude:

--- a/app/lib/index_file_set.rb
+++ b/app/lib/index_file_set.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+class IndexFileSet
+  class << self
+    def process
+      CSV.open("config/emory/index_file_set_results.csv", "w") do |csv|
+        FileSet.all.each do |file_set|
+          if file_set.mime_type.nil? # check if file_set is characterized
+            csv << [file_set.id, "Fileset not characterized", "Not fixed"]
+          else
+            solr_doc = SolrDocument.find(file_set.id)
+            if solr_doc.mime_type.nil? # when file_set is characterized but wasn't indexed properly
+              reindex_file_set(file_set, csv)
+            elsif solr_doc.thumbnail_path.to_s.start_with?("/assets/default-") # when file_set was characterized but thumbnail_path in solr doc is incorrect
+              regenerate_derivatives(file_set, csv)
+            end
+          end
+        end
+      end
+    end
+
+    private
+
+      def reindex_file_set(file_set, csv)
+        file_set.to_solr
+        file_set.save!
+        csv << [file_set.id, "Fileset not indexed", "Fixed"]
+      end
+
+      def regenerate_derivatives(file_set, csv)
+        preferred_file_uri = preferred_file(file_set)
+        asset_path = preferred_file_uri[preferred_file_uri.index(file_set.id.to_s)..-1]
+        CreateDerivativesJob.perform_later(file_set, asset_path)
+        csv << [file_set.id, "Thumbnail_path mismatch in solr_doc", "Queued"]
+      end
+
+      def preferred_file(file_set)
+        preferred = if file_set.service_file.present?
+                      file_set.service_file.uri.to_s
+                    elsif file_set.intermediate_file.present?
+                      file_set.intermediate_file.uri.to_s
+                    else
+                      file_set.preservation_master_file.uri.to_s
+                    end
+        preferred
+      end
+  end
+end

--- a/lib/tasks/index_file_sets.rake
+++ b/lib/tasks/index_file_sets.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+namespace :curate do
+  namespace :file_sets do
+    desc "Perform indexing on file_sets for which mime_type is missing"
+    task index_file_set: :environment do
+      IndexFileSet.process
+    end
+  end
+end

--- a/spec/lib/index_file_set_spec.rb
+++ b/spec/lib/index_file_set_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe IndexFileSet, :clean do
+  let(:csv)         { IO.read(File.join("config/emory/index_file_set_results.csv")) }
+  let(:file)        { File.open(fixture_path + '/book_page/0003_preservation_master.tif') }
+  let(:file_set)    { FactoryBot.create(:file_set) }
+
+  context 'file_set is indexed incorrectly' do
+    before do
+      allow(SolrDocument).to receive_message_chain(:find, :mime_type)
+      Hydra::Works::AddFileToFileSet.call(file_set, file, :preservation_master_file)
+      described_class.process
+    end
+
+    it 'reindexes file_set' do
+      expect(csv).to include("#{file_set.id},Fileset not indexed,Fixed")
+    end
+  end
+
+  context 'file_set thumbnail_path in solr is incorrect' do
+    before do
+      allow(SolrDocument).to receive_message_chain(:find, :thumbnail_path).and_return("/assets/default-f936e9c3ea7a38e2c2092099586a71380b11258697b37fb4df376704495a849a.png")
+      allow(SolrDocument).to receive_message_chain(:find, :mime_type).and_return('image/tiff')
+      Hydra::Works::AddFileToFileSet.call(file_set, file, :preservation_master_file)
+      described_class.process
+    end
+
+    it 'regenerates thumbnail and fixes thumbnail_path in solr' do
+      expect(csv).to include("#{file_set.id},Thumbnail_path mismatch in solr_doc,Queued")
+    end
+  end
+end


### PR DESCRIPTION
* This commit adds a way to reindex file_sets that have a missing
`mime_type` in solr and appends file_set info to csv.
* Also, adds a way to regen thumbnails for file_sets that have a
default preview image as thumbnail and appends file_set info to csv.