### PR TITLE
Adds metadata to manifest

### DIFF
--- a/app/presenters/hyrax/curate_generic_work_presenter.rb
+++ b/app/presenters/hyrax/curate_generic_work_presenter.rb
@@ -27,5 +27,13 @@ module Hyrax
         manifest_helper.polymorphic_url([:iiif_manifest], identifier: id)
       end
     end
+
+    def manifest_metadata
+      [
+        { "label" => "identifier", "value" => id },
+        { "label" => "Provided by", "value" => holding_repository },
+        { "label" => "Rights status", "value" => rights_statement }
+      ]
+    end
   end
 end

--- a/app/presenters/hyrax/curate_generic_work_presenter.rb
+++ b/app/presenters/hyrax/curate_generic_work_presenter.rb
@@ -30,9 +30,9 @@ module Hyrax
 
     def manifest_metadata
       [
-        { "label" => "identifier", "value" => id },
         { "label" => "Provided by", "value" => holding_repository },
-        { "label" => "Rights status", "value" => rights_statement }
+        { "label" => "Rights Status", "value" => rights_statement },
+        { "label" => "Identifier", "value" => id }
       ]
     end
   end

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -87,7 +87,9 @@ RSpec.describe IiifController, type: :controller do
         "has_model_ssim" => ["CurateGenericWork"],
         "date_created_tesim" => ['an unformatted date'],
         "date_modified_dtsi" => "2019-11-11T18:20:32Z",
-        "depositor_tesim" => 'example_user' }
+        "depositor_tesim" => 'example_user',
+        "holding_repository_tesim" => ["test holding repo"],
+        "rights_statement_tesim" => ["example.com"] }
     end
 
     before do
@@ -113,6 +115,13 @@ RSpec.describe IiifController, type: :controller do
       expect(response_values["@id"]).to include "/iiif/#{work.id}/manifest"
       expect(response_values).to include "label"
       expect(response_values["label"]).to include work.title.first.to_s
+      expect(response_values).to include "metadata"
+      expect(response_values["metadata"][0]["label"]).to eq "identifier"
+      expect(response_values["metadata"][0]["value"]).to eq work.id
+      expect(response_values["metadata"][1]["label"]).to eq "Provided by"
+      expect(response_values["metadata"][1]["value"]).to eq ["test holding repo"]
+      expect(response_values["metadata"][2]["label"]).to eq "Rights status"
+      expect(response_values["metadata"][2]["value"]).to eq ["example.com"]
       expect(response_values).to include "sequences"
       expect(response_values["sequences"].first["@type"]).to include "sc:Sequence"
       expect(response_values["sequences"].first["@id"]).to include "/iiif/#{work.id}/manifest/sequence/normal"

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -116,12 +116,12 @@ RSpec.describe IiifController, type: :controller do
       expect(response_values).to include "label"
       expect(response_values["label"]).to include work.title.first.to_s
       expect(response_values).to include "metadata"
-      expect(response_values["metadata"][0]["label"]).to eq "identifier"
-      expect(response_values["metadata"][0]["value"]).to eq work.id
-      expect(response_values["metadata"][1]["label"]).to eq "Provided by"
-      expect(response_values["metadata"][1]["value"]).to eq ["test holding repo"]
-      expect(response_values["metadata"][2]["label"]).to eq "Rights status"
-      expect(response_values["metadata"][2]["value"]).to eq ["example.com"]
+      expect(response_values["metadata"][0]["label"]).to eq "Provided by"
+      expect(response_values["metadata"][0]["value"]).to eq ["test holding repo"]
+      expect(response_values["metadata"][1]["label"]).to eq "Rights Status"
+      expect(response_values["metadata"][1]["value"]).to eq ["example.com"]
+      expect(response_values["metadata"][2]["label"]).to eq "Identifier"
+      expect(response_values["metadata"][2]["value"]).to eq work.id
       expect(response_values).to include "sequences"
       expect(response_values["sequences"].first["@type"]).to include "sc:Sequence"
       expect(response_values["sequences"].first["@id"]).to include "/iiif/#{work.id}/manifest/sequence/normal"

--- a/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
+++ b/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
       "human_readable_type_tesim" => ["Curate Generic Work"],
       "has_model_ssim" => ["CurateGenericWork"],
       "date_created_tesim" => ['an unformatted date'],
-      "depositor_tesim" => user_key }
+      "depositor_tesim" => user_key,
+      "holding_repository_tesim" => ["test holding repo"],
+      "rights_statement_tesim" => ["empl.com"] }
   end
 
   describe '#manifest_url' do
@@ -45,5 +47,12 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
 
       it { is_expected.to eq "http://example-curate/iiif/888888/manifest" }
     end
+  end
+
+  describe "#manifest_metadata" do
+    subject { presenter.manifest_metadata }
+    let(:presenter) { described_class.new(solr_document, ability) }
+
+    it { is_expected.to eq [{ "label" => "identifier", "value" => "888888" }, { "label" => "Provided by", "value" => ["test holding repo"] }, { "label" => "Rights status", "value" => ["empl.com"] }] }
   end
 end

--- a/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
+++ b/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
@@ -53,6 +53,6 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
     subject { presenter.manifest_metadata }
     let(:presenter) { described_class.new(solr_document, ability) }
 
-    it { is_expected.to eq [{ "label" => "identifier", "value" => "888888" }, { "label" => "Provided by", "value" => ["test holding repo"] }, { "label" => "Rights status", "value" => ["empl.com"] }] }
+    it { is_expected.to eq [{ "label" => "Provided by", "value" => ["test holding repo"] }, { "label" => "Rights Status", "value" => ["empl.com"] }, { "label" => "Identifier", "value" => "888888" }] }
   end
 end


### PR DESCRIPTION
* In this commit, we are adding metadata to work manifests that
get generated. Only selective metadata is added to the manifest.
* This will help when viewing works in lux, and will appear in
the more information tab in UV.

Example as seen in Lux:
![image](https://user-images.githubusercontent.com/17075287/75475274-80c2ae80-5966-11ea-9654-0e142df24cc9.png)
