### PR TITLE
Fix sortable fields for Lux

### DIFF
--- a/app/indexers/curate_generic_work_indexer.rb
+++ b/app/indexers/curate_generic_work_indexer.rb
@@ -25,7 +25,8 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
       solr_doc['human_readable_data_collection_dates_tesim'] = human_readable_data_collection_dates
       solr_doc['human_readable_conference_dates_tesim'] = [human_readable_conference_dates]
       solr_doc['human_readable_copyright_date_tesim'] = [human_readable_copyright_date]
-      solr_doc['title_ssi'] = sort_title
+      solr_doc['title_ssort'] = sort_title
+      solr_doc['creator_ssort'] = object.creator.first
     end
   end
 

--- a/app/models/curate_generic_work.rb
+++ b/app/models/curate_generic_work.rb
@@ -61,7 +61,7 @@ class CurateGenericWork < ActiveFedora::Base
   end
 
   property :creator, predicate: "http://purl.org/dc/elements/1.1/creator" do |index|
-    index.as :stored_searchable, :facetable, :sortable, :stored_sortable
+    index.as :stored_searchable, :facetable, :sortable
   end
 
   property :data_classifications, predicate: "http://metadata.emory.edu/vocab/cor-terms#dataClassification" do |index|

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -134,6 +134,10 @@ class SolrDocument
   end
 
   def sort_title
-    self['title_ssi']
+    self['title_ssort']
+  end
+
+  def sort_creator
+    self['creator_ssort']
   end
 end

--- a/spec/indexers/curate_generic_work_spec.rb
+++ b/spec/indexers/curate_generic_work_spec.rb
@@ -116,8 +116,8 @@ RSpec.describe CurateGenericWorkIndexer do
     end
 
     it 'indexes sort fields for title and creator' do
-      expect(solr_document['title_ssi']).to eq 'Some title'
-      expect(solr_document['creator_ssi']).to eq 'Some creator'
+      expect(solr_document['title_ssort']).to eq 'Some title'
+      expect(solr_document['creator_ssort']).to eq 'Some creator'
     end
 
     context 'when title has a leading article' do
@@ -129,7 +129,7 @@ RSpec.describe CurateGenericWorkIndexer do
       end
 
       it 'indexes title sort field without leading articles' do
-        expect(solr_document['title_ssi']).to eq 'title'
+        expect(solr_document['title_ssort']).to eq 'title'
       end
     end
   end


### PR DESCRIPTION
- In order for objects in Lux to be sorted case-insensitively by `:title` and `:creator`, those fields must be stored in Solr as `:title_ssort` and `:creator_ssort`, not `:title_ssi` and `:creator_ssi` as implemented in #917