### PR TITLE
Index sort fields for Lux

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,6 +86,7 @@ Metrics/MethodLength:
         - app/importers/modular_importer.rb
         - app/indexers/curate/file_set_indexer.rb
         - app/jobs/characterize_job.rb
+        - app/indexers/curate_generic_work_indexer.rb
 
 Metrics/ModuleLength:
     Exclude:

--- a/app/indexers/curate_generic_work_indexer.rb
+++ b/app/indexers/curate_generic_work_indexer.rb
@@ -25,7 +25,7 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
       solr_doc['human_readable_data_collection_dates_tesim'] = human_readable_data_collection_dates
       solr_doc['human_readable_conference_dates_tesim'] = [human_readable_conference_dates]
       solr_doc['human_readable_copyright_date_tesim'] = [human_readable_copyright_date]
-      solr_doc['title_ssi'] = object.title.first
+      solr_doc['title_ssi'] = sort_title
     end
   end
 
@@ -89,5 +89,10 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
     years = [year_created, year_issued].flatten.compact.uniq.sort
     return nil if years.empty?
     years
+  end
+
+  def sort_title
+    return unless object.title.first
+    object.title.first.gsub(/^(an?|the)\s/i, '')
   end
 end

--- a/app/indexers/curate_generic_work_indexer.rb
+++ b/app/indexers/curate_generic_work_indexer.rb
@@ -25,6 +25,7 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
       solr_doc['human_readable_data_collection_dates_tesim'] = human_readable_data_collection_dates
       solr_doc['human_readable_conference_dates_tesim'] = [human_readable_conference_dates]
       solr_doc['human_readable_copyright_date_tesim'] = [human_readable_copyright_date]
+      solr_doc['title_ssi'] = object.title.first
     end
   end
 

--- a/app/models/curate_generic_work.rb
+++ b/app/models/curate_generic_work.rb
@@ -61,7 +61,7 @@ class CurateGenericWork < ActiveFedora::Base
   end
 
   property :creator, predicate: "http://purl.org/dc/elements/1.1/creator" do |index|
-    index.as :stored_searchable, :facetable, :sortable
+    index.as :stored_searchable, :facetable, :sortable, :stored_sortable
   end
 
   property :data_classifications, predicate: "http://metadata.emory.edu/vocab/cor-terms#dataClassification" do |index|

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -132,4 +132,8 @@ class SolrDocument
   def year_for_lux
     self['year_for_lux_isim']
   end
+
+  def sort_title
+    self['title_ssi']
+  end
 end

--- a/spec/indexers/curate_generic_work_spec.rb
+++ b/spec/indexers/curate_generic_work_spec.rb
@@ -110,13 +110,27 @@ RSpec.describe CurateGenericWorkIndexer do
     let(:attributes) do
       {
         id:      '123',
-        title:   ['A title'],
-        creator: ['A creator']
+        title:   ['Some title'],
+        creator: ['Some creator']
       }
     end
+
     it 'indexes sort fields for title and creator' do
-      expect(solr_document['title_ssi']).to eq 'A title'
-      expect(solr_document['creator_ssi']).to eq 'A creator'
+      expect(solr_document['title_ssi']).to eq 'Some title'
+      expect(solr_document['creator_ssi']).to eq 'Some creator'
+    end
+
+    context 'when title has a leading article' do
+      let(:attributes) do
+        {
+          id:      '123',
+          title:   ['A title']
+        }
+      end
+
+      it 'indexes title sort field without leading articles' do
+        expect(solr_document['title_ssi']).to eq 'title'
+      end
     end
   end
 end

--- a/spec/indexers/curate_generic_work_spec.rb
+++ b/spec/indexers/curate_generic_work_spec.rb
@@ -105,4 +105,18 @@ RSpec.describe CurateGenericWorkIndexer do
       end
     end
   end
+
+  describe 'sort fields' do
+    let(:attributes) do
+      {
+        id:      '123',
+        title:   ['A title'],
+        creator: ['A creator']
+      }
+    end
+    it 'indexes sort fields for title and creator' do
+      expect(solr_document['title_ssi']).to eq 'A title'
+      expect(solr_document['creator_ssi']).to eq 'A creator'
+    end
+  end
 end

--- a/spec/indexers/curate_generic_work_spec.rb
+++ b/spec/indexers/curate_generic_work_spec.rb
@@ -123,8 +123,8 @@ RSpec.describe CurateGenericWorkIndexer do
     context 'when title has a leading article' do
       let(:attributes) do
         {
-          id:      '123',
-          title:   ['A title']
+          id:    '123',
+          title: ['A title']
         }
       end
 


### PR DESCRIPTION
- Sortable fields for `:title` and `:creator` are indexed for Lux
- Addresses [Lux ticket 245](https://github.com/emory-libraries/dlp-lux/issues/245)