### PR TITLE
Index fields for Lux search results display

### DIFF
--- a/app/indexers/curate_collection_indexer.rb
+++ b/app/indexers/curate_collection_indexer.rb
@@ -4,4 +4,10 @@ class CurateCollectionIndexer < Hyrax::CollectionIndexer
   def rdf_service
     CurateIndexer
   end
+
+  def generate_solr_document
+    super.tap do |solr_doc|
+      solr_doc['member_works_count_isi'] = object.child_works.count
+    end
+  end
 end

--- a/app/indexers/curate_generic_work_indexer.rb
+++ b/app/indexers/curate_generic_work_indexer.rb
@@ -29,6 +29,7 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
       solr_doc['creator_ssort'] = object.creator.first
       solr_doc['year_for_lux_ssi'] = sort_year
       solr_doc['child_works_for_lux_tesim'] = child_works_for_lux
+      solr_doc['parent_work_for_lux_tesim'] = parent_work_for_lux
     end
   end
 
@@ -112,5 +113,13 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
       thumbnail_path = c.to_solr["thumbnail_path_ss"]
       "#{id}, #{thumbnail_path}, #{title}"
     end
+  end
+
+  def parent_work_for_lux
+    parent = object.parent_works.first
+    return nil if parent.nil?
+    id = parent.id
+    title = parent.title.first
+    ["#{id}, #{title}"]
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -3,6 +3,26 @@
 require 'rails_helper'
 
 RSpec.describe Collection do
+  context "Solr document for collections" do
+    let(:collection)     { FactoryBot.build(:collection_lw) }
+    let(:work1)          { FactoryBot.build(:work, id: 'wk1', title: ['Work 1']) }
+    let(:work2)          { FactoryBot.build(:work, id: 'wk2', title: ['Work 2']) }
+    let(:work3)          { FactoryBot.build(:work, id: 'wk3', title: ['Work 3']) }
+    let(:solr_doc)       { collection.to_solr }
+
+    it "indexes a count of 0 child works for empty collections" do
+      expect(solr_doc['member_works_count_isi']).to eq 0
+    end
+
+    it "indexes the correct count of child works for populated collections" do
+      works = [work1, work2, work3]
+      works.each { |w| collection.ordered_members << w }
+      collection.save!
+      collection.reload
+      expect(solr_doc['member_works_count_isi']).to eq 3
+    end
+  end
+
   describe "#holding_repository" do
     subject { described_class.new }
     let(:holding_repository) { ['Woodruff'] }

--- a/spec/models/curate_generic_work_spec.rb
+++ b/spec/models/curate_generic_work_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe CurateGenericWork do
     let(:work3)       { FactoryBot.build(:work, id: 'wk3', title: ['Work 3']) }
     let(:fileset1)    { FactoryBot.build(:file_set, id: 'fs1', title: ['Fileset 1']) }
     let(:fileset2)    { FactoryBot.build(:file_set, id: 'fs2', title: ['Fileset 2']) }
-    let(:solr_doc)    { work1.to_solr }
+    let(:solr_doc1)   { work1.to_solr }
+    let(:solr_doc2)   { work2.to_solr }
 
     before do
       work1.members = [work2, work3, fileset1, fileset2]
@@ -45,10 +46,16 @@ RSpec.describe CurateGenericWork do
     end
 
     it "saves ids, thumbnail paths, and titles of child works in Solr document in alphabetical order by title" do
-      expect(solr_doc['child_works_for_lux_tesim']).to eq [
+      expect(solr_doc1['child_works_for_lux_tesim']).to eq [
         "wk2, /assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png, Work 2",
         "wk3, /assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png, Work 3"
       ]
+      expect(solr_doc2['child_works_for_lux_tesim']).to eq nil
+    end
+
+    it 'saves id and title of parent work in Solr document' do
+      expect(solr_doc1['parent_work_for_lux_tesim']).to eq nil
+      expect(solr_doc2['parent_work_for_lux_tesim']).to eq ["wk1, Work 1"]
     end
   end
 


### PR DESCRIPTION
- Fields are indexed in Solr for (1) the number of works in a collection and (2) the id and title of a child work's parent work
- See [Lux ticket 280](https://github.com/emory-libraries/dlp-lux/issues/280)