### PR TITLE
Info json url

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -21,7 +21,15 @@ class IiifController < ApplicationController
     Rails.logger.info("Trying to proxy info from #{@iiif_url}")
     response.set_header('Access-Control-Allow-Origin', '*')
     @info_original = HTTP.get(@iiif_url).to_s
-    send_data HTTP.get(@iiif_url).body, type: 'application/json', x_sendfile: true, disposition: 'inline'
+    @info_public_iiif = rewrite_iiif_base_uri(@info_original)
+    send_data @info_public_iiif, type: 'application/json', x_sendfile: true, disposition: 'inline'
+  end
+
+  def rewrite_iiif_base_uri(info_original)
+    parsed_json = JSON.parse(info_original)
+    public_base_uri = "#{ENV['IIIF_SERVER_URL']}#{trailing_slash_fix}#{identifier}"
+    parsed_json["@id"] = public_base_uri
+    JSON.generate(parsed_json)
   end
 
   def iiif_url

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -20,6 +20,7 @@ class IiifController < ApplicationController
     @iiif_url = "#{ENV['PROXIED_IIIF_SERVER_URL']}#{trailing_slash_fix}#{identifier}/info.json"
     Rails.logger.info("Trying to proxy info from #{@iiif_url}")
     response.set_header('Access-Control-Allow-Origin', '*')
+    @info_original = HTTP.get(@iiif_url).to_s
     send_data HTTP.get(@iiif_url).body, type: 'application/json', x_sendfile: true, disposition: 'inline'
   end
 

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -41,14 +41,28 @@ RSpec.describe IiifController, type: :controller, clean: true do
   end
 
   describe "a request for info.json" do
+    before do
+      ENV['IIIF_MANIFEST_CACHE'] = Rails.root.join('tmp').to_s
+      ENV['PROXIED_IIIF_SERVER_URL'] = 'https://iiif-cor-arch.library.emory.edu/cantaloupe/iiif/2'
+      stub_request(:get, "https://iiif-cor-arch.library.emory.edu/cantaloupe/iiif/2/7f15795a197b389f6f2b0cb28362f777e1378f6f/info.json")
+        .with(
+          headers: {
+            'Connection' => 'close',
+            'Host' => 'iiif-cor-arch.library.emory.edu',
+            'User-Agent' => 'http.rb/4.3.0'
+          }
+        )
+        .to_return(status: 200, body: "", headers: {})
+    end
+    let(:image_sha) { "7f15795a197b389f6f2b0cb28362f777e1378f6f" }
     let(:params) do
       {
-        identifier: identifier,
+        identifier: image_sha,
         info:       "info",
         format:     "json"
       }
     end
-    let(:expected_iiif_url) { 'http://127.0.0.1:8182/iiif/2/508hdr7srt-cor/info.json' }
+    let(:expected_iiif_url) { 'https://iiif-cor-arch.library.emory.edu/cantaloupe/iiif/2/7f15795a197b389f6f2b0cb28362f777e1378f6f/info.json' }
     it "returns as json" do
       get :info, params: params
       expect(assigns(:iiif_url)).to eq expected_iiif_url

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe IiifController, type: :controller, clean: true do
     before do
       ENV['IIIF_MANIFEST_CACHE'] = Rails.root.join('tmp').to_s
       ENV['PROXIED_IIIF_SERVER_URL'] = 'https://iiif-cor-arch.library.emory.edu/cantaloupe/iiif/2'
+      ENV['IIIF_SERVER_URL'] = 'https://curate.library.emory.edu/iiif/2'
       stub_request(:get, "https://iiif-cor-arch.library.emory.edu/cantaloupe/iiif/2/7f15795a197b389f6f2b0cb28362f777e1378f6f/info.json")
         .with(
           headers: {
@@ -79,8 +80,15 @@ RSpec.describe IiifController, type: :controller, clean: true do
     it "returns valid json" do
       get :info, params: params
       expect(assigns(:info_original)).not_to be nil
-      foo_parsed = JSON.parse(assigns(:info_original))
-      expect(foo_parsed["@id"]).to eq 'https://iiif-cor-arch.library.emory.edu/cantaloupe/iiif/2/7f15795a197b389f6f2b0cb28362f777e1378f6f'
+      parsed_json_orig = JSON.parse(assigns(:info_original))
+      expect(parsed_json_orig["@id"]).to eq 'https://iiif-cor-arch.library.emory.edu/cantaloupe/iiif/2/7f15795a197b389f6f2b0cb28362f777e1378f6f'
+    end
+
+    it "changes json from Cantaloupe to have the public iiif url" do
+      get :info, params: params
+      expect(assigns(:info_public_iiif)).not_to be nil
+      parsed_json_public = JSON.parse(assigns(:info_public_iiif))
+      expect(parsed_json_public["@id"]).to eq 'https://curate.library.emory.edu/iiif/2/7f15795a197b389f6f2b0cb28362f777e1378f6f'
     end
   end
 

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -52,7 +52,11 @@ RSpec.describe IiifController, type: :controller, clean: true do
             'User-Agent' => 'http.rb/4.3.0'
           }
         )
-        .to_return(status: 200, body: "", headers: {})
+        .to_return(
+          status:  200,
+          body:    info_dot_json_from_cantaloupe,
+          headers: {}
+        )
     end
     let(:image_sha) { "7f15795a197b389f6f2b0cb28362f777e1378f6f" }
     let(:params) do
@@ -62,11 +66,21 @@ RSpec.describe IiifController, type: :controller, clean: true do
         format:     "json"
       }
     end
+    let(:info_dot_json_from_cantaloupe) do
+      File.open(Rails.root.join("spec", "fixtures", "iiif_responses", "info.json")).read
+    end
     let(:expected_iiif_url) { 'https://iiif-cor-arch.library.emory.edu/cantaloupe/iiif/2/7f15795a197b389f6f2b0cb28362f777e1378f6f/info.json' }
-    it "returns as json" do
+    it "constructs the info.json url correctly" do
       get :info, params: params
       expect(assigns(:iiif_url)).to eq expected_iiif_url
       expect(response.has_header?('Access-Control-Allow-Origin')).to be_truthy
+    end
+
+    it "returns valid json" do
+      get :info, params: params
+      expect(assigns(:info_original)).not_to be nil
+      foo_parsed = JSON.parse(assigns(:info_original))
+      expect(foo_parsed["@id"]).to eq 'https://iiif-cor-arch.library.emory.edu/cantaloupe/iiif/2/7f15795a197b389f6f2b0cb28362f777e1378f6f'
     end
   end
 

--- a/spec/fixtures/iiif_responses/info.json
+++ b/spec/fixtures/iiif_responses/info.json
@@ -1,0 +1,95 @@
+{
+  "@context": "http://iiif.io/api/image/2/context.json",
+  "@id": "https://iiif-cor-arch.library.emory.edu/cantaloupe/iiif/2/7f15795a197b389f6f2b0cb28362f777e1378f6f",
+  "protocol": "http://iiif.io/api/image",
+  "width": 11344,
+  "height": 4313,
+  "sizes": [
+    {
+      "width": 177,
+      "height": 67
+    },
+    {
+      "width": 355,
+      "height": 135
+    },
+    {
+      "width": 709,
+      "height": 270
+    },
+    {
+      "width": 1418,
+      "height": 539
+    },
+    {
+      "width": 2836,
+      "height": 1078
+    },
+    {
+      "width": 5672,
+      "height": 2157
+    },
+    {
+      "width": 11344,
+      "height": 4313
+    }
+  ],
+  "tiles": [
+    {
+      "width": 1418,
+      "height": 540,
+      "scaleFactors": [
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+        64
+      ]
+    }
+  ],
+  "profile": [
+    "http://iiif.io/api/image/2/level2.json",
+    {
+      "formats": [
+        "jpg",
+        "tif",
+        "bmp",
+        "gif",
+        "png",
+        "webp",
+        "jp2"
+      ],
+      "maxArea": 400000000,
+      "qualities": [
+        "bitonal",
+        "default",
+        "gray",
+        "color"
+      ],
+      "supports": [
+        "regionByPx",
+        "sizeByW",
+        "sizeByWhListed",
+        "cors",
+        "regionSquare",
+        "sizeByDistortedWh",
+        "sizeAboveFull",
+        "canonicalLinkHeader",
+        "sizeByConfinedWh",
+        "sizeByPct",
+        "jsonldMediaType",
+        "regionByPct",
+        "rotationArbitrary",
+        "sizeByH",
+        "baseUriRedirect",
+        "rotationBy90s",
+        "profileLinkHeader",
+        "sizeByForcedWh",
+        "sizeByWh",
+        "mirroring"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
UV was going directly to iiif-cor via the info.json, re-writing the info.json to make sure UV is only attempting to go via the Curate controller.

Note pixel height and width

Before 
![image](https://user-images.githubusercontent.com/45948126/75916270-08f0fa00-5e26-11ea-9377-6457cc32fc3c.png)

After
![image](https://user-images.githubusercontent.com/45948126/75916305-1d34f700-5e26-11ea-947f-459b43205343.png)

Before on left, after on right, subject's eye. After image is more pixelated / has less information
![image](https://user-images.githubusercontent.com/45948126/75916738-e4495200-5e26-11ea-9b88-6d00dcc83416.png)
