### PR TITLE
Adds env variable for manifest cache path

### DIFF
--- a/app/lib/create_manifest.rb
+++ b/app/lib/create_manifest.rb
@@ -20,14 +20,14 @@ class CreateManifest
         date_modified = solr_doc[:date_modified_dtsi] || solr_doc[:system_create_dtsi]
         key = date_modified.to_datetime.strftime('%Y-%m-%d_%H-%M-%S') + '_' + solr_doc[:id]
 
-        return if File.exist?(ENV['IIIF_MANIFEST_CACHE'] + key)
+        return if File.exist?(File.join(ENV['IIIF_MANIFEST_CACHE'], key))
         presenter = Hyrax::CurateGenericWorkPresenter.new(solr_doc, ManifestAbility.new)
         manifest_hash = ::IIIFManifest::ManifestFactory.new(presenter).to_h
         persist_manifest(key: key, manifest_hash: manifest_hash)
       end
 
       def persist_manifest(key:, manifest_hash:)
-        File.open(ENV['IIIF_MANIFEST_CACHE'] + key, 'w+') do |f|
+        File.open(File.join(ENV['IIIF_MANIFEST_CACHE'], key), 'w+') do |f|
           f.write(manifest_hash.to_json)
         end
       end

--- a/app/lib/create_manifest.rb
+++ b/app/lib/create_manifest.rb
@@ -20,14 +20,14 @@ class CreateManifest
         date_modified = solr_doc[:date_modified_dtsi] || solr_doc[:system_create_dtsi]
         key = date_modified.to_datetime.strftime('%Y-%m-%d_%H-%M-%S') + '_' + solr_doc[:id]
 
-        return if File.exist?(Rails.root.join('tmp', key))
+        return if File.exist?(ENV['IIIF_MANIFEST_CACHE'] + key)
         presenter = Hyrax::CurateGenericWorkPresenter.new(solr_doc, ManifestAbility.new)
         manifest_hash = ::IIIFManifest::ManifestFactory.new(presenter).to_h
         persist_manifest(key: key, manifest_hash: manifest_hash)
       end
 
       def persist_manifest(key:, manifest_hash:)
-        File.open(Rails.root.join('tmp', key), 'w+') do |f|
+        File.open(ENV['IIIF_MANIFEST_CACHE'] + key, 'w+') do |f|
           f.write(manifest_hash.to_json)
         end
       end

--- a/app/services/manifest_builder_service.rb
+++ b/app/services/manifest_builder_service.rb
@@ -24,7 +24,7 @@ class ManifestBuilderService
       date_modified = solr_doc[:date_modified_dtsi] || solr_doc[:system_create_dtsi]
       key = date_modified.to_datetime.strftime('%Y-%m-%d_%H-%M-%S') + '_' + solr_doc[:id]
 
-      if File.exist?(Rails.root.join('tmp', key))
+      if File.exist?(File.join(ENV['IIIF_MANIFEST_CACHE'], key))
         render_manifest_file(key: key)
       else
         manifest_hash = ::IIIFManifest::ManifestFactory.new(presenter(solr_doc)).to_h
@@ -40,14 +40,14 @@ class ManifestBuilderService
     end
 
     def render_manifest_file(key:)
-      manifest_file = File.open(Rails.root.join('tmp', key))
+      manifest_file = File.open(File.join(ENV['IIIF_MANIFEST_CACHE'], key))
       manifest = manifest_file.read
       manifest_file.close
       manifest
     end
 
     def persist_manifest(key:, manifest_hash:)
-      File.open(Rails.root.join('tmp', key), 'w+') do |f|
+      File.open(File.join(ENV['IIIF_MANIFEST_CACHE'], key), 'w+') do |f|
         f.write(manifest_hash.to_json)
       end
     end

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -8,6 +8,10 @@ PROXIED_IIIF_SERVER_URL=
 # images in views, etc.
 IIIF_SERVER_URL=
 
+# This variable will contain the path to the directory where manifests get
+# cached. Path will need to end with a '/'. Eg: "full/path/to/directory/"
+IIIF_MANIFEST_CACHE=
+
 SIDEKIQ_WORKERS=
 
 RAILS_HOST=

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -9,7 +9,7 @@ PROXIED_IIIF_SERVER_URL=
 IIIF_SERVER_URL=
 
 # This variable will contain the path to the directory where manifests get
-# cached. Path will need to end with a '/'. Eg: "full/path/to/directory/"
+# cached. Eg: "/full/path/to/directory"
 IIIF_MANIFEST_CACHE=
 
 SIDEKIQ_WORKERS=

--- a/spec/controllers/hyrax/curate_generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/curate_generic_works_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Hyrax::CurateGenericWorksController do
   let(:work) { FactoryBot.create(:public_generic_work, id: '888889') }
   describe "GET #manifest" do
-    before { ENV['IIIF_MANIFEST_CACHE'] = "./tmp/" }
+    before { ENV['IIIF_MANIFEST_CACHE'] = "./tmp" }
 
     it "returns http success" do
       get :manifest, params: { id: work.id, format: 'json' }

--- a/spec/controllers/hyrax/curate_generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/curate_generic_works_controller_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe Hyrax::CurateGenericWorksController do
   let(:work) { FactoryBot.create(:public_generic_work, id: '888889') }
   describe "GET #manifest" do
+    before { ENV['IIIF_MANIFEST_CACHE'] = "./tmp/" }
+
     it "returns http success" do
       get :manifest, params: { id: work.id, format: 'json' }
       expect(response).to have_http_status(:success)

--- a/spec/lib/create_manifest_spec.rb
+++ b/spec/lib/create_manifest_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe CreateManifest, :clean do
   let(:presenter) { described_class.new(solr_document, ability, request) }
 
   before do
+    ENV['IIIF_MANIFEST_CACHE'] = "./tmp/"
     allow(CurateGenericWork).to receive(:all).and_return([generic_work])
     allow(SolrDocument).to receive(:find).and_return(solr_document)
     FileUtils.rm_f("./tmp/2019-11-11_18-20-32_888888")

--- a/spec/lib/create_manifest_spec.rb
+++ b/spec/lib/create_manifest_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CreateManifest, :clean do
   let(:presenter) { described_class.new(solr_document, ability, request) }
 
   before do
-    ENV['IIIF_MANIFEST_CACHE'] = "./tmp/"
+    ENV['IIIF_MANIFEST_CACHE'] = "./tmp"
     allow(CurateGenericWork).to receive(:all).and_return([generic_work])
     allow(SolrDocument).to receive(:find).and_return(solr_document)
     FileUtils.rm_f("./tmp/2019-11-11_18-20-32_888888")

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 require 'iiif_manifest'
-RSpec.describe Hyrax::FileSetPresenter do
+RSpec.describe Hyrax::FileSetPresenter, :clean do
   let(:file_set) { FactoryBot.create(:file_set) }
   let(:pmf)      { File.open(fixture_path + '/book_page/0003_preservation_master.tif') }
   let(:sf)       { File.open(fixture_path + '/book_page/0003_service.jpg') }

--- a/spec/services/manifest_builder_service_spec.rb
+++ b/spec/services/manifest_builder_service_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe ManifestBuilderService do
 
   context "returning a iiif manifest" do
     before do
+      ENV['IIIF_MANIFEST_CACHE'] = "./tmp"
       allow(SolrDocument).to receive(:find).and_return(solr_document)
       File.delete(cache_file) if File.exist?(cache_file)
     end

--- a/spec/system/iiif_manifest_spec.rb
+++ b/spec/system/iiif_manifest_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'viewing an IIIF manifest', type: :system, clean: true do
   let(:attributes) { {} }
   let(:env)        { Hyrax::Actors::Environment.new(work, ability, attributes) }
   let(:actor_stack_work) do
-    ENV['IIIF_MANIFEST_CACHE'] = "./tmp/"
+    ENV['IIIF_MANIFEST_CACHE'] = "./tmp"
     Hyrax::CurationConcern.actor.create(env)
   end
 

--- a/spec/system/iiif_manifest_spec.rb
+++ b/spec/system/iiif_manifest_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'viewing an IIIF manifest', type: :system, clean: true do
   let(:attributes) { {} }
   let(:env)        { Hyrax::Actors::Environment.new(work, ability, attributes) }
   let(:actor_stack_work) do
+    ENV['IIIF_MANIFEST_CACHE'] = "./tmp/"
     Hyrax::CurationConcern.actor.create(env)
   end
 


### PR DESCRIPTION
* We are adding an env variable that will contain the path to the
directory where manifests get cached. Path example:
`full/path/to/directory/`