### PR TITLE
Index sort fields on collections

### DIFF
--- a/app/indexers/curate_collection_indexer.rb
+++ b/app/indexers/curate_collection_indexer.rb
@@ -8,6 +8,13 @@ class CurateCollectionIndexer < Hyrax::CollectionIndexer
   def generate_solr_document
     super.tap do |solr_doc|
       solr_doc['member_works_count_isi'] = object.child_works.count
+      solr_doc['title_ssort'] = sort_title
+      solr_doc['creator_ssort'] = object.creator.first
     end
+  end
+
+  def sort_title
+    return unless object.title.first
+    object.title.first.gsub(/^(an?|the)\s/i, '')
   end
 end

--- a/spec/indexers/collection_indexer_spec.rb
+++ b/spec/indexers/collection_indexer_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CurateCollectionIndexer do
+  let(:solr_document) { indexer.generate_solr_document }
+  let(:collection) { Collection.new(attributes) }
+  let(:indexer) { described_class.new(collection) }
+
+  describe 'sort fields' do
+    let(:attributes) do
+      {
+        id:      '123',
+        title:   ['Some title'],
+        creator: ['Some creator']
+      }
+    end
+
+    it 'indexes sort fields for title and creator' do
+      expect(solr_document['title_ssort']).to eq 'Some title'
+      expect(solr_document['creator_ssort']).to eq 'Some creator'
+    end
+
+    context 'when title has a leading article' do
+      let(:attributes) do
+        {
+          id:    '123',
+          title: ['A title']
+        }
+      end
+
+      it 'indexes title sort field without leading articles' do
+        expect(solr_document['title_ssort']).to eq 'title'
+      end
+    end
+  end
+end


### PR DESCRIPTION
- The sortable fields for Lux `title_ssort` and `creator_ssort` are now indexed on Collections in addition to CurateGenericWorks