### PR TITLE
IIIF controller must proxy info.json requests

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -3,12 +3,25 @@
 class IiifController < ApplicationController
   def show
     @iiif_url = iiif_url
+    Rails.logger.info("Trying to proxy image from #{@iiif_url}")
     send_data HTTP.get(@iiif_url).body, type: 'image/jpeg', x_sendfile: true, disposition: 'inline'
+  end
+
+  def info
+    @iiif_url = "#{ENV['PROXIED_IIIF_SERVER_URL']}#{trailing_slash_fix}#{identifier}/info.json"
+    Rails.logger.info("Trying to proxy info from #{@iiif_url}")
+    send_data HTTP.get(@iiif_url).body, type: 'application/json', x_sendfile: true, disposition: 'inline'
   end
 
   def iiif_url
     raise "PROXIED_IIIF_SERVER_URL must be set" unless ENV['PROXIED_IIIF_SERVER_URL']
-    "#{ENV['PROXIED_IIIF_SERVER_URL']}/#{identifier}/#{region}/#{size}/#{rotation}/#{quality}.#{format}"
+    "#{ENV['PROXIED_IIIF_SERVER_URL']}#{trailing_slash_fix}#{identifier}/#{region}/#{size}/#{rotation}/#{quality}.#{format}"
+  end
+
+  # IIIF URLS really do not like extra slashes. Ensure that we only add a slash after the
+  # PROXIED_IIIF_SERVER_URL value if it is needed
+  def trailing_slash_fix
+    '/' unless ENV['PROXIED_IIIF_SERVER_URL'].last == '/'
   end
 
   def identifier

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
+  get '/iiif/2/:identifier/info.json', to: 'iiif#info'
   get '/iiif/2/:identifier/:region/:size/:rotation/:quality.:format', to: 'iiif#show'
 
   mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -29,6 +29,31 @@ RSpec.describe IiifController, type: :controller do
     end
   end
 
+  describe "a request for info.json" do
+    let(:params) do
+      {
+        identifier: identifier,
+        info:       "info",
+        format:     "json"
+      }
+    end
+    let(:expected_iiif_url) { 'http://127.0.0.1:8182/iiif/2/abc123/info.json' }
+
+    before do
+      ENV['PROXIED_IIIF_SERVER_URL'] = 'http://127.0.0.1:8182/iiif/2'
+    end
+
+    it "returns as json" do
+      stub_request(:any, expected_iiif_url).to_return(
+        body:    "SUCCESS",
+        status:  200,
+        headers: { 'Content-Length' => 3 }
+      )
+      get :info, params: params
+      expect(assigns(:iiif_url)).to eq expected_iiif_url
+    end
+  end
+
   describe "a request for a public object" do
     let(:expected_iiif_url) { 'http://127.0.0.1:8182/iiif/2/abc123/full/full/0/default.jpg' }
 

--- a/spec/routing/iiif_routing_spec.rb
+++ b/spec/routing/iiif_routing_spec.rb
@@ -23,6 +23,6 @@ RSpec.describe "routes for iiif", type: :routing do
         "controller" => "iiif",
         "action" => "info",
         "identifier" => "a0f9219f14f071be7e3b872186f3507cfeccd5bf"
-        )
+      )
   end
 end

--- a/spec/routing/iiif_routing_spec.rb
+++ b/spec/routing/iiif_routing_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "routes for iiif", type: :routing do
+  it "routes iiif image requests to the iiif#show controller" do
+    expect(get("/iiif/2/a0f9219f14f071be7e3b872186f3507cfeccd5bf/full/600,/0/default.jpg"))
+      .to route_to(
+        "controller" => "iiif",
+        "action" => "show",
+        "identifier" => "a0f9219f14f071be7e3b872186f3507cfeccd5bf",
+        "region" => "full",
+        "size" => "600,",
+        "rotation" => "0",
+        "quality" => "default",
+        "format" => "jpg"
+      )
+  end
+
+  it "routes info.json requests to the iiif#info controller" do
+    expect(get("/iiif/2/a0f9219f14f071be7e3b872186f3507cfeccd5bf/info.json"))
+      .to route_to(
+        "controller" => "iiif",
+        "action" => "info",
+        "identifier" => "a0f9219f14f071be7e3b872186f3507cfeccd5bf"
+        )
+  end
+end


### PR DESCRIPTION
It isn't enough that the IiifController proxies image requests to
cantaloupe -- it needs to also proxy info.json requests. This PR adds
that feature.

BUGFIX: Only add an extra slash when it is needed to construct a IIIF url

Connected to https://github.com/emory-libraries/dlp-lux/issues/260