### PR TITLE
Adds `thumbnail_id` to collection_form

### DIFF
--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -29,7 +29,7 @@ module Hyrax
                     :subject_names, :subject_geo, :subject_time_periods, :notes,
                     :rights_documentation, :sensitive_material, :internal_rights_note,
                     :contact_information, :staff_notes, :system_of_record_ID, :emory_ark,
-                    :visibility]
+                    :visibility, :thumbnail_id]
 
       self.required_fields = [:title, :holding_repository, :creator, :abstract]
 

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
                          :subject_names, :subject_geo, :subject_time_periods, :notes,
                          :rights_documentation, :sensitive_material, :internal_rights_note,
                          :contact_information, :staff_notes, :system_of_record_ID, :emory_ark,
-                         :visibility]
+                         :visibility, :thumbnail_id]
     end
   end
 
@@ -94,7 +94,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
                          :abstract, :primary_language, :finding_aid_link, :institution, :local_call_number, { keywords: [] },
                          { subject_topics: [] }, { subject_names: [] }, { subject_geo: [] }, { subject_time_periods: [] },
                          { notes: [] }, :rights_documentation, :sensitive_material, :internal_rights_note, :contact_information,
-                         { staff_notes: [] }, :system_of_record_ID, { emory_ark: [] }, :visibility,
+                         { staff_notes: [] }, :system_of_record_ID, { emory_ark: [] }, :visibility, :thumbnail_id,
                          { permissions_attributes: [:type, :name, :access, :id, :_destroy] }]
     end
   end


### PR DESCRIPTION
* This commit adds `thumbnail_id` to terms (params) for the collection
form which was missing earlier. We will now be able to edit the
thumbnail for a collection.