### PR TITLE
Adds a way to upload banner image for a collection

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller_override.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller_override.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module Hyrax
+  module Dashboard
+    module CollectionsControllerOverride
+      # [Hyrax-overwrite] We are overwriting the `add_new_banner` method because
+      # we are using the collection_banner (L#13) column in uploaded_files table
+      # instead of the default. Our uploaded_files table is different compared
+      # to Hyrax.
+      def add_new_banner(uploaded_file_ids)
+        f = uploaded_files(uploaded_file_ids).first
+        banner_info = CollectionBrandingInfo.new(
+          collection_id: @collection.id,
+          filename:      File.split(f.collection_banner_url).last,
+          role:          "banner",
+          alt_txt:       "",
+          target_url:    ""
+        )
+        banner_info.save f.collection_banner_url
+      end
+    end
+  end
+end

--- a/app/controllers/hyrax/uploads_controller.rb
+++ b/app/controllers/hyrax/uploads_controller.rb
@@ -13,6 +13,7 @@ module Hyrax
                              extracted_text:           params[:extracted_text],
                              transcript:               params[:transcript],
                              fileset_use:              params[:fileset_use],
+                             collection_banner:        params[:collection_banner],
                              user:                     current_user }
       @upload.save!
     end

--- a/app/models/hyrax/uploaded_file.rb
+++ b/app/models/hyrax/uploaded_file.rb
@@ -12,6 +12,7 @@ module Hyrax
     mount_uploader :intermediate_file, UploadedFileUploader
     mount_uploader :extracted_text, UploadedFileUploader
     mount_uploader :transcript, UploadedFileUploader
+    mount_uploader :collection_banner, UploadedFileUploader
     # mount_uploader :file, UploadedFileUploader
     # alias uploader file
     has_many :job_io_wrappers,

--- a/app/views/hyrax/dashboard/collections/_form_branding.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_branding.html.erb
@@ -1,0 +1,159 @@
+<!-- [Hyrax-overwrite] -->
+
+<!-- [Hyrax-overwrite] We are overwriting the `add_new_banner` method in collections 
+controller because we are using the collection_banner (L#25) column in uploaded_files
+table instead of the default. Our uploaded_files table is different compared
+to Hyrax. -->
+<div class="set-access-controls">
+  <h3><%= t('.branding.label') %></h3>
+  <p><%= t('.branding.description') %></p>
+  <label><strong><%= t('.banner.label') %></strong></label>
+  <p><%= t('.banner.description') %>.</p>
+
+  <div id="fileupload">
+    <!-- Redirect browsers with JavaScript disabled to the origin page -->
+    <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>" /></noscript>
+    <!-- The table listing the files available for upload/download -->
+
+    <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
+    <div class="row fileupload-buttonbar">
+      <div class="col-xs-4">
+        <!-- The fileinput-button span is used to style the file input field as button -->
+        <span class="btn btn-success fileinput-button">
+          <span class="glyphicon glyphicon-plus"></span>
+          <span>Choose File</span>
+          <input type="file" name="collection_banner" single />
+        </span>
+      </div> <!-- end col-xs-4 -->
+
+      <!-- The global progress state -->
+      <div class="col-xs-8 fileupload-progress branding-banner-progress fade">
+        <!-- The global progress bar -->
+        <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+          <div class="progress-bar progress-bar-success" style="width:0%;"></div>
+        </div>
+        <!-- The extended global progress state -->
+        <div class="progress-extended">&nbsp;</div>
+      </div> <!-- end col-xs-5 fileupload-progress fade -->
+    </div> <!-- end row fileupload-buttonbar -->
+
+    <div class="row branding-banner-list">
+      <div class="col-xs-12">
+        <div class="container">
+        <% if f.object.banner_info[:file] %>
+          <div id="banner">
+            <div class="row branding-banner-row">
+              <div class="col-sm-3">
+                <span class="name">
+                  <span><%= f.object.banner_info[:file] %></span>
+                  <input type="hidden" name="banner_unchanged" value="true" />
+                </span>
+              </div>
+
+              <div class="col-sm-2">
+                <button class="btn btn-danger delete branding-banner-remove" data-type="DELETE" data-url="/" onclick=$("#banner").remove();>
+                  <span class="glyphicon glyphicon-remove"></span>
+                  <span class="controls-remove-text">Remove</span>
+                  <span class="sr-only">
+                    previous
+                    <span class="controls-field-name-text">Remove Current Banner</span>
+                  </span>
+                </button>
+              </div> <!-- end col-sm-2 -->
+            </div> <!-- row branding-banner-row -->
+
+            <% if f.object.banner_info[:relative_path] %>
+            <div class="banner-image">
+              <i><%= image_tag(f.object.banner_info[:relative_path],
+                               size: "800x100",
+                               alt: "Unable to display banner: #{f.object.banner_info[:file]}") %></i>
+            </div>
+            <% end %>
+          </div> <!-- end banner -->
+          <div role="presentation" class="table table-striped"><span class="files"></span></div>
+        <% else %>
+          <div role="presentation" class="table table-striped"><span class="files"></span></div>
+        <% end %>
+
+          <!-- The global file processing state -->
+          <span class="fileupload-process"></span>
+        </div> <!-- end container -->
+      </div> <!-- end row branding-banner-list -->
+    </div> <!-- end row branding-banner-list -->
+  </div> <!-- fileupload -->
+
+  <%= render 'hyrax/uploads/js_templates_branding' %>
+
+  <label><strong><%= t('.logo.label') %></strong></label>
+  <p><%= t('.logo.description') %></p>
+
+  <div id="fileuploadlogo">
+    <!-- Redirect browsers with JavaScript disabled to the origin page -->
+    <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>" /></noscript>
+    <!-- The table listing the files available for upload/download -->
+
+    <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
+    <div class="row fileupload-buttonbar">
+      <div class="col-xs-4">
+        <!-- The fileinput-button span is used to style the file input field as button -->
+        <span class="btn btn-success fileinput-button">
+          <span class="glyphicon glyphicon-plus"></span>
+          <span>Choose File</span>
+          <input type="file" name="files[]" single />
+        </span>
+      </div> <!-- end col-xs-4 -->
+
+      <!-- The global progress state -->
+      <div class="col-xs-8 fileupload-progress branding-logo-progress fade">
+        <!-- The global progress bar -->
+        <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+          <div class="progress-bar progress-bar-success" style="width:0%;"></div>
+        </div>
+        <!-- The extended global progress state -->
+        <div class="progress-extended">&nbsp;</div>
+      </div> <!-- end col-xs-8 fileupload-progress branding-logo-progress fade -->
+    </div> <!-- end row fileupload-buttonbar -->
+
+    <div class="row branding-logo-list">
+      <div class="col-xs-12">
+        <div class="container">
+          <% i = 0 %>
+          <% f.object.logo_info.each_with_index do |linfo, i| %>
+            <div class="row branding-logo-row" id="logorow_<%= i %>">
+              <div class="col-sm-3">
+                <span class="name">
+                  <span><%= linfo[:file] %></span>
+                <input type="hidden" name="logo_files[]" value="<%= linfo[:full_path] %>" />
+                </span>
+              </div>
+
+              <div class="col-sm-4 branding-logo-input">
+                <label for="linkurl_<%= i %>">Link URL:
+                  <input id="linkurl_<%= i %>" class="branding-logo-input" type="text" name="linkurl[]" value="<%= linfo[:linkurl] %>" />
+                </label>
+                <label for="alttext_<%= i %>">Alt Text:
+                  <input id="alttext_<%= i %>" class="branding-logo-input" type="text" name="alttext[]" value="<%= linfo[:alttext] %>" />
+                </label>
+              </div>
+
+              <div class="col-sm-2">
+                <button class="btn btn-danger delete branding-logo-remove" data-type="DELETE" data-url="/" onclick=$("#logorow_<%= i %>").remove();>
+                  <span class="glyphicon glyphicon-remove"></span>
+                  <span class="controls-remove-text">Remove</span>
+                   <span class="sr-only">
+                    previous
+                    <span class="controls-field-name-text">Remove Logo <%= i + 1 %></span>
+                  </span>
+                </button>
+              </div> <!-- end col-sm-2 -->
+            </div> <!-- row logorow -->
+          <% end %>
+          <span class="files"></span>
+        </div> <!-- end container -->
+
+        <!-- The global file processing state -->
+        <span class="fileupload-process"></span>
+      </div> <!-- end col-xs-12 -->
+    </div> <!-- end row branding-logo-list -->
+  </div> <!-- end fileuploadlogo -->
+</div> <!-- end set-access-controls -->

--- a/app/views/hyrax/uploads/create.json.jbuilder
+++ b/app/views/hyrax/uploads/create.json.jbuilder
@@ -11,6 +11,7 @@ json.files [@upload] do |uploaded_file|
   # TODO: implement these
   # json.url  "/uploads/#{uploaded_file.id}"
   # json.thumbnail_url uploaded_file.id
+  json.name uploaded_file.collection_banner.file.filename if uploaded_file.collection_banner.file.present?
   json.deleteUrl hyrax.uploaded_file_path(uploaded_file)
   json.deleteType 'DELETE'
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,8 @@ module DlpCurate
     # -- all .rb files in that directory are automatically loaded.
     config.active_job.queue_adapter = :sidekiq
     config.autoload_paths += %W[#{config.root}/lib]
+    config.to_prepare do
+      Hyrax::Dashboard::CollectionsController.prepend Hyrax::Dashboard::CollectionsControllerOverride
+    end
   end
 end

--- a/db/migrate/20200312194124_add_banner_to_uploaded_files.rb
+++ b/db/migrate/20200312194124_add_banner_to_uploaded_files.rb
@@ -1,0 +1,5 @@
+class AddBannerToUploadedFiles < ActiveRecord::Migration[5.1]
+  def change
+    add_column :uploaded_files, :collection_banner, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -497,6 +497,7 @@ ActiveRecord::Schema.define(version: 201901241536542) do
     t.string "extracted_text"
     t.string "transcript"
     t.string "fileset_use"
+    t.string "collection_banner"
     t.index ["file_set_uri"], name: "index_uploaded_files_on_file_set_uri"
     t.index ["user_id"], name: "index_uploaded_files_on_user_id"
   end

--- a/spec/controllers/hyrax/uploads_controller_spec.rb
+++ b/spec/controllers/hyrax/uploads_controller_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# [Hyrax-overwrite]
+require 'rails_helper'
+
+RSpec.describe Hyrax::UploadsController do
+  routes { Hyrax::Engine.routes }
+
+  let(:user) { FactoryBot.create(:user) }
+
+  describe "#create" do
+    let(:file)  { fixture_file_upload('/world.png', 'image/png') }
+    let(:file2) { fixture_file_upload('/sun.png', 'image/png') }
+
+    context "when signed in" do
+      before do
+        sign_in user
+      end
+      it "is successful with pmf" do
+        post :create, params: { preservation_master_file: file, format: 'json' }
+        expect(response).to be_success
+        expect(assigns(:upload)).to be_kind_of Hyrax::UploadedFile
+        expect(assigns(:upload)).to be_persisted
+        expect(assigns(:upload).user).to eq user
+        expect(assigns(:upload).preservation_master_file.file.original_filename).to eq 'world.png'
+      end
+      it "is successful with collection_banner" do
+        post :create, params: { collection_banner: file2, format: 'json' }
+        expect(assigns(:upload)).to be_kind_of Hyrax::UploadedFile
+        expect(assigns(:upload)).to be_persisted
+        expect(assigns(:upload).user).to eq user
+        expect(assigns(:upload).collection_banner.file.original_filename).to eq 'sun.png'
+      end
+    end
+
+    context "when not signed in" do
+      it "is unauthorized" do
+        post :create, params: { files: [file], format: 'json' }
+        expect(response.status).to eq 401
+      end
+    end
+  end
+end

--- a/spec/system/edit_collection_spec.rb
+++ b/spec/system/edit_collection_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Edit an existing collection', :clean, type: :system, js: true do
   context 'logged in as an admin user' do
     before { login_as admin }
 
-    scenario 'successfully edits the work' do
+    scenario 'successfully edits the collection' do
       visit "/dashboard/collections/#{collection.id}/edit"
       expect(find_field('title (Title)').value).to eq 'Robert Langmuir African American Photograph Collection'
       expect(find_field('holding_repository (Library)').value).to eq 'Stuart A. Rose Manuscript, Archives, and Rare Book Library'
@@ -60,6 +60,16 @@ RSpec.describe 'Edit an existing collection', :clean, type: :system, js: true do
       # Now the form should have the new values
       expect(page).to have_content 'New Title'
       expect(page).to have_content file_set.id
+    end
+
+    scenario 'successfully uploads a banner image' do
+      visit "/dashboard/collections/#{collection.id}/edit"
+      expect(page).to have_link('Branding', href: '#branding')
+      click_on 'Branding'
+      attach_file("collection_banner", (fixture_path + '/balloon.jpeg'), visible: false)
+      expect(find("input[name='banner_files[]']", visible: false).value).to eq '1'
+      click_on 'Save changes'
+      expect(page).to have_content 'balloon.jpeg'
     end
   end
 end


### PR DESCRIPTION
* This commit enables uploading a banner image for a collection and
saving it. Since we have changed the uploaded_files table provided by
hyrax, we need to add a new column to the table called `collection_banner`
that will be used to upload a file using carrierwave.
* We are also overwriting the `add_new_banner` method because we need to
reference `collection_banner_url` instead of the default provided by
hyrax.

Collection edit:
![image](https://user-images.githubusercontent.com/17075287/76885503-b6680280-6855-11ea-81c8-5144ddf514ae.png)

Collection show page:
![image](https://user-images.githubusercontent.com/17075287/76885526-c08a0100-6855-11ea-8733-2fe0b6f43ef2.png)
