### PR TITLE
Adds manifest caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ In order to set up your dev environment for database authentication, you will ne
 Run the test suite with `bin/rails ci`
 
 For our CI we are using CircleCI that we adopted from hyrax project: [Hyrax CircleCI Config](https://github.com/samvera/hyrax/blob/master/.circleci/config.yml)
+
+# Caching manifests with localhost
+
+In a development environment, rake task creates and caches manifests with
+`base_url` as `localhost:3000`.
+
+In order to run the rake task locally and see cached manifests properly,
+please use port 3000 with localhost.

--- a/app/builders/curate_manifest_helper.rb
+++ b/app/builders/curate_manifest_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+class CurateManifestHelper
+  include Rails.application.routes.url_helpers
+  include ActionDispatch::Routing::PolymorphicRoutes
+end

--- a/app/lib/create_manifest.rb
+++ b/app/lib/create_manifest.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'iiif_manifest'
+
+class CreateManifest
+  class << self
+    def process(work_id = nil)
+      if work_id.present?
+        process_work(work_id)
+      else
+        CurateGenericWork.all.each do |work|
+          process_work(work.id)
+        end
+      end
+    end
+
+    private
+
+      def process_work(work_id)
+        solr_doc = ::SolrDocument.find(work_id)
+        date_modified = solr_doc[:date_modified_dtsi] || solr_doc[:system_create_dtsi]
+        key = date_modified.to_datetime.strftime('%Y-%m-%d_%H-%M-%S') + '_' + solr_doc[:id]
+
+        return if File.exist?(Rails.root.join('tmp', key))
+        presenter = Hyrax::CurateGenericWorkPresenter.new(solr_doc, ManifestAbility.new)
+        manifest_hash = ::IIIFManifest::ManifestFactory.new(presenter).to_h
+        persist_manifest(key: key, manifest_hash: manifest_hash)
+      end
+
+      def persist_manifest(key:, manifest_hash:)
+        File.open(Rails.root.join('tmp', key), 'w+') do |f|
+          f.write(manifest_hash.to_json)
+        end
+      end
+  end
+end

--- a/app/models/manifest_ability.rb
+++ b/app/models/manifest_ability.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class ManifestAbility
+  include CanCan::Ability
+
+  def initialize
+    can :read, :all
+  end
+end

--- a/app/presenters/hyrax/curate_generic_work_presenter.rb
+++ b/app/presenters/hyrax/curate_generic_work_presenter.rb
@@ -7,5 +7,25 @@ module Hyrax
     CurateGenericWorkAttributes.instance.attributes.each do |key|
       delegate key.to_sym, to: :solr_document
     end
+
+    # [Hyrax-overwrite] We might not always have a request and a `base_url`,
+    # therfore, we are using our CurateManifestHelper and passing in a hardcoded
+    # host for creation of manifest_url
+
+    def manifest_helper
+      @manifest_helper ||= if request.nil?
+                             CurateManifestHelper.new
+                           else
+                             ManifestHelper.new(request.base_url)
+                           end
+    end
+
+    def manifest_url
+      if request.nil?
+        manifest_helper.polymorphic_url([:manifest, self], host: "http://#{ENV['HOSTNAME'] || 'localhost:3000'}")
+      else
+        manifest_helper.polymorphic_url([:manifest, self])
+      end
+    end
   end
 end

--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+# [Hyrax-overwrite] hardcoding `base_url` on L21 and L36 instead of getting
+# it from the request.
+require 'iiif_manifest'
+
+module Hyrax
+  # This gets mixed into FileSetPresenter in order to create
+  # a canvas on a IIIF manifest
+  module DisplaysImage
+    extend ActiveSupport::Concern
+
+    # Creates a display image only where FileSet is an image.
+    #
+    # @return [IIIFManifest::DisplayImage] the display image required by the manifest builder.
+    def display_image
+      return nil unless ::FileSet.exists?(id) && solr_document.image? && current_ability.can?(:read, id)
+      # @todo this is slow, find a better way (perhaps index iiif url):
+      original_file = ::FileSet.find(id).original_file
+      @request_base_url = request_base_url
+
+      url = Hyrax.config.iiif_image_url_builder.call(
+        original_file.id,
+        @request_base_url,
+        Hyrax.config.iiif_image_size_default
+      )
+      # @see https://github.com/samvera-labs/iiif_manifest
+      IIIFManifest::DisplayImage.new(url,
+                                     width:         640,
+                                     height:        480,
+                                     iiif_endpoint: iiif_endpoint(original_file.id))
+    end
+
+    private
+
+      def request_base_url
+        base_url = if request.nil?
+                     "http://#{ENV['HOSTNAME'] || 'localhost:3000'}"
+                   else
+                     request.base_url
+                   end
+        base_url
+      end
+
+      def iiif_endpoint(file_id)
+        return unless Hyrax.config.iiif_image_server?
+        IIIFManifest::IIIFEndpoint.new(
+          Hyrax.config.iiif_info_url_builder.call(file_id, @request_base_url),
+          profile: Hyrax.config.iiif_image_compliance_level_uri
+        )
+      end
+  end
+end

--- a/lib/tasks/create_manifest.rake
+++ b/lib/tasks/create_manifest.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'iiif_manifest'
+
+namespace :curate do
+  namespace :works do
+    desc "Create manifest for work and save them"
+    task create_manifest: :environment do
+      work = ENV['work']
+      if work.present?
+        CreateManifest.process(work)
+      else
+        CreateManifest.process
+      end
+    end
+  end
+end

--- a/spec/controllers/hyrax/curate_generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/curate_generic_works_controller_spec.rb
@@ -5,7 +5,38 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::CurateGenericWorksController do
-  it "has tests" do
-    skip "Add your tests here"
+  let(:user) { FactoryBot.create(:user) }
+  let(:work) { FactoryBot.create(:public_generic_work, id: '888889') }
+  let(:solr_document) { SolrDocument.new(attributes) }
+  let(:manifest_file) { IO.read(fixture_path + '/manifest_fixture.json') }
+  before { sign_in user }
+  let(:attributes) do
+    { "id" => '888889',
+      "title_tesim" => ['foo', 'bar'],
+      "human_readable_type_tesim" => ["Curate Generic Work"],
+      "has_model_ssim" => ["CurateGenericWork"],
+      "date_created_tesim" => ['an unformatted date'],
+      "date_modified_dtsi" => "2019-11-11T18:20:32Z",
+      "depositor_tesim" => user.uid }
+  end
+  describe "GET #manifest" do
+    it "returns http success" do
+      get :manifest, params: { id: work.id, format: 'json' }
+      expect(response).to have_http_status(:success)
+    end
+
+    context "generates manifest" do
+      before do
+        allow(SolrDocument).to receive(:find).and_return(solr_document)
+      end
+
+      it "saves manifest file" do
+        get :manifest, params: { id: work.id, format: 'json' }
+        expect(response.body).to include(work.id)
+        expect(File).to exist("./tmp/2019-11-11_18-20-32_888889")
+        get :manifest, params: { id: work.id, format: 'json' }
+        expect(File.open("./tmp/2019-11-11_18-20-32_888889").read). to eq manifest_file
+      end
+    end
   end
 end

--- a/spec/fixtures/manifest_fixture.json
+++ b/spec/fixtures/manifest_fixture.json
@@ -1,0 +1,1 @@
+{"@context":"http://iiif.io/api/presentation/2/context.json","@type":"sc:Manifest","@id":"http://test.host/concern/curate_generic_works/888889/manifest","label":"Test title"}

--- a/spec/lib/create_manifest_spec.rb
+++ b/spec/lib/create_manifest_spec.rb
@@ -21,9 +21,11 @@ RSpec.describe CreateManifest, :clean do
   before do
     allow(CurateGenericWork).to receive(:all).and_return([generic_work])
     allow(SolrDocument).to receive(:find).and_return(solr_document)
+    FileUtils.rm_f("./tmp/2019-11-11_18-20-32_888888")
   end
 
   it 'creates manifest and saves to tmp' do
+    expect(File).not_to exist("./tmp/2019-11-11_18-20-32_888888")
     described_class.process
     expect(File).to exist("./tmp/2019-11-11_18-20-32_888888")
   end

--- a/spec/lib/create_manifest_spec.rb
+++ b/spec/lib/create_manifest_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CreateManifest, :clean do
+  let(:generic_work)  { FactoryBot.create(:public_work, id: '888888', title: ['foo']) }
+  let(:solr_document) { SolrDocument.new(attributes) }
+  let(:request) { ENV['HOSTNAME'] = 'example.org' }
+  let(:ability) { instance_double(Ability) }
+  let(:user_key) { 'a_user_key' }
+  let(:attributes) do
+    { "id" => '888888',
+      "title_tesim" => ['foo'],
+      "human_readable_type_tesim" => ["Curate Generic Work"],
+      "has_model_ssim" => ["CurateGenericWork"],
+      "date_created_tesim" => ['an unformatted date'],
+      "date_modified_dtsi" => "2019-11-11T18:20:32Z",
+      "depositor_tesim" => user_key }
+  end
+  let(:presenter) { described_class.new(solr_document, ability, request) }
+
+  before do
+    allow(CurateGenericWork).to receive(:all).and_return([generic_work])
+    allow(SolrDocument).to receive(:find).and_return(solr_document)
+  end
+
+  it 'creates manifest and saves to tmp' do
+    described_class.process
+    expect(File).to exist("./tmp/2019-11-11_18-20-32_888888")
+  end
+end

--- a/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
+++ b/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
@@ -5,7 +5,27 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::CurateGenericWorkPresenter do
-  it "has tests" do
-    skip "Add your tests here"
+  let(:solr_document) { SolrDocument.new(attributes) }
+  let(:request) { instance_double(ActionDispatch::Request) }
+  let(:ability) { instance_double(Ability) }
+  let(:user_key) { 'a_user_key' }
+  let(:attributes) do
+    { "id" => '888888',
+      "title_tesim" => ['foo', 'bar'],
+      "human_readable_type_tesim" => ["Curate Generic Work"],
+      "has_model_ssim" => ["CurateGenericWork"],
+      "date_created_tesim" => ['an unformatted date'],
+      "depositor_tesim" => user_key }
+  end
+  let(:presenter) { described_class.new(solr_document, ability, request) }
+
+  describe '#manifest_url' do
+    subject { presenter.manifest_url }
+    before do
+      allow(request).to receive(:host).and_return 'example.org'
+      allow(request).to receive(:base_url).and_return 'http://example.org'
+    end
+
+    it { is_expected.to eq 'http://example.org/concern/curate_generic_works/888888/manifest' }
   end
 end

--- a/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
+++ b/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
@@ -17,15 +17,33 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
       "date_created_tesim" => ['an unformatted date'],
       "depositor_tesim" => user_key }
   end
-  let(:presenter) { described_class.new(solr_document, ability, request) }
 
   describe '#manifest_url' do
-    subject { presenter.manifest_url }
-    before do
-      allow(request).to receive(:host).and_return 'example.org'
-      allow(request).to receive(:base_url).and_return 'http://example.org'
+    context 'when request is not nil' do
+      subject { presenter.manifest_url }
+      let(:presenter) { described_class.new(solr_document, ability, request) }
+      before do
+        allow(request).to receive(:host).and_return 'example.org'
+        allow(request).to receive(:base_url).and_return 'http://example.org'
+      end
+
+      it { is_expected.to eq 'http://example.org/concern/curate_generic_works/888888/manifest' }
     end
 
-    it { is_expected.to eq 'http://example.org/concern/curate_generic_works/888888/manifest' }
+    context 'when request is nil and HOSTNAME is nil' do
+      subject { presenter.manifest_url }
+      let(:presenter) { described_class.new(solr_document, ability) }
+      before { ENV['HOSTNAME'] = nil }
+
+      it { is_expected.to eq "http://localhost:3000/concern/curate_generic_works/888888/manifest" }
+    end
+
+    context 'when request is nil and HOSTNAME is assigned' do
+      subject { presenter.manifest_url }
+      let(:presenter) { described_class.new(solr_document, ability) }
+      before { ENV['HOSTNAME'] = 'example-curate' }
+
+      it { is_expected.to eq "http://example-curate/concern/curate_generic_works/888888/manifest" }
+    end
   end
 end


### PR DESCRIPTION
* Manifest creation for large book objects times out. This PR implements caching of manifests. If there is a cached manifest for an object, UV will use that, else it'll create a new manifest and cache it for future use.
* There is also a rake task that creates manifests for all the works (or a single work) and caches them.
Rake task: `RAILS_ENV=*env* bundle exec rails curate:works:create_manifest` OR `RAILS_ENV=*env* bundle exec rails curate:works:create_manifest work=*work_id*`