### PR TITLE
Adds persistent url to work show page and manifest

### DIFF
--- a/app/lib/curate_purl.rb
+++ b/app/lib/curate_purl.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# This module will be used to define persistent url
+# for works and collections
+module CuratePurl
+  def purl
+    "#{ENV['LUX_BASE_URL'] || ''}/purl/#{id}"
+  end
+end

--- a/app/lib/curate_purl.rb
+++ b/app/lib/curate_purl.rb
@@ -4,6 +4,6 @@
 # for works and collections
 module CuratePurl
   def purl
-    "#{ENV['LUX_BASE_URL'] || ''}/purl/#{id}"
+    "#{ENV['LUX_BASE_URL'] || 'localhost:3000'}/purl/#{id}"
   end
 end

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -6,6 +6,7 @@ module Hyrax
     include PresentsAttributes
     include ActionView::Helpers::NumberHelper
     include ActionView::Helpers::TagHelper
+    include CuratePurl
     attr_accessor :solr_document, :current_ability, :request
     attr_reader :subcollection_count
     attr_accessor :parent_collections # This is expected to be a Blacklight::Solr::Response with all of the parent collections

--- a/app/presenters/hyrax/curate_generic_work_presenter.rb
+++ b/app/presenters/hyrax/curate_generic_work_presenter.rb
@@ -8,6 +8,8 @@ module Hyrax
       delegate key.to_sym, to: :solr_document
     end
 
+    include CuratePurl
+
     # [Hyrax-overwrite] We might not always have a request and a `base_url`,
     # therfore, we are using our CurateManifestHelper and passing in a hardcoded
     # host for creation of manifest_url
@@ -32,7 +34,8 @@ module Hyrax
       [
         { "label" => "Provided by", "value" => holding_repository },
         { "label" => "Rights Status", "value" => rights_statement },
-        { "label" => "Identifier", "value" => id }
+        { "label" => "Identifier", "value" => id },
+        { "label" => "Persistent URL", "value" => "<a href=\"http://#{purl}\">#{purl}</a>" }
       ]
     end
   end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,3 +1,11 @@
+<!-- Persistent URL block start -->
+<div>
+  Persistent URL
+  <ul class="tabular">
+    <li><a href="http://<%= presenter.purl %>" target="_blank"><%= presenter.purl %></a></li>
+  </ul>
+</div>
+<!-- Persistent URL block end -->
 <% CurateGenericWorkAttributes.instance.attributes.each do |key| %>
   <% case key
      when 'content_type' %>

--- a/app/views/hyrax/collections/_show_descriptions.html.erb
+++ b/app/views/hyrax/collections/_show_descriptions.html.erb
@@ -1,0 +1,17 @@
+<!-- [Hyrax-overwrite] -->
+<!-- Persistent URL block start -->
+<div>
+  <b>Persistent URL</b>
+  <ul class="tabular">
+    <li><a href="http://<%= @presenter.purl %>" target="_blank"><%= @presenter.purl %></a></li>
+  </ul>
+</div>
+<!-- Persistent URL block end -->
+<dl>
+  <% present_terms(@presenter, @presenter.terms_with_values) do |r, term| %>
+    <div>
+      <dt><%= r.label(term) %></dt>
+      <dd><%= r.value(term) %></dd>
+    </div>
+  <% end %>
+</dl>

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -12,6 +12,9 @@ IIIF_SERVER_URL=
 # cached. Eg: "/full/path/to/directory"
 IIIF_MANIFEST_CACHE=
 
+# This variable will contain Lux's base URL. Eg: 'digital-test.library.emory.edu'
+LUX_BASE_URL=
+
 SIDEKIQ_WORKERS=
 
 RAILS_HOST=

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -144,6 +144,7 @@ RSpec.describe IiifController, type: :controller, clean: true do
       work.ordered_members << file_set
       work.save!
       allow(SolrDocument).to receive(:find).and_return(solr_document)
+      ENV['LUX_BASE_URL'] = 'empl.com'
     end
 
     it "saves manifest file in a cache" do
@@ -169,6 +170,8 @@ RSpec.describe IiifController, type: :controller, clean: true do
       expect(response_values["metadata"][1]["value"]).to eq ["example.com"]
       expect(response_values["metadata"][2]["label"]).to eq "Identifier"
       expect(response_values["metadata"][2]["value"]).to eq work.id
+      expect(response_values["metadata"][3]["label"]).to eq "Persistent URL"
+      expect(response_values["metadata"][3]["value"]).to eq "<a href=\"http://empl.com/purl/#{work.id}\">empl.com/purl/#{work.id}</a>"
       expect(response_values).to include "sequences"
       expect(response_values["sequences"].first["@type"]).to include "sc:Sequence"
       expect(response_values["sequences"].first["@id"]).to include "/iiif/#{work.id}/manifest/sequence/normal"

--- a/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
+++ b/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
@@ -49,10 +49,25 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
     end
   end
 
-  describe "#manifest_metadata" do
-    subject { presenter.manifest_metadata }
+  describe "instance methods" do
     let(:presenter) { described_class.new(solr_document, ability) }
 
-    it { is_expected.to eq [{ "label" => "Provided by", "value" => ["test holding repo"] }, { "label" => "Rights Status", "value" => ["empl.com"] }, { "label" => "Identifier", "value" => "888888" }] }
+    before do
+      ENV['LUX_BASE_URL'] = "empl.com"
+    end
+
+    describe "#manifest_metadata" do
+      subject { presenter.manifest_metadata }
+
+      it {
+        is_expected.to eq [{ "label" => "Provided by", "value" => ["test holding repo"] }, { "label" => "Rights Status", "value" => ["empl.com"] },
+                           { "label" => "Identifier", "value" => "888888" }, { "label" => "Persistent URL", "value" => "<a href=\"http://empl.com/purl/888888\">empl.com/purl/888888</a>" }]
+      }
+    end
+
+    describe "#purl" do
+      subject { presenter.purl }
+      it { is_expected.to eq "empl.com/purl/888888" }
+    end
   end
 end

--- a/spec/system/show_collection_spec.rb
+++ b/spec/system/show_collection_spec.rb
@@ -42,10 +42,12 @@ RSpec.describe 'viewing a collection', :clean, type: :system, js: true do
   before do
     private_work.member_of_collections = [collection]
     private_work.save!
+    ENV['LUX_BASE_URL'] = 'empl.com'
   end
 
   it 'has all the expected metadata fields' do
     visit "/collections/#{collection.id}"
+    expect(page).to have_content("empl.com/purl/#{collection.id}")
     expect(page).to have_content 'Robert Langmuir African American Photograph Collection'
     expect(page).to have_content 'Created by: Langmuir, Robert, collector'
     expect(page).to have_content 'Rose Library'


### PR DESCRIPTION
* Adds the persistent url pattern to the work and collection show page in
curate and also adds this to the manfiest metadata to be displayed
in the more info tab in lux.
* Lux base_url is added through an env variable.

Curate work show page:
![image](https://user-images.githubusercontent.com/17075287/75804951-e0e29780-5d4e-11ea-81db-2c71255bb726.png)

Lux more info tab:
![image](https://user-images.githubusercontent.com/17075287/75804973-e9d36900-5d4e-11ea-8a65-d29839fb22be.png)

Curate collection show page:
![image](https://user-images.githubusercontent.com/17075287/75804997-f5bf2b00-5d4e-11ea-99c4-4bb8ede5de38.png)

