### PR TITLE
Changes ability for manifest creation to read all

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -60,7 +60,7 @@ class IiifController < ApplicationController
 
     # @param [SolrDocument] document
     def presenter(document)
-      ability = Ability.new(current_user)
+      ability = ManifestAbility.new
       Hyrax::CurateGenericWorkPresenter.new(document, ability)
     end
 end

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe IiifController, type: :controller do
-  let(:identifier) { "abc123" }
+  let(:identifier) { "508hdr7srt-cor" }
   let(:region) { "full" }
   let(:size) { "full" }
   let(:rotation) { 0 }
@@ -37,7 +37,7 @@ RSpec.describe IiifController, type: :controller do
         format:     "json"
       }
     end
-    let(:expected_iiif_url) { 'http://127.0.0.1:8182/iiif/2/abc123/info.json' }
+    let(:expected_iiif_url) { 'http://127.0.0.1:8182/iiif/2/508hdr7srt-cor/info.json' }
 
     before do
       ENV['PROXIED_IIIF_SERVER_URL'] = 'http://127.0.0.1:8182/iiif/2'
@@ -56,7 +56,7 @@ RSpec.describe IiifController, type: :controller do
   end
 
   describe "a request for a public object" do
-    let(:expected_iiif_url) { 'http://127.0.0.1:8182/iiif/2/abc123/full/full/0/default.jpg' }
+    let(:expected_iiif_url) { 'http://127.0.0.1:8182/iiif/2/508hdr7srt-cor/full/full/0/default.jpg' }
 
     before do
       ENV['PROXIED_IIIF_SERVER_URL'] = 'http://127.0.0.1:8182/iiif/2'
@@ -71,6 +71,54 @@ RSpec.describe IiifController, type: :controller do
       get :show, params: params
       expect(assigns(:iiif_url)).to eq expected_iiif_url
       expect(response.has_header?('Access-Control-Allow-Origin')).to be_truthy
+    end
+  end
+
+  describe "#manifest" do
+    let(:work)          { FactoryBot.create(:public_generic_work, id: identifier) }
+    let(:file_set)      { FactoryBot.create(:file_set) }
+    let(:pmf)           { File.open(fixture_path + '/book_page/0003_preservation_master.tif') }
+    let(:solr_document) { SolrDocument.new(attributes) }
+    let(:cache_file)    { Rails.root.join('tmp', "2019-11-11_18-20-32_#{identifier}") }
+    let(:attributes) do
+      { "id" => identifier,
+        "title_tesim" => [work.title.first],
+        "human_readable_type_tesim" => ["Curate Generic Work"],
+        "has_model_ssim" => ["CurateGenericWork"],
+        "date_created_tesim" => ['an unformatted date'],
+        "date_modified_dtsi" => "2019-11-11T18:20:32Z",
+        "depositor_tesim" => 'example_user' }
+    end
+
+    before do
+      Hydra::Works::AddFileToFileSet.call(file_set, pmf, :preservation_master_file)
+      work.ordered_members << file_set
+      work.save!
+      allow(SolrDocument).to receive(:find).and_return(solr_document)
+    end
+
+    it "saves manifest file in a cache" do
+      FileUtils.rm_f("./tmp/2019-11-11_18-20-32_508hdr7srt-cor")
+
+      get :manifest, params: params
+      expect(File).to exist(cache_file)
+
+      response_values = JSON.parse(File.open(cache_file).read)
+
+      expect(response_values).to include "@context"
+      expect(response_values["@context"]).to include "http://iiif.io/api/presentation/2/context.json"
+      expect(response_values).to include "@type"
+      expect(response_values["@type"]).to include "sc:Manifest"
+      expect(response_values).to include "@id"
+      expect(response_values["@id"]).to include "/iiif/#{work.id}/manifest"
+      expect(response_values).to include "label"
+      expect(response_values["label"]).to include work.title.first.to_s
+      expect(response_values).to include "sequences"
+      expect(response_values["sequences"].first["@type"]).to include "sc:Sequence"
+      expect(response_values["sequences"].first["@id"]).to include "/iiif/#{work.id}/manifest/sequence/normal"
+      expect(response_values["sequences"].first["canvases"].first["@id"]).to include "/iiif/#{work.id}/manifest/canvas/#{file_set.id}"
+      expect(response_values["sequences"].first["canvases"].first["images"].first["resource"]["@id"]).to include
+      "/images/#{file_set.id}%2Ffiles%2F#{file_set.files.first.id.split('/').last}/full/600,/0/default.jpg"
     end
   end
 end


### PR DESCRIPTION
* When we load a work in lux for which a manifest isn't cached, it creates a shortened manifest. If we then delete that manifest, and load the same work in curate, the manifest is generated properly.
* Shortened manifest through lux might be because when lux calls the manifest method in the iiif_controller in curate (https://github.com/emory-libraries/dlp-curate/blob/master/app/controllers/iiif_controller.rb#L23), it creates an ability for the current_user (https://github.com/emory-libraries/dlp-curate/blob/master/app/controllers/iiif_controller.rb#L63). Since, lux might not know or pass the current_user, we get an incorrect manifest.