### PR TITLE
Changes manifest_url to meet lux requirements

### DIFF
--- a/app/controllers/hyrax/curate_generic_works_controller.rb
+++ b/app/controllers/hyrax/curate_generic_works_controller.rb
@@ -45,7 +45,7 @@ module Hyrax
 
     def manifest
       headers['Access-Control-Allow-Origin'] = '*'
-      render json: ManifestBuilderService.build_manifest(params[:id])
+      render json: ManifestBuilderService.build_manifest(params[:id], presenter)
     end
   end
 end

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -22,7 +22,8 @@ class IiifController < ApplicationController
 
   def manifest
     headers['Access-Control-Allow-Origin'] = '*'
-    render json: ManifestBuilderService.build_manifest(identifier)
+    solr_doc = SolrDocument.find(identifier)
+    render json: ManifestBuilderService.build_manifest(identifier, presenter(solr_doc))
   end
 
   # IIIF URLS really do not like extra slashes. Ensure that we only add a slash after the
@@ -54,4 +55,12 @@ class IiifController < ApplicationController
   def format
     params["format"]
   end
+
+  private
+
+    # @param [SolrDocument] document
+    def presenter(document)
+      ability = Ability.new(current_user)
+      Hyrax::CurateGenericWorkPresenter.new(document, ability)
+    end
 end

--- a/app/presenters/hyrax/curate_generic_work_presenter.rb
+++ b/app/presenters/hyrax/curate_generic_work_presenter.rb
@@ -22,9 +22,9 @@ module Hyrax
 
     def manifest_url
       if request.nil?
-        manifest_helper.polymorphic_url([:manifest, self], host: "http://#{ENV['HOSTNAME'] || 'localhost:3000'}")
+        manifest_helper.polymorphic_url([:iiif_manifest], identifier: id, host: "http://#{ENV['HOSTNAME'] || 'localhost:3000'}")
       else
-        manifest_helper.polymorphic_url([:manifest, self])
+        manifest_helper.polymorphic_url([:iiif_manifest], identifier: id)
       end
     end
   end

--- a/app/services/manifest_builder_service.rb
+++ b/app/services/manifest_builder_service.rb
@@ -3,8 +3,9 @@
 require 'iiif_manifest'
 
 class ManifestBuilderService
-  def initialize(identifier)
+  def initialize(identifier, presenter)
     @identifier = identifier
+    @presenter = presenter
   end
 
   def manifest
@@ -12,8 +13,8 @@ class ManifestBuilderService
   end
 
   # ManifestBuilderService.build_manifest(identifier)
-  def self.build_manifest(identifier)
-    service = ManifestBuilderService.new(identifier)
+  def self.build_manifest(identifier, presenter)
+    service = ManifestBuilderService.new(identifier, presenter)
     service.manifest
   end
 
@@ -27,16 +28,10 @@ class ManifestBuilderService
       if File.exist?(Rails.root.join('tmp', key))
         render_manifest_file(key: key)
       else
-        manifest_hash = ::IIIFManifest::ManifestFactory.new(presenter(solr_doc)).to_h
+        manifest_hash = ::IIIFManifest::ManifestFactory.new(@presenter).to_h
         persist_manifest(key: key, manifest_hash: manifest_hash)
         manifest_hash.to_json
       end
-    end
-
-    # @param [SolrDocument] document
-    def presenter(document)
-      ability = Ability.new(::User.new)
-      Hyrax::CurateGenericWorkPresenter.new(document, ability)
     end
 
     def render_manifest_file(key:)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
-  get '/iiif/:identifier/manifest', to: 'iiif#manifest'
+  get '/iiif/:identifier/manifest', to: 'iiif#manifest', as: :iiif_manifest
   get '/iiif/2/:identifier/:region/:size/:rotation/:quality.:format', to: 'iiif#show'
   get '/iiif/2/:identifier/info.json', to: 'iiif#info'
 

--- a/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
+++ b/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
         allow(request).to receive(:base_url).and_return 'http://example.org'
       end
 
-      it { is_expected.to eq 'http://example.org/concern/curate_generic_works/888888/manifest' }
+      it { is_expected.to eq 'http://example.org/iiif/888888/manifest' }
     end
 
     context 'when request is nil and HOSTNAME is nil' do
@@ -35,7 +35,7 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
       let(:presenter) { described_class.new(solr_document, ability) }
       before { ENV['HOSTNAME'] = nil }
 
-      it { is_expected.to eq "http://localhost:3000/concern/curate_generic_works/888888/manifest" }
+      it { is_expected.to eq "http://localhost:3000/iiif/888888/manifest" }
     end
 
     context 'when request is nil and HOSTNAME is assigned' do
@@ -43,7 +43,7 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
       let(:presenter) { described_class.new(solr_document, ability) }
       before { ENV['HOSTNAME'] = 'example-curate' }
 
-      it { is_expected.to eq "http://example-curate/concern/curate_generic_works/888888/manifest" }
+      it { is_expected.to eq "http://example-curate/iiif/888888/manifest" }
     end
   end
 end

--- a/spec/system/iiif_manifest_spec.rb
+++ b/spec/system/iiif_manifest_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'viewing an IIIF manifest', type: :system, clean: true do
       expect(response_values).to include "@type"
       expect(response_values["@type"]).to include "sc:Manifest"
       expect(response_values).to include "@id"
-      expect(response_values["@id"]).to include "/concern/curate_generic_works/#{work.id}/manifest"
+      expect(response_values["@id"]).to include "/iiif/#{work.id}/manifest"
       expect(response_values).to include "label"
       expect(response_values["label"]).to include work.title.first.to_s
 


### PR DESCRIPTION
* We are changing the manifest url to `host_name/iiif/work.id/manifest`
to meet lux requirements.
* In this commit, we are also changing the way `build_manifest` gets
called. We now pass the presenter to the manifest builder class from
the works_controller so we don't need to worry about building a
presenter for the manifest builder service.
* We are also editing the iiif_controller's manifest method when it
calls the `build_manifest` method by passing a presenter that we
create in the controller itself. Here, when we create a presenter
for the work, we are passing the work's solr_doc, creating a new
ability for the `current_user`, and the request is nil. When the
request is nil, the manifest_url is being built by passing the
host manually to the polymorphic_url method.