### PR TITLE
Adds request options to Faraday connection

### DIFF
--- a/config/initializers/active_fedora_timeout.rb
+++ b/config/initializers/active_fedora_timeout.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+# [Overwrite - ActiveFedora ~> 11.5.4]
 # We are adding request options (timeouts) when creating a new Faraday connection.
 # This is added in ActiveFedora 12+ and this file can be removed once we upgrade
 # AF. Refer: https://github.com/samvera/active_fedora/pull/1271

--- a/config/initializers/active_fedora_timeout.rb
+++ b/config/initializers/active_fedora_timeout.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# We are adding request options (timeouts) when creating a new Faraday connection.
+# This is added in ActiveFedora 12+ and this file can be removed once we upgrade
+# AF. Refer: https://github.com/samvera/active_fedora/pull/1271
+# We are overwriting the `authorized_connection` method from Fedora class in AF.
+class ActiveFedora::Fedora
+  def request_options
+    @config[:request]
+  end
+
+  def authorized_connection
+    options = {}
+    options[:ssl] = ssl_options if ssl_options
+    options[:request] = request_options if request_options
+    Faraday.new(host, options) do |conn|
+      conn.response :encoding # use Faraday::Encoding middleware
+      conn.adapter Faraday.default_adapter # net/http
+      conn.basic_auth(user, password)
+    end
+  end
+end

--- a/spec/unit/fedora_spec.rb
+++ b/spec/unit/fedora_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ActiveFedora::Fedora do
+  subject(:fedora) { described_class.new(config) }
+  describe "#authorized_connection" do
+    describe "with request options" do
+      let(:config) do
+        { url:      "https://example.com",
+          user:     "fedoraAdmin",
+          password: "fedoraAdmin",
+          request:  { timeout: 300, open_timeout: 60 } }
+      end
+      specify do
+        expect(Faraday).to receive(:new).with("https://example.com", request: { timeout: 300, open_timeout: 60 }).and_call_original
+        fedora.authorized_connection
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Currently, request to create a graph for descendants in fedora times
out. In this commit, we add request options when creating a Faraday
connection. This way we can specify timeout in seconds so that the
read request for graph finishes. This is added by default in ActiveFedora
12+ and this monkey patch can be removed once we upgrade AF. Refer:
https://github.com/samvera/active_fedora/pull/1271
* This will solve the issue where ResolrizeJob used to timeout.