### PR TITLE
Index sort field for date

### DIFF
--- a/app/indexers/curate_generic_work_indexer.rb
+++ b/app/indexers/curate_generic_work_indexer.rb
@@ -27,6 +27,7 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
       solr_doc['human_readable_copyright_date_tesim'] = [human_readable_copyright_date]
       solr_doc['title_ssort'] = sort_title
       solr_doc['creator_ssort'] = object.creator.first
+      solr_doc['year_for_lux_isi'] = sort_year
     end
   end
 
@@ -95,5 +96,9 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
   def sort_title
     return unless object.title.first
     object.title.first.gsub(/^(an?|the)\s/i, '')
+  end
+
+  def sort_year
+    year_for_lux.nil? ? nil : year_for_lux.first
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -140,4 +140,8 @@ class SolrDocument
   def sort_creator
     self['creator_ssort']
   end
+
+  def sort_year
+    self['year_for_lux_isi']
+  end
 end

--- a/spec/indexers/curate_generic_work_spec.rb
+++ b/spec/indexers/curate_generic_work_spec.rb
@@ -109,15 +109,34 @@ RSpec.describe CurateGenericWorkIndexer do
   describe 'sort fields' do
     let(:attributes) do
       {
-        id:      '123',
-        title:   ['Some title'],
-        creator: ['Some creator']
+        id:           '123',
+        title:        ['Some title'],
+        creator:      ['Some creator'],
+        date_created: '1940-10-15',
+        date_issued:  '1941-01-15'
       }
     end
 
     it 'indexes sort fields for title and creator' do
       expect(solr_document['title_ssort']).to eq 'Some title'
       expect(solr_document['creator_ssort']).to eq 'Some creator'
+    end
+
+    it 'indexes sort field for date containing earliest year' do
+      expect(solr_document['year_for_lux_isi']).to eq 1940
+    end
+
+    context 'when year for lux is not indexed' do
+      let(:attributes) do
+        {
+          id:    '123',
+          title: ['Some title']
+        }
+      end
+
+      it 'doesn\'t index a sort field for date' do
+        expect(solr_document['year_for_lux_isi']).to eq nil
+      end
     end
 
     context 'when title has a leading article' do


### PR DESCRIPTION
- In order to sort by date in Lux, a single-valued `:year_for_lux` field is indexed in Solr
- Date sorting will go by an object's earliest year per [Lux ticket 277](https://github.com/emory-libraries/dlp-lux/issues/277)