### PR TITLE
Sets the CORS header for the IIIF proxy

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -4,12 +4,14 @@ class IiifController < ApplicationController
   def show
     @iiif_url = iiif_url
     Rails.logger.info("Trying to proxy image from #{@iiif_url}")
+    response.set_header('Access-Control-Allow-Origin', '*')
     send_data HTTP.get(@iiif_url).body, type: 'image/jpeg', x_sendfile: true, disposition: 'inline'
   end
 
   def info
     @iiif_url = "#{ENV['PROXIED_IIIF_SERVER_URL']}#{trailing_slash_fix}#{identifier}/info.json"
     Rails.logger.info("Trying to proxy info from #{@iiif_url}")
+    response.set_header('Access-Control-Allow-Origin', '*')
     send_data HTTP.get(@iiif_url).body, type: 'application/json', x_sendfile: true, disposition: 'inline'
   end
 

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe IiifController, type: :controller do
       )
       get :info, params: params
       expect(assigns(:iiif_url)).to eq expected_iiif_url
+      expect(response.has_header?('Access-Control-Allow-Origin')).to be_truthy
     end
   end
 
@@ -69,6 +70,7 @@ RSpec.describe IiifController, type: :controller do
       )
       get :show, params: params
       expect(assigns(:iiif_url)).to eq expected_iiif_url
+      expect(response.has_header?('Access-Control-Allow-Origin')).to be_truthy
     end
   end
 end


### PR DESCRIPTION
When the Access-Control-Allow-Origin header is missing, the content sent is not loaded by UV.