### PR TITLE
Adds preferred_file method for file_set instance

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -101,7 +101,7 @@ module Hyrax
           actor.revert_content(params[:revision])
         elsif params.key?(:file_set)
           if params[:file_set].key?(:files)
-            actor.update_content(params[:file_set][:files].first, preferred: preferred_file)
+            actor.update_content(params[:file_set][:files].first, preferred: @file_set.preferred_file)
           else
             update_metadata
           end
@@ -206,17 +206,6 @@ module Hyrax
         @if = @file_set.intermediate_file unless @file_set.intermediate_file.nil?
         @et = @file_set.extracted unless @file_set.extracted.nil?
         @tf = @file_set.transcript_file unless @file_set.transcript_file.nil?
-      end
-
-      def preferred_file
-        preferred = if @sf
-                      :service_file
-                    elsif @if
-                      :intermediate_file
-                    else
-                      :preservation_master_file
-                    end
-        preferred
       end
   end
 end

--- a/app/lib/index_file_set.rb
+++ b/app/lib/index_file_set.rb
@@ -27,21 +27,11 @@ class IndexFileSet
       end
 
       def regenerate_derivatives(file_set, csv)
-        preferred_file_uri = preferred_file(file_set)
+        preferred_file_symbol = file_set.preferred_file
+        preferred_file_uri = file_set.send(preferred_file_symbol).uri.to_s
         asset_path = preferred_file_uri[preferred_file_uri.index(file_set.id.to_s)..-1]
         CreateDerivativesJob.perform_later(file_set, asset_path)
         csv << [file_set.id, "Thumbnail_path mismatch in solr_doc", "Queued"]
-      end
-
-      def preferred_file(file_set)
-        preferred = if file_set.service_file.present?
-                      file_set.service_file.uri.to_s
-                    elsif file_set.intermediate_file.present?
-                      file_set.intermediate_file.uri.to_s
-                    else
-                      file_set.preservation_master_file.uri.to_s
-                    end
-        preferred
       end
   end
 end

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -74,6 +74,17 @@ class FileSet < ActiveFedora::Base
     result
   end
 
+  def preferred_file
+    preferred = if service_file.present?
+                  :service_file
+                elsif intermediate_file.present?
+                  :intermediate_file
+                else
+                  :preservation_master_file
+                end
+    preferred
+  end
+
   private
 
     def service

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -75,14 +75,13 @@ class FileSet < ActiveFedora::Base
   end
 
   def preferred_file
-    preferred = if service_file.present?
-                  :service_file
-                elsif intermediate_file.present?
-                  :intermediate_file
-                else
-                  :preservation_master_file
-                end
-    preferred
+    if service_file.present?
+      :service_file
+    elsif intermediate_file.present?
+      :intermediate_file
+    else
+      :preservation_master_file
+    end
   end
 
   private

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -128,4 +128,44 @@ RSpec.describe FileSet, :perform_enqueued, :clean do
       end
     end
   end
+
+  describe "#preferred_file" do
+    let(:file_set) { FactoryBot.create(:file_set) }
+    let(:pmf)      { File.open(fixture_path + '/book_page/0003_preservation_master.tif') }
+    let(:sf)       { File.open(fixture_path + '/book_page/0003_service.jpg') }
+    let(:imf)      { File.open(fixture_path + '/book_page/0003_intermediate.jp2') }
+
+    context 'when service_file is present' do
+      before do
+        Hydra::Works::AddFileToFileSet.call(file_set, pmf, :preservation_master_file)
+        Hydra::Works::AddFileToFileSet.call(file_set, sf, :service_file)
+        Hydra::Works::AddFileToFileSet.call(file_set, imf, :intermediate_file)
+      end
+
+      it 'returns service_file symbol' do
+        expect(file_set.preferred_file).to eq(:service_file)
+      end
+    end
+
+    context 'when service_file is absent but intermediate_file is present' do
+      before do
+        Hydra::Works::AddFileToFileSet.call(file_set, pmf, :preservation_master_file)
+        Hydra::Works::AddFileToFileSet.call(file_set, imf, :intermediate_file)
+      end
+
+      it 'returns intermediate_file symbol' do
+        expect(file_set.preferred_file).to eq(:intermediate_file)
+      end
+    end
+
+    context 'when only the preservation is present' do
+      before do
+        Hydra::Works::AddFileToFileSet.call(file_set, pmf, :preservation_master_file)
+      end
+
+      it 'returns preservation_master_file symbol' do
+        expect(file_set.preferred_file).to eq(:preservation_master_file)
+      end
+    end
+  end
 end


### PR DESCRIPTION
* This commit adds a new file_set instance method `preferred_file`
which returns the preferred_file for the file_set.
* Instances where `preferred_file` logic was being used is replaced
with a call to this new instance method.
* Tests are updated as well.