### PR TITLE
Index child metadata for hierarchical objects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,123 +1,123 @@
 inherit_gem:
-  bixby: bixby_default.yml
+    bixby: bixby_default.yml
 
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
-  Exclude:
-    - "bin/**/*"
-    - "db/**/*"
-    - "tmp/**/*"
-    - "vendor/**/*"
-    - "node_modules/**/*"
-    - lib/tasks/sample_data.rake
+    TargetRubyVersion: 2.5
+    Exclude:
+        - "bin/**/*"
+        - "db/**/*"
+        - "tmp/**/*"
+        - "vendor/**/*"
+        - "node_modules/**/*"
+        - lib/tasks/sample_data.rake
 
 Layout/AlignHash:
-  EnforcedColonStyle: table
+    EnforcedColonStyle: table
 
 RSpec/MessageSpies:
-  EnforcedStyle: receive
+    EnforcedStyle: receive
 
 Lint/NonLocalExitFromIterator:
-  Exclude:
-    - app/importers/collection_permission_ensurer.rb
+    Exclude:
+        - app/importers/collection_permission_ensurer.rb
 
 Metrics/AbcSize:
-  Exclude:
-    - app/importers/modular_importer.rb
-    - spec/system/import_langmuir_from_csv_spec.rb
-    - app/importers/curate_collection_importer.rb
-    - app/importers/curate_record_importer.rb
-    - app/lib/metadata_details.rb
-    - app/indexers/curate/file_set_indexer.rb
-    - app/importers/preservation_workflow_importer.rb
+    Exclude:
+        - app/importers/modular_importer.rb
+        - spec/system/import_langmuir_from_csv_spec.rb
+        - app/importers/curate_collection_importer.rb
+        - app/importers/curate_record_importer.rb
+        - app/lib/metadata_details.rb
+        - app/indexers/curate/file_set_indexer.rb
+        - app/importers/preservation_workflow_importer.rb
 
 Metrics/BlockLength:
-  Exclude:
-    - "spec/**/*"
-    - "config/routes.rb"
-    - "config/initializers/simple_form_bootstrap.rb"
-    - "app/controllers/catalog_controller.rb"
-    - "config/initializers/hyrax.rb"
-    - app/importers/curate_collection_importer.rb
-    - lib/tasks/curate_collections.rake
-    - lib/tasks/curate_books.rake
-    - config/initializers/characterization_service.rb
-    - config/initializers/job_io_wrapper.rb
-    - lib/tasks/derivatives.rake
+    Exclude:
+        - "spec/**/*"
+        - "config/routes.rb"
+        - "config/initializers/simple_form_bootstrap.rb"
+        - "app/controllers/catalog_controller.rb"
+        - "config/initializers/hyrax.rb"
+        - app/importers/curate_collection_importer.rb
+        - lib/tasks/curate_collections.rake
+        - lib/tasks/curate_books.rake
+        - config/initializers/characterization_service.rb
+        - config/initializers/job_io_wrapper.rb
+        - lib/tasks/derivatives.rake
 
 Metrics/ClassLength:
-  Exclude:
-    - "spec/**/*"
-    - "app/models/curate_generic_work.rb"
-    - "app/controllers/catalog_controller.rb"
-    - "app/actors/hyrax/actors/file_set_actor.rb"
-    - "app/forms/hyrax/forms/collection_form.rb"
-    - app/uploaders/zizia/csv_manifest_validator.rb
-    - app/presenters/hyrax/collection_presenter.rb
-    - app/importers/curate_mapper.rb
-    - app/importers/curate_record_importer.rb
-    - app/models/solr_document.rb
+    Exclude:
+        - "spec/**/*"
+        - "app/models/curate_generic_work.rb"
+        - "app/controllers/catalog_controller.rb"
+        - "app/actors/hyrax/actors/file_set_actor.rb"
+        - "app/forms/hyrax/forms/collection_form.rb"
+        - app/uploaders/zizia/csv_manifest_validator.rb
+        - app/presenters/hyrax/collection_presenter.rb
+        - app/importers/curate_mapper.rb
+        - app/importers/curate_record_importer.rb
+        - app/models/solr_document.rb
 
 Metrics/CyclomaticComplexity:
-  Exclude:
-    - app/importers/curate_record_importer.rb
-    - config/prepends/custom_visibility.rb
-    - config/initializers/file_actor.rb
-    - app/indexers/curate/file_set_indexer.rb
+    Exclude:
+        - app/importers/curate_record_importer.rb
+        - config/prepends/custom_visibility.rb
+        - config/initializers/file_actor.rb
+        - app/indexers/curate/file_set_indexer.rb
 
 Metrics/LineLength:
-  Exclude:
-    - spec/importers/curate_mapper_spec.rb
-    - app/importers/curate_record_importer.rb
+    Exclude:
+        - spec/importers/curate_mapper_spec.rb
+        - app/importers/curate_record_importer.rb
 
 Metrics/MethodLength:
-  Exclude:
-    - app/uploaders/zizia/csv_manifest_validator.rb
-    - app/importers/curate_collection_importer.rb
-    - app/presenters/hyrax/curate_collection_presenter.rb
-    - app/presenters/hyrax/collection_presenter.rb
-    - app/importers/curate_mapper.rb
-    - app/forms/hyrax/curate_generic_work_form.rb
-    - app/importers/curate_record_importer.rb
-    - config/prepends/custom_visibility.rb
-    - app/controllers/hyrax/file_sets_controller.rb
-    - app/jobs/create_work_job.rb
-    - app/importers/modular_importer.rb
-    - app/indexers/curate/file_set_indexer.rb
-    - app/jobs/characterize_job.rb
-    - app/indexers/curate_generic_work_indexer.rb
+    Exclude:
+        - app/uploaders/zizia/csv_manifest_validator.rb
+        - app/importers/curate_collection_importer.rb
+        - app/presenters/hyrax/curate_collection_presenter.rb
+        - app/presenters/hyrax/collection_presenter.rb
+        - app/importers/curate_mapper.rb
+        - app/forms/hyrax/curate_generic_work_form.rb
+        - app/importers/curate_record_importer.rb
+        - config/prepends/custom_visibility.rb
+        - app/controllers/hyrax/file_sets_controller.rb
+        - app/jobs/create_work_job.rb
+        - app/importers/modular_importer.rb
+        - app/indexers/curate/file_set_indexer.rb
+        - app/jobs/characterize_job.rb
+        - app/indexers/curate_generic_work_indexer.rb
 
 Metrics/ModuleLength:
-  Exclude:
-    - app/lib/metadata_definitions.rb
+    Exclude:
+        - app/lib/metadata_definitions.rb
 
 Metrics/PerceivedComplexity:
-  Exclude:
-    - app/importers/curate_record_importer.rb
-    - app/forms/hyrax/curate_generic_work_form.rb
+    Exclude:
+        - app/importers/curate_record_importer.rb
+        - app/forms/hyrax/curate_generic_work_form.rb
 
 RSpec/ExampleLength:
-  Exclude:
-    - "spec/**/*"
+    Exclude:
+        - "spec/**/*"
 
 RSpec/NestedGroups:
-  Exclude:
-    - "spec/controllers/hyrax/downloads_controller_spec.rb"
-    - "spec/controllers/hyrax/file_sets_controller_spec.rb"
+    Exclude:
+        - "spec/controllers/hyrax/downloads_controller_spec.rb"
+        - "spec/controllers/hyrax/file_sets_controller_spec.rb"
 
 RSpec/InstanceVariable:
-  Exclude:
-    - "spec/services/characterization_service_spec.rb"
+    Exclude:
+        - "spec/services/characterization_service_spec.rb"
 
 RSpec/MessageChain:
-  Exclude:
-    - "spec/services/characterization_service_spec.rb"
-    - "spec/actors/hyrax/actors/file_actor_spec.rb"
-    - "spec/system/show_file_spec.rb"
-    - "spec/jobs/file_set_clean_up_job_spec.rb"
+    Exclude:
+        - "spec/services/characterization_service_spec.rb"
+        - "spec/actors/hyrax/actors/file_actor_spec.rb"
+        - "spec/system/show_file_spec.rb"
+        - "spec/jobs/file_set_clean_up_job_spec.rb"
 
 RSpec/AnyInstance:
-  Exclude:
-    - "spec/models/job_io_wrapper_spec.rb"
+    Exclude:
+        - "spec/models/job_io_wrapper_spec.rb"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,11 +6,11 @@ inherit_from: .rubocop_todo.yml
 AllCops:
     TargetRubyVersion: 2.5
     Exclude:
-        - "bin/**/*"
-        - "db/**/*"
-        - "tmp/**/*"
-        - "vendor/**/*"
-        - "node_modules/**/*"
+        - 'bin/**/*'
+        - 'db/**/*'
+        - 'tmp/**/*'
+        - 'vendor/**/*'
+        - 'node_modules/**/*'
         - lib/tasks/sample_data.rake
 
 Layout/AlignHash:
@@ -35,11 +35,11 @@ Metrics/AbcSize:
 
 Metrics/BlockLength:
     Exclude:
-        - "spec/**/*"
-        - "config/routes.rb"
-        - "config/initializers/simple_form_bootstrap.rb"
-        - "app/controllers/catalog_controller.rb"
-        - "config/initializers/hyrax.rb"
+        - 'spec/**/*'
+        - 'config/routes.rb'
+        - 'config/initializers/simple_form_bootstrap.rb'
+        - 'app/controllers/catalog_controller.rb'
+        - 'config/initializers/hyrax.rb'
         - app/importers/curate_collection_importer.rb
         - lib/tasks/curate_collections.rake
         - lib/tasks/curate_books.rake
@@ -49,11 +49,11 @@ Metrics/BlockLength:
 
 Metrics/ClassLength:
     Exclude:
-        - "spec/**/*"
-        - "app/models/curate_generic_work.rb"
-        - "app/controllers/catalog_controller.rb"
-        - "app/actors/hyrax/actors/file_set_actor.rb"
-        - "app/forms/hyrax/forms/collection_form.rb"
+        - 'spec/**/*'
+        - 'app/models/curate_generic_work.rb'
+        - 'app/controllers/catalog_controller.rb'
+        - 'app/actors/hyrax/actors/file_set_actor.rb'
+        - 'app/forms/hyrax/forms/collection_form.rb'
         - app/uploaders/zizia/csv_manifest_validator.rb
         - app/presenters/hyrax/collection_presenter.rb
         - app/importers/curate_mapper.rb
@@ -100,24 +100,24 @@ Metrics/PerceivedComplexity:
 
 RSpec/ExampleLength:
     Exclude:
-        - "spec/**/*"
+        - 'spec/**/*'
 
 RSpec/NestedGroups:
     Exclude:
-        - "spec/controllers/hyrax/downloads_controller_spec.rb"
-        - "spec/controllers/hyrax/file_sets_controller_spec.rb"
+        - 'spec/controllers/hyrax/downloads_controller_spec.rb'
+        - 'spec/controllers/hyrax/file_sets_controller_spec.rb'
 
 RSpec/InstanceVariable:
     Exclude:
-        - "spec/services/characterization_service_spec.rb"
+        - 'spec/services/characterization_service_spec.rb'
 
 RSpec/MessageChain:
     Exclude:
-        - "spec/services/characterization_service_spec.rb"
-        - "spec/actors/hyrax/actors/file_actor_spec.rb"
-        - "spec/system/show_file_spec.rb"
-        - "spec/jobs/file_set_clean_up_job_spec.rb"
+        - 'spec/services/characterization_service_spec.rb'
+        - 'spec/actors/hyrax/actors/file_actor_spec.rb'
+        - 'spec/system/show_file_spec.rb'
+        - 'spec/jobs/file_set_clean_up_job_spec.rb'
 
 RSpec/AnyInstance:
     Exclude:
-        - "spec/models/job_io_wrapper_spec.rb"
+        - 'spec/models/job_io_wrapper_spec.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,122 +1,123 @@
 inherit_gem:
-    bixby: bixby_default.yml
+  bixby: bixby_default.yml
 
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-    TargetRubyVersion: 2.5
-    Exclude:
-        - 'bin/**/*'
-        - 'db/**/*'
-        - 'tmp/**/*'
-        - 'vendor/**/*'
-        - 'node_modules/**/*'
-        - lib/tasks/sample_data.rake
+  TargetRubyVersion: 2.5
+  Exclude:
+    - "bin/**/*"
+    - "db/**/*"
+    - "tmp/**/*"
+    - "vendor/**/*"
+    - "node_modules/**/*"
+    - lib/tasks/sample_data.rake
 
 Layout/AlignHash:
-    EnforcedColonStyle: table
+  EnforcedColonStyle: table
 
 RSpec/MessageSpies:
-    EnforcedStyle: receive
+  EnforcedStyle: receive
 
 Lint/NonLocalExitFromIterator:
-    Exclude:
-        - app/importers/collection_permission_ensurer.rb
+  Exclude:
+    - app/importers/collection_permission_ensurer.rb
 
 Metrics/AbcSize:
-    Exclude:
-        - app/importers/modular_importer.rb
-        - spec/system/import_langmuir_from_csv_spec.rb
-        - app/importers/curate_collection_importer.rb
-        - app/importers/curate_record_importer.rb
-        - app/lib/metadata_details.rb
-        - app/indexers/curate/file_set_indexer.rb
-        - app/importers/preservation_workflow_importer.rb
+  Exclude:
+    - app/importers/modular_importer.rb
+    - spec/system/import_langmuir_from_csv_spec.rb
+    - app/importers/curate_collection_importer.rb
+    - app/importers/curate_record_importer.rb
+    - app/lib/metadata_details.rb
+    - app/indexers/curate/file_set_indexer.rb
+    - app/importers/preservation_workflow_importer.rb
 
 Metrics/BlockLength:
-    Exclude:
-        - 'spec/**/*'
-        - 'config/routes.rb'
-        - 'config/initializers/simple_form_bootstrap.rb'
-        - 'app/controllers/catalog_controller.rb'
-        - 'config/initializers/hyrax.rb'
-        - app/importers/curate_collection_importer.rb
-        - lib/tasks/curate_collections.rake
-        - lib/tasks/curate_books.rake
-        - config/initializers/characterization_service.rb
-        - config/initializers/job_io_wrapper.rb
-        - lib/tasks/derivatives.rake
+  Exclude:
+    - "spec/**/*"
+    - "config/routes.rb"
+    - "config/initializers/simple_form_bootstrap.rb"
+    - "app/controllers/catalog_controller.rb"
+    - "config/initializers/hyrax.rb"
+    - app/importers/curate_collection_importer.rb
+    - lib/tasks/curate_collections.rake
+    - lib/tasks/curate_books.rake
+    - config/initializers/characterization_service.rb
+    - config/initializers/job_io_wrapper.rb
+    - lib/tasks/derivatives.rake
 
 Metrics/ClassLength:
-    Exclude:
-        - 'spec/**/*'
-        - 'app/models/curate_generic_work.rb'
-        - 'app/controllers/catalog_controller.rb'
-        - 'app/actors/hyrax/actors/file_set_actor.rb'
-        - 'app/forms/hyrax/forms/collection_form.rb'
-        - app/uploaders/zizia/csv_manifest_validator.rb
-        - app/presenters/hyrax/collection_presenter.rb
-        - app/importers/curate_mapper.rb
-        - app/importers/curate_record_importer.rb
+  Exclude:
+    - "spec/**/*"
+    - "app/models/curate_generic_work.rb"
+    - "app/controllers/catalog_controller.rb"
+    - "app/actors/hyrax/actors/file_set_actor.rb"
+    - "app/forms/hyrax/forms/collection_form.rb"
+    - app/uploaders/zizia/csv_manifest_validator.rb
+    - app/presenters/hyrax/collection_presenter.rb
+    - app/importers/curate_mapper.rb
+    - app/importers/curate_record_importer.rb
+    - app/models/solr_document.rb
 
 Metrics/CyclomaticComplexity:
-    Exclude:
-        - app/importers/curate_record_importer.rb
-        - config/prepends/custom_visibility.rb
-        - config/initializers/file_actor.rb
-        - app/indexers/curate/file_set_indexer.rb
+  Exclude:
+    - app/importers/curate_record_importer.rb
+    - config/prepends/custom_visibility.rb
+    - config/initializers/file_actor.rb
+    - app/indexers/curate/file_set_indexer.rb
 
 Metrics/LineLength:
-    Exclude:
-        - spec/importers/curate_mapper_spec.rb
-        - app/importers/curate_record_importer.rb
+  Exclude:
+    - spec/importers/curate_mapper_spec.rb
+    - app/importers/curate_record_importer.rb
 
 Metrics/MethodLength:
-    Exclude:
-        - app/uploaders/zizia/csv_manifest_validator.rb
-        - app/importers/curate_collection_importer.rb
-        - app/presenters/hyrax/curate_collection_presenter.rb
-        - app/presenters/hyrax/collection_presenter.rb
-        - app/importers/curate_mapper.rb
-        - app/forms/hyrax/curate_generic_work_form.rb
-        - app/importers/curate_record_importer.rb
-        - config/prepends/custom_visibility.rb
-        - app/controllers/hyrax/file_sets_controller.rb
-        - app/jobs/create_work_job.rb
-        - app/importers/modular_importer.rb
-        - app/indexers/curate/file_set_indexer.rb
-        - app/jobs/characterize_job.rb
-        - app/indexers/curate_generic_work_indexer.rb
+  Exclude:
+    - app/uploaders/zizia/csv_manifest_validator.rb
+    - app/importers/curate_collection_importer.rb
+    - app/presenters/hyrax/curate_collection_presenter.rb
+    - app/presenters/hyrax/collection_presenter.rb
+    - app/importers/curate_mapper.rb
+    - app/forms/hyrax/curate_generic_work_form.rb
+    - app/importers/curate_record_importer.rb
+    - config/prepends/custom_visibility.rb
+    - app/controllers/hyrax/file_sets_controller.rb
+    - app/jobs/create_work_job.rb
+    - app/importers/modular_importer.rb
+    - app/indexers/curate/file_set_indexer.rb
+    - app/jobs/characterize_job.rb
+    - app/indexers/curate_generic_work_indexer.rb
 
 Metrics/ModuleLength:
-    Exclude:
-        - app/lib/metadata_definitions.rb
+  Exclude:
+    - app/lib/metadata_definitions.rb
 
 Metrics/PerceivedComplexity:
-    Exclude:
-        - app/importers/curate_record_importer.rb
-        - app/forms/hyrax/curate_generic_work_form.rb
+  Exclude:
+    - app/importers/curate_record_importer.rb
+    - app/forms/hyrax/curate_generic_work_form.rb
 
 RSpec/ExampleLength:
-    Exclude:
-        - 'spec/**/*'
+  Exclude:
+    - "spec/**/*"
 
 RSpec/NestedGroups:
-    Exclude:
-        - 'spec/controllers/hyrax/downloads_controller_spec.rb'
-        - 'spec/controllers/hyrax/file_sets_controller_spec.rb'
+  Exclude:
+    - "spec/controllers/hyrax/downloads_controller_spec.rb"
+    - "spec/controllers/hyrax/file_sets_controller_spec.rb"
 
 RSpec/InstanceVariable:
-    Exclude:
-        - 'spec/services/characterization_service_spec.rb'
+  Exclude:
+    - "spec/services/characterization_service_spec.rb"
 
 RSpec/MessageChain:
-    Exclude:
-        - 'spec/services/characterization_service_spec.rb'
-        - 'spec/actors/hyrax/actors/file_actor_spec.rb'
-        - 'spec/system/show_file_spec.rb'
-        - 'spec/jobs/file_set_clean_up_job_spec.rb'
+  Exclude:
+    - "spec/services/characterization_service_spec.rb"
+    - "spec/actors/hyrax/actors/file_actor_spec.rb"
+    - "spec/system/show_file_spec.rb"
+    - "spec/jobs/file_set_clean_up_job_spec.rb"
 
 RSpec/AnyInstance:
-    Exclude:
-        - 'spec/models/job_io_wrapper_spec.rb'
+  Exclude:
+    - "spec/models/job_io_wrapper_spec.rb"

--- a/app/indexers/curate_generic_work_indexer.rb
+++ b/app/indexers/curate_generic_work_indexer.rb
@@ -28,6 +28,8 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
       solr_doc['title_ssort'] = sort_title
       solr_doc['creator_ssort'] = object.creator.first
       solr_doc['year_for_lux_isi'] = sort_year
+      solr_doc['child_work_ids_tesim'] = child_work_ids
+      solr_doc['child_work_titles_tesim'] = child_work_titles
     end
   end
 
@@ -100,5 +102,17 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
 
   def sort_year
     year_for_lux.nil? ? nil : year_for_lux.first
+  end
+
+  def child_work_ids
+    ids = object.child_works.map(&:id)
+    return nil if ids.empty?
+    ids
+  end
+
+  def child_work_titles
+    titles = object.child_works.map(&:title)
+    return nil if titles.empty?
+    titles
   end
 end

--- a/app/indexers/curate_generic_work_indexer.rb
+++ b/app/indexers/curate_generic_work_indexer.rb
@@ -28,8 +28,7 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
       solr_doc['title_ssort'] = sort_title
       solr_doc['creator_ssort'] = object.creator.first
       solr_doc['year_for_lux_isi'] = sort_year
-      solr_doc['child_work_ids_tesim'] = child_work_ids
-      solr_doc['child_work_titles_tesim'] = child_work_titles
+      solr_doc['child_works_for_lux_tesim'] = child_works_for_lux
     end
   end
 
@@ -104,15 +103,11 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
     year_for_lux.nil? ? nil : year_for_lux.first
   end
 
-  def child_work_ids
-    ids = object.child_works.map(&:id)
-    return nil if ids.empty?
-    ids
-  end
-
-  def child_work_titles
-    titles = object.child_works.map(&:title)
-    return nil if titles.empty?
-    titles
+  def child_works_for_lux
+    children = object.child_works
+    return nil if children.empty?
+    ids_and_titles = children.map { |c| [c.id, c.title] }
+    # Sort child works' id and title pairs alphabetically by title
+    ids_and_titles.sort_by { |w| w[1][0] }
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -145,11 +145,7 @@ class SolrDocument
     self['year_for_lux_isi']
   end
 
-  def child_work_ids
-    self['child_work_ids_tesim']
-  end
-
-  def child_work_titles
-    self['child_work_titles_tesim']
+  def child_works_for_lux
+    self['child_works_for_lux_tesim']
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -144,4 +144,12 @@ class SolrDocument
   def sort_year
     self['year_for_lux_isi']
   end
+
+  def child_work_ids
+    self['child_ids_tesim']
+  end
+
+  def child_work_titles
+    self['child_titles_tesim']
+  end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -146,10 +146,10 @@ class SolrDocument
   end
 
   def child_work_ids
-    self['child_ids_tesim']
+    self['child_work_ids_tesim']
   end
 
   def child_work_titles
-    self['child_titles_tesim']
+    self['child_work_titles_tesim']
   end
 end

--- a/spec/models/curate_generic_work_spec.rb
+++ b/spec/models/curate_generic_work_spec.rb
@@ -1418,10 +1418,10 @@ RSpec.describe CurateGenericWork do
       # Check copyright_date_tesim also saved as human_readable_copyright_date_tesim
       expect(solr_doc['human_readable_copyright_date_tesim']).to eq ['between 1942 and 1944']
 
-      # Check that no ids for CurateGenericWorks are indexed for simple objects
+      # Check that ids for child CurateGenericWorks are not indexed for simple objects
       expect(solr_doc['child_work_ids_tesim']).to eq nil
 
-      # Check that no titles for CurateGenericWorks are indexed for simple objects
+      # Check that titles for child CurateGenericWorks are not indexed for simple objects
       expect(solr_doc['child_work_titles_tesim']).to eq nil
     end
   end

--- a/spec/models/curate_generic_work_spec.rb
+++ b/spec/models/curate_generic_work_spec.rb
@@ -44,9 +44,8 @@ RSpec.describe CurateGenericWork do
       expect(work1.assign_id).to match(/\d{3}[A-z0-9]{7}-cor/)
     end
 
-    it "saves ids and titles of child works in Solr document" do
-      expect(solr_doc['child_work_ids_tesim']).to contain_exactly("wk3", "wk2")
-      expect(solr_doc['child_work_titles_tesim']).to contain_exactly(["Work 3"], ["Work 2"])
+    it "saves ids and titles of child works in Solr document in alphabetical order by title" do
+      expect(solr_doc['child_works_for_lux_tesim']).to eq [["wk2", ["Work 2"]], ["wk3", ["Work 3"]]]
     end
   end
 
@@ -1418,11 +1417,8 @@ RSpec.describe CurateGenericWork do
       # Check copyright_date_tesim also saved as human_readable_copyright_date_tesim
       expect(solr_doc['human_readable_copyright_date_tesim']).to eq ['between 1942 and 1944']
 
-      # Check that ids for child CurateGenericWorks are not indexed for simple objects
-      expect(solr_doc['child_work_ids_tesim']).to eq nil
-
-      # Check that titles for child CurateGenericWorks are not indexed for simple objects
-      expect(solr_doc['child_work_titles_tesim']).to eq nil
+      # Check that ids and titles for child CurateGenericWorks are not indexed for simple objects
+      expect(solr_doc['child_works_tesim']).to eq nil
     end
   end
 

--- a/spec/models/curate_generic_work_spec.rb
+++ b/spec/models/curate_generic_work_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe CurateGenericWork do
     let(:work3)       { FactoryBot.build(:work, id: 'wk3', title: ['Work 3']) }
     let(:fileset1)    { FactoryBot.build(:file_set, id: 'fs1', title: ['Fileset 1']) }
     let(:fileset2)    { FactoryBot.build(:file_set, id: 'fs2', title: ['Fileset 2']) }
+    let(:solr_doc)    { work1.to_solr }
 
     before do
       work1.members = [work2, work3, fileset1, fileset2]
@@ -41,6 +42,11 @@ RSpec.describe CurateGenericWork do
 
     it "checks assign id" do
       expect(work1.assign_id).to match(/\d{3}[A-z0-9]{7}-cor/)
+    end
+
+    it "saves ids and titles of child works in Solr document" do
+      expect(solr_doc['child_work_ids_tesim']).to contain_exactly("wk3", "wk2")
+      expect(solr_doc['child_work_titles_tesim']).to contain_exactly(["Work 3"], ["Work 2"])
     end
   end
 
@@ -1411,6 +1417,12 @@ RSpec.describe CurateGenericWork do
 
       # Check copyright_date_tesim also saved as human_readable_copyright_date_tesim
       expect(solr_doc['human_readable_copyright_date_tesim']).to eq ['between 1942 and 1944']
+
+      # Check that no ids for CurateGenericWorks are indexed for simple objects
+      expect(solr_doc['child_work_ids_tesim']).to eq nil
+
+      # Check that no titles for CurateGenericWorks are indexed for simple objects
+      expect(solr_doc['child_work_titles_tesim']).to eq nil
     end
   end
 

--- a/spec/models/curate_generic_work_spec.rb
+++ b/spec/models/curate_generic_work_spec.rb
@@ -1418,7 +1418,7 @@ RSpec.describe CurateGenericWork do
       expect(solr_doc['human_readable_copyright_date_tesim']).to eq ['between 1942 and 1944']
 
       # Check that ids and titles for child CurateGenericWorks are not indexed for simple objects
-      expect(solr_doc['child_works_tesim']).to eq nil
+      expect(solr_doc['child_works_for_lux_tesim']).to eq nil
     end
   end
 


### PR DESCRIPTION
- Solr documents for hierarchical objects (i.e., CurateGenericWorks with one or more CurateGenericWorks as children) now index the IDs and titles of child objects as pairs in the `:child_works_for_lux` field.