### PR TITLE
Visibility for Lux

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,4 @@
 # Use local database auth instead of Shibboleth
 export DATABASE_AUTH=true
+PROJECT_NAME=dlp-curate
+SOLR_URL=http://localhost:8983/solr/hydra-development

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ flycheck_*.el
 ## Environment normalization:
 /.bundle
 /vendor/bundle
+.env.development

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -97,6 +97,10 @@ Metrics/PerceivedComplexity:
         - app/importers/curate_record_importer.rb
         - app/forms/hyrax/curate_generic_work_form.rb
 
+RSpec/DescribeClass:
+    Exclude:
+        - 'spec/models/lux_visibility_spec.rb'
+
 RSpec/ExampleLength:
     Exclude:
         - 'spec/**/*'

--- a/config/prepends/custom_visibility.rb
+++ b/config/prepends/custom_visibility.rb
@@ -41,13 +41,13 @@ module CustomVisibility
   def low_res_visibility!
     visibility_will_change! unless visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES
     remove_groups = represented_visibility - [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES]
-    set_read_groups([Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED], remove_groups)
+    set_read_groups([Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC], remove_groups)
   end
 
   def emory_low_visibility!
     visibility_will_change! unless visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMORY_LOW
     remove_groups = represented_visibility - [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMORY_LOW]
-    set_read_groups([Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMORY_LOW], remove_groups)
+    set_read_groups([Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED], remove_groups)
   end
 
   def rose_high_visibility!

--- a/config/prepends/custom_visibility.rb
+++ b/config/prepends/custom_visibility.rb
@@ -41,7 +41,7 @@ module CustomVisibility
   def low_res_visibility!
     visibility_will_change! unless visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES
     remove_groups = represented_visibility - [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES]
-    set_read_groups([Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES], remove_groups)
+    set_read_groups([Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED], remove_groups)
   end
 
   def emory_low_visibility!

--- a/spec/factories/curate_generic_works.rb
+++ b/spec/factories/curate_generic_works.rb
@@ -127,12 +127,21 @@ FactoryBot.define do
       visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     end
 
+    factory :public_low_work do
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES }
+    end
+
     factory :private_work do
       visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
+    # The "Emory High Download" category in the UI is the repurposed "Authenticated" category for registered users
+    factory :emory_high_work do
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+    end
+
     factory :emory_low_work do
-      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES }
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMORY_LOW }
     end
 
     factory :registered_generic_work do

--- a/spec/factories/curate_generic_works.rb
+++ b/spec/factories/curate_generic_works.rb
@@ -131,6 +131,10 @@ FactoryBot.define do
       visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     end
 
+    factory :emory_low_work do
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LOW_RES }
+    end
+
     factory :registered_generic_work do
       read_groups { ["registered"] }
     end

--- a/spec/models/lux_visibility_spec.rb
+++ b/spec/models/lux_visibility_spec.rb
@@ -30,4 +30,15 @@ RSpec.describe "visibility and access restrictions for lux", :clean do
       expect(work.to_solr["read_access_group_ssim"]).to contain_exactly "public"
     end
   end
+
+# This is the badge called "Emory Low Download"
+  context "when an object is marked as Emory Low Download in Curate" do
+    let(:work)       { FactoryBot.build(:emory_low_work) }
+    it "has a Solr field" do
+      actor_stack_work
+      work.reload
+      expect(work.to_solr["edit_access_group_ssim"]).to contain_exactly "admin"
+      expect(work.to_solr["read_access_group_ssim"]).to contain_exactly "registered"
+    end
+  end
 end

--- a/spec/models/lux_visibility_spec.rb
+++ b/spec/models/lux_visibility_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:work CurateGenericWork`
+require 'rails_helper'
+
+RSpec.describe "visibility and access restrictions for lux", :clean do
+  let(:ability)    { ::Ability.new(FactoryBot.create(:user)) }
+  let(:attributes) { {} }
+  let(:env)        { Hyrax::Actors::Environment.new(work, ability, attributes) }
+  let(:actor_stack_work) do
+    Hyrax::CurationConcern.actor.create(env)
+  end
+
+  context "when an object is marked as private in Curate" do
+    let(:work)       { FactoryBot.build(:work) }
+    it "has a Solr " do
+      actor_stack_work
+      work.reload
+      expect(work.to_solr["edit_access_group_ssim"]).to contain_exactly "admin"
+    end
+  end
+
+  context "when an object is marked as Public in Curate" do
+    let(:work)       { FactoryBot.build(:public_work) }
+    it "has a Solr field" do
+      actor_stack_work
+      work.reload
+      expect(work.to_solr["edit_access_group_ssim"]).to contain_exactly "admin"
+      expect(work.to_solr["read_access_group_ssim"]).to contain_exactly "public"
+    end
+  end
+end

--- a/spec/models/lux_visibility_spec.rb
+++ b/spec/models/lux_visibility_spec.rb
@@ -12,18 +12,20 @@ RSpec.describe "visibility and access restrictions for lux", :clean do
     Hyrax::CurationConcern.actor.create(env)
   end
 
-  context "when an object is marked as private in Curate" do
-    let(:work)       { FactoryBot.build(:work) }
-    it "has a Solr " do
+  context "when an object is marked as Private in Curate" do
+    let(:work) { FactoryBot.build(:work) }
+    it "does not have a read access group, because it should not be visible in Lux" do
       actor_stack_work
       work.reload
       expect(work.to_solr["edit_access_group_ssim"]).to contain_exactly "admin"
+      expect(work.to_solr["read_access_group_ssim"]).to eq nil
     end
   end
 
+  # This is the badge called "Public" in the UI
   context "when an object is marked as Public in Curate" do
-    let(:work)       { FactoryBot.build(:public_work) }
-    it "has a Solr field" do
+    let(:work) { FactoryBot.build(:public_work) }
+    it "is visible to unauthenticated users in Lux" do
       actor_stack_work
       work.reload
       expect(work.to_solr["edit_access_group_ssim"]).to contain_exactly "admin"
@@ -31,10 +33,32 @@ RSpec.describe "visibility and access restrictions for lux", :clean do
     end
   end
 
-# This is the badge called "Emory Low Download"
+  # This is the badge called "Public Low View" in the UI
+  context "when an object is marked as Public Low View in Curate" do
+    let(:work) { FactoryBot.build(:public_low_work) }
+    it "is visible to unauthenticated users in Lux" do
+      actor_stack_work
+      work.reload
+      expect(work.to_solr["edit_access_group_ssim"]).to contain_exactly "admin"
+      expect(work.to_solr["read_access_group_ssim"]).to contain_exactly "public"
+    end
+  end
+
+  # This is the badge called "Emory Low Download" in the UI
   context "when an object is marked as Emory Low Download in Curate" do
-    let(:work)       { FactoryBot.build(:emory_low_work) }
-    it "has a Solr field" do
+    let(:work) { FactoryBot.build(:emory_low_work) }
+    it "is visible to registered users in Lux" do
+      actor_stack_work
+      work.reload
+      expect(work.to_solr["edit_access_group_ssim"]).to contain_exactly "admin"
+      expect(work.to_solr["read_access_group_ssim"]).to contain_exactly "registered"
+    end
+  end
+
+  # The "Emory High Download" category in the UI is the repurposed "Authenticated" category for registered users
+  context "when an object is marked as Emory High Download in Curate" do
+    let(:work) { FactoryBot.build(:emory_high_work) }
+    it "is visible to registered users in Lux" do
       actor_stack_work
       work.reload
       expect(work.to_solr["edit_access_group_ssim"]).to contain_exactly "admin"


### PR DESCRIPTION
 - Registered users should see Emory Low and Emory High in Lux
 - Unauthenticated users should see Public and Public Low objects in Lux

Connected to [#289 in Lux](https://github.com/emory-libraries/dlp-lux/issues/289)
