### PR TITLE
Index thumbnail_path for Lux child works

### DIFF
--- a/app/indexers/curate_generic_work_indexer.rb
+++ b/app/indexers/curate_generic_work_indexer.rb
@@ -104,10 +104,13 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
   end
 
   def child_works_for_lux
-    children = object.child_works
+    children = object.child_works.sort_by { |c| c.title.first }
     return nil if children.empty?
-    ids_and_titles = children.map { |c| [c.id, c.title] }
-    # Sort child works' id and title pairs alphabetically by title
-    ids_and_titles.sort_by { |w| w[1][0] }
+    children.map do |c|
+      id = c.id
+      title = c.title.first
+      thumbnail_path = c.to_solr["thumbnail_path_ss"]
+      "#{id}, #{thumbnail_path}, #{title}"
+    end
   end
 end

--- a/spec/models/curate_generic_work_spec.rb
+++ b/spec/models/curate_generic_work_spec.rb
@@ -44,8 +44,11 @@ RSpec.describe CurateGenericWork do
       expect(work1.assign_id).to match(/\d{3}[A-z0-9]{7}-cor/)
     end
 
-    it "saves ids and titles of child works in Solr document in alphabetical order by title" do
-      expect(solr_doc['child_works_for_lux_tesim']).to eq [["wk2", ["Work 2"]], ["wk3", ["Work 3"]]]
+    it "saves ids, thumbnail paths, and titles of child works in Solr document in alphabetical order by title" do
+      expect(solr_doc['child_works_for_lux_tesim']).to eq [
+        "wk2, /assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png, Work 2",
+        "wk3, /assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png, Work 3"
+      ]
     end
   end
 
@@ -1417,7 +1420,7 @@ RSpec.describe CurateGenericWork do
       # Check copyright_date_tesim also saved as human_readable_copyright_date_tesim
       expect(solr_doc['human_readable_copyright_date_tesim']).to eq ['between 1942 and 1944']
 
-      # Check that ids and titles for child CurateGenericWorks are not indexed for simple objects
+      # Check that metadata for child CurateGenericWorks is not indexed for simple objects
       expect(solr_doc['child_works_for_lux_tesim']).to eq nil
     end
   end


### PR DESCRIPTION
- `thumbnail_path` is added to `child_works_for_lux`
- Formatting of `child_works_for_lux` field is simplified for easier parsing on Lux side