### PR TITLE
 Limit deep zoom by limiting the region values

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,0 @@
-# Use local database auth instead of Shibboleth
-export DATABASE_AUTH=true

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ flycheck_*.el
 ## Environment normalization:
 /.bundle
 /vendor/bundle
+
+.env.development

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,7 @@ Metrics/ClassLength:
         - 'spec/**/*'
         - 'app/models/curate_generic_work.rb'
         - 'app/controllers/catalog_controller.rb'
+        - 'app/controllers/iiif_controller.rb'
         - 'app/actors/hyrax/actors/file_set_actor.rb'
         - 'app/forms/hyrax/forms/collection_form.rb'
         - app/uploaders/zizia/csv_manifest_validator.rb

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -119,6 +119,26 @@ RSpec.describe IiifController, type: :controller, clean: true do
         expect(response.has_header?('Access-Control-Allow-Origin')).to be_truthy
       end
     end
+
+    context "a request for anything larger than max region" do
+      let(:expected_iiif_url) { "http://127.0.0.1:8182/iiif/2/#{image_sha}/0,0,800,800/,400/0/default.jpg" }
+      let(:region) { "0,0,600,600" }
+      it "alters the iiif request to what is permitted" do
+        get :show, params: params
+        expect(assigns(:iiif_url)).to eq expected_iiif_url
+        expect(response.has_header?('Access-Control-Allow-Origin')).to be_truthy
+      end
+    end
+
+    context "a request for anything smaller than max region" do
+      let(:expected_iiif_url) { "http://127.0.0.1:8182/iiif/2/#{image_sha}/12,12,800,800/,400/0/default.jpg" }
+      let(:region) { "12,12,200,250" }
+      it "does not alter the iiif region param" do
+        get :show, params: params
+        expect(assigns(:iiif_url)).to eq expected_iiif_url
+        expect(response.has_header?('Access-Control-Allow-Origin')).to be_truthy
+      end
+    end
   end
 
   describe "#manifest" do


### PR DESCRIPTION
For low_res visibility images, do not allow region values that would
enable deepest levels of zooming.

Default value is 800 pixels. This can be adjusted via an environment
variable MIN_TILE_SIZE_FOR_LOW_RES.

Connected to https://github.com/emory-libraries/dlp-lux/issues/313