### PR TITLE
displays preferred image in work show page iiif

### DIFF
--- a/app/presenters/hyrax/displays_image.rb
+++ b/app/presenters/hyrax/displays_image.rb
@@ -15,11 +15,12 @@ module Hyrax
     def display_image
       return nil unless ::FileSet.exists?(id) && solr_document.image? && current_ability.can?(:read, id)
       # @todo this is slow, find a better way (perhaps index iiif url):
-      original_file = ::FileSet.find(id).original_file
+      file_set = ::FileSet.find(id)
+      preferred_file = file_set.send(file_set.preferred_file)
       @request_base_url = request_base_url
 
       url = Hyrax.config.iiif_image_url_builder.call(
-        original_file.id,
+        preferred_file.id,
         @request_base_url,
         Hyrax.config.iiif_image_size_default
       )
@@ -27,7 +28,7 @@ module Hyrax
       IIIFManifest::DisplayImage.new(url,
                                      width:         640,
                                      height:        480,
-                                     iiif_endpoint: iiif_endpoint(original_file.id))
+                                     iiif_endpoint: iiif_endpoint(preferred_file.id))
     end
 
     private

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'iiif_manifest'
+RSpec.describe Hyrax::FileSetPresenter do
+  let(:file_set) { FactoryBot.create(:file_set) }
+  let(:pmf)      { File.open(fixture_path + '/book_page/0003_preservation_master.tif') }
+  let(:sf)       { File.open(fixture_path + '/book_page/0003_service.jpg') }
+  let(:imf)      { File.open(fixture_path + '/book_page/0003_intermediate.jp2') }
+  before do
+    Hydra::Works::AddFileToFileSet.call(file_set, pmf, :preservation_master_file)
+    Hydra::Works::AddFileToFileSet.call(file_set, sf, :service_file)
+    Hydra::Works::AddFileToFileSet.call(file_set, imf, :intermediate_file)
+    file_set.to_solr
+    file_set.save!
+  end
+  describe "#display_image" do
+    let(:solr_document) { SolrDocument.find(file_set.id) }
+    let(:presenter) { described_class.new(solr_document, ManifestAbility.new) }
+    context 'displays preferred file' do
+      subject { presenter.display_image.url }
+      it { is_expected.to include(file_set.service_file.id.split('/').last) }
+    end
+  end
+end


### PR DESCRIPTION
Closes #681 

After multiple attempts writing system tests for iframe for iiif there is no way to identify which file it is displaying within the UI. Iframe point directly to the work manifest. The image is drawn with Canvas.

Hyrax only has tests for display_image in a file_set_presenter_spec.rb. This would be for a different ticket where we need to display preferred image on a fille_set page with UV

