### PR TITLE
Manifests should always be available

### DIFF
--- a/app/controllers/hyrax/curate_generic_works_controller.rb
+++ b/app/controllers/hyrax/curate_generic_works_controller.rb
@@ -5,6 +5,7 @@ module Hyrax
     # Adds Hyrax behaviors to the controller.
     include Hyrax::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
+
     self.curation_concern_type = ::CurateGenericWork
 
     # Use this line if you want to use a custom presenter
@@ -42,37 +43,14 @@ module Hyrax
       end
     end
 
-    def manifest
+    def index
       headers['Access-Control-Allow-Origin'] = '*'
-      manifest_builder
+      render json: ManifestBuilderService.build_manifest(params[:id])
     end
 
-    private
-
-      def manifest_builder
-        solr_doc = ::SolrDocument.find(params[:id])
-        date_modified = solr_doc[:date_modified_dtsi] || solr_doc[:system_create_dtsi]
-        key = date_modified.to_datetime.strftime('%Y-%m-%d_%H-%M-%S') + '_' + solr_doc[:id]
-
-        if File.exist?(Rails.root.join('tmp', key))
-          render_manifest_file(key: key)
-        else
-          manifest_hash = ::IIIFManifest::ManifestFactory.new(presenter).to_h
-          persist_manifest(key: key, manifest_hash: manifest_hash)
-          render json: manifest_hash.to_json
-        end
-      end
-
-      def render_manifest_file(key:)
-        manifest_file = File.open(Rails.root.join('tmp', key))
-        render json: manifest_file.read
-        manifest_file.close
-      end
-
-      def persist_manifest(key:, manifest_hash:)
-        File.open(Rails.root.join('tmp', key), 'w+') do |f|
-          f.write(manifest_hash.to_json)
-        end
-      end
+    def manifest
+      headers['Access-Control-Allow-Origin'] = '*'
+      render json: ManifestBuilderService.build_manifest(params[:id])
+    end
   end
 end

--- a/app/controllers/hyrax/curate_generic_works_controller.rb
+++ b/app/controllers/hyrax/curate_generic_works_controller.rb
@@ -43,11 +43,6 @@ module Hyrax
       end
     end
 
-    def index
-      headers['Access-Control-Allow-Origin'] = '*'
-      render json: ManifestBuilderService.build_manifest(params[:id])
-    end
-
     def manifest
       headers['Access-Control-Allow-Origin'] = '*'
       render json: ManifestBuilderService.build_manifest(params[:id])

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -20,6 +20,11 @@ class IiifController < ApplicationController
     "#{ENV['PROXIED_IIIF_SERVER_URL']}#{trailing_slash_fix}#{identifier}/#{region}/#{size}/#{rotation}/#{quality}.#{format}"
   end
 
+  def manifest
+    headers['Access-Control-Allow-Origin'] = '*'
+    render json: ManifestBuilderService.build_manifest(identifier)
+  end
+
   # IIIF URLS really do not like extra slashes. Ensure that we only add a slash after the
   # PROXIED_IIIF_SERVER_URL value if it is needed
   def trailing_slash_fix

--- a/app/services/manifest_builder_service.rb
+++ b/app/services/manifest_builder_service.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'iiif_manifest'
+
+class ManifestBuilderService
+  def initialize(identifier)
+    @identifier = identifier
+  end
+
+  def manifest
+    manifest_builder
+  end
+
+  # ManifestBuilderService.build_manifest(identifier)
+  def self.build_manifest(identifier)
+    service = ManifestBuilderService.new(identifier)
+    service.manifest
+  end
+
+  private
+
+    def manifest_builder
+      solr_doc = ::SolrDocument.find(@identifier)
+      date_modified = solr_doc[:date_modified_dtsi] || solr_doc[:system_create_dtsi]
+      key = date_modified.to_datetime.strftime('%Y-%m-%d_%H-%M-%S') + '_' + solr_doc[:id]
+
+      if File.exist?(Rails.root.join('tmp', key))
+        render_manifest_file(key: key)
+      else
+        manifest_hash = ::IIIFManifest::ManifestFactory.new(presenter(solr_doc)).to_h
+        persist_manifest(key: key, manifest_hash: manifest_hash)
+        manifest_hash.to_json
+      end
+    end
+
+    # @param [SolrDocument] document
+    def presenter(document)
+      ability = Ability.new(::User.new)
+      Hyrax::CurateGenericWorkPresenter.new(document, ability)
+    end
+
+    def render_manifest_file(key:)
+      manifest_file = File.open(Rails.root.join('tmp', key))
+      manifest = manifest_file.read
+      manifest_file.close
+      manifest
+    end
+
+    def persist_manifest(key:, manifest_hash:)
+      File.open(Rails.root.join('tmp', key), 'w+') do |f|
+        f.write(manifest_hash.to_json)
+      end
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,9 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
-  get '/iiif/2/:identifier/info.json', to: 'iiif#info'
+  get '/iiif/:identifier/manifest', to: 'iiif#manifest'
   get '/iiif/2/:identifier/:region/:size/:rotation/:quality.:format', to: 'iiif#show'
+  get '/iiif/2/:identifier/info.json', to: 'iiif#info'
 
   mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
   mount Blacklight::Engine => '/'

--- a/spec/controllers/hyrax/curate_generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/curate_generic_works_controller_spec.rb
@@ -1,42 +1,13 @@
 # frozen_string_literal: true
 
-# Generated via
-#  `rails generate hyrax:work CurateGenericWork`
 require 'rails_helper'
 
 RSpec.describe Hyrax::CurateGenericWorksController do
-  let(:user) { FactoryBot.create(:user) }
   let(:work) { FactoryBot.create(:public_generic_work, id: '888889') }
-  let(:solr_document) { SolrDocument.new(attributes) }
-  let(:manifest_file) { IO.read(fixture_path + '/manifest_fixture.json') }
-  before { sign_in user }
-  let(:attributes) do
-    { "id" => '888889',
-      "title_tesim" => ['foo', 'bar'],
-      "human_readable_type_tesim" => ["Curate Generic Work"],
-      "has_model_ssim" => ["CurateGenericWork"],
-      "date_created_tesim" => ['an unformatted date'],
-      "date_modified_dtsi" => "2019-11-11T18:20:32Z",
-      "depositor_tesim" => user.uid }
-  end
   describe "GET #manifest" do
     it "returns http success" do
       get :manifest, params: { id: work.id, format: 'json' }
       expect(response).to have_http_status(:success)
-    end
-
-    context "generates manifest" do
-      before do
-        allow(SolrDocument).to receive(:find).and_return(solr_document)
-      end
-
-      it "saves manifest file" do
-        get :manifest, params: { id: work.id, format: 'json' }
-        expect(response.body).to include(work.id)
-        expect(File).to exist("./tmp/2019-11-11_18-20-32_888889")
-        get :manifest, params: { id: work.id, format: 'json' }
-        expect(File.open("./tmp/2019-11-11_18-20-32_888889").read). to eq manifest_file
-      end
     end
   end
 end

--- a/spec/fixtures/manifest_fixture.json
+++ b/spec/fixtures/manifest_fixture.json
@@ -1,1 +1,0 @@
-{"@context":"http://iiif.io/api/presentation/2/context.json","@type":"sc:Manifest","@id":"http://test.host/concern/curate_generic_works/888889/manifest","label":"Test title"}

--- a/spec/routing/iiif_routing_spec.rb
+++ b/spec/routing/iiif_routing_spec.rb
@@ -25,4 +25,13 @@ RSpec.describe "routes for iiif", type: :routing do
         "identifier" => "a0f9219f14f071be7e3b872186f3507cfeccd5bf"
       )
   end
+
+  it "routes manifest requests to the iiif#manifest controller" do
+    expect(get("/iiif/508hdr7srq-cor/manifest"))
+      .to route_to(
+        "controller" => "iiif",
+        "action" => "manifest",
+        "identifier" => "508hdr7srq-cor"
+      )
+  end
 end

--- a/spec/services/manifest_builder_service_spec.rb
+++ b/spec/services/manifest_builder_service_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ManifestBuilderService do
+  let(:identifier) { '508hdr7srq-cor' }
+  let(:service) { described_class.new(identifier) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:work) { FactoryBot.create(:public_generic_work, id: identifier) }
+  let(:solr_document) { SolrDocument.new(attributes) }
+  # let(:manifest_file) { IO.read(fixture_path + '/manifest_fixture.json') }
+  let(:attributes) do
+    { "id" => identifier,
+      "title_tesim" => ['foo', 'bar'],
+      "human_readable_type_tesim" => ["Curate Generic Work"],
+      "has_model_ssim" => ["CurateGenericWork"],
+      "date_created_tesim" => ['an unformatted date'],
+      "date_modified_dtsi" => "2019-11-11T18:20:32Z",
+      "depositor_tesim" => user.uid }
+  end
+
+  context "returning a iiif manifest" do
+    before do
+      allow(SolrDocument).to receive(:find).and_return(solr_document)
+    end
+
+    it 'generates a iiif presentation manifest' do
+      response_values = JSON.parse(service.manifest)
+      expect(response_values["@context"]).to include "http://iiif.io/api/presentation/2/context.json"
+    end
+
+    it 'can be called at the class level' do
+      response_values = JSON.parse(described_class.build_manifest(identifier))
+      expect(response_values["@context"]).to include "http://iiif.io/api/presentation/2/context.json"
+    end
+  end
+end

--- a/spec/system/iiif_manifest_spec.rb
+++ b/spec/system/iiif_manifest_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 require 'iiif_manifest'
 
-RSpec.describe 'viewing an IIIF manifest', type: :system do
+RSpec.describe 'viewing an IIIF manifest', type: :system, clean: true do
   let(:ability)    { ::Ability.new(FactoryBot.create(:user)) }
   let(:attributes) { {} }
   let(:env)        { Hyrax::Actors::Environment.new(work, ability, attributes) }
@@ -10,13 +10,14 @@ RSpec.describe 'viewing an IIIF manifest', type: :system do
     Hyrax::CurationConcern.actor.create(env)
   end
 
-  context "when an object is marked as Public in Curate" do
+  context "public works" do
     let(:work) { FactoryBot.build(:public_work) }
     it "has a well-formed manifest" do
       actor_stack_work
       work.reload
 
-      visit "/concern/curate_generic_works/#{work.id}/manifest"
+      # visit "/concern/curate_generic_works/#{work.id}/manifest"
+      visit "/iiif/#{work.id}/manifest"
 
       expect(page.response_headers["Content-Type"]).to eq "application/json; charset=utf-8"
 
@@ -33,6 +34,18 @@ RSpec.describe 'viewing an IIIF manifest', type: :system do
 
       # for continued work: per the 2.1 Presentation API, the manifest must include sequences,
       # and the sequences must include canvases
+    end
+  end
+
+  context "public_low_work" do
+    let(:work) { FactoryBot.build(:public_low_work) }
+    it 'allows everyone to see the manifest even if they are not authenticated' do
+      actor_stack_work
+      work.reload
+      visit "/iiif/#{work.id}/manifest"
+      expect(page.response_headers["Content-Type"]).to eq "application/json; charset=utf-8"
+      response_values = JSON.parse(page.body)
+      expect(response_values).to include "@context"
     end
   end
 end


### PR DESCRIPTION
Move the IIIF manifest generation out of CurateGenericWorksController,
where it is gated by Shibboleth, and into the iiif controller, where it
is more publicly accessible. The goal is to let us load iiif images for
public_low_view objects.

Once this is merged you should be able to get a work's manifest by visiting `/iiif/WORKID/manifest`

Connected to https://github.com/emory-libraries/dlp-lux/issues/313