### PR TITLE
Removes keyword arg from update_content

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -101,7 +101,7 @@ module Hyrax
           actor.revert_content(params[:revision])
         elsif params.key?(:file_set)
           if params[:file_set].key?(:files)
-            actor.update_content(params[:file_set][:files].first, preferred: @file_set.preferred_file)
+            actor.update_content(params[:file_set][:files].first, @file_set.preferred_file)
           else
             update_metadata
           end


### PR DESCRIPTION
* This commit removes preferred keyword from update_content method call
in file_sets_controller. The preferred file symbol is being received as a
normal arg in file_set_actor's update_content method and we were previously
passing this a hashed key-value pair argument from the file_sets_controller update 
method. By removing the key `preferred:` from the file_sets_controller, we pass this
as a normal argument instead of the requirement of a keyword.