### PR TITLE
Redirects to origin when signing in via shib

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -5,7 +5,10 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     @user = User.from_omniauth(request.env["omniauth.auth"])
 
     if @user.persisted?
-      sign_in_and_redirect @user
+      sign_in @user
+      # This will help the user go back to where they came.
+      # Refer: https://github.com/omniauth/omniauth/wiki/Saving-User-Location
+      redirect_to request.env["omniauth.origin"] || '/dashboard'
       set_flash_message(:notice, :success, kind: "Shibboleth")
     else
       redirect_to root_path

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -8,7 +8,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in @user
       # This will help the user go back to where they came.
       # Refer: https://github.com/omniauth/omniauth/wiki/Saving-User-Location
-      redirect_to request.env["omniauth.origin"] || '/dashboard'
+      redirect_to request.env["omniauth.origin"] || hyrax.dashboard_path
       set_flash_message(:notice, :success, kind: "Shibboleth")
     else
       redirect_to root_path

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe OmniauthCallbacksController do
   context "when origin is missing" do
     it "redirects to dashboard" do
       post :shibboleth
-      expect(response.redirect_url).to eq 'http://test.host/dashboard'
+      expect(response.redirect_url).to include 'http://test.host/dashboard'
     end
   end
 end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe OmniauthCallbacksController do
+  before do
+    User.create(provider:     'shibboleth',
+                uid:          'brianbboys1967',
+                ppid:         'P0000001',
+                display_name: 'Brian Wilson')
+    request.env["devise.mapping"] = Devise.mappings[:user]
+    request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:shib]
+  end
+  OmniAuth.config.mock_auth[:shib] =
+    OmniAuth::AuthHash.new(
+      provider: 'shibboleth',
+      uid:      "P0000001",
+      info:     {
+        display_name: "Brian Wilson",
+        uid:          'brianbboys1967'
+      }
+    )
+
+  context "when origin is present" do
+    before do
+      request.env["omniauth.origin"] = '/example'
+    end
+
+    it "redirects to origin" do
+      post :shibboleth
+      expect(response.redirect_url).to eq 'http://test.host/example'
+    end
+  end
+
+  context "when origin is missing" do
+    it "redirects to dashboard" do
+      post :shibboleth
+      expect(response.redirect_url).to eq 'http://test.host/dashboard'
+    end
+  end
+end


### PR DESCRIPTION
* In this commit, we redirect the user to omniauth request's origin
if it exists, else will redirect to the dashboard. Refer:
https://github.com/omniauth/omniauth/wiki/Saving-User-Location