### PR TITLE
Add new env var and capistrano task to fix banner persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ flycheck_*.el
 /vendor/bundle
 
 .env.development
+
+# ignore branding path
+public/branding

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -10,6 +10,7 @@ set :rails_env, 'production'
 set :assets_prefix, "#{shared_path}/public/assets"
 set :migration_role, :app
 set :service_unit_name, "sidekiq.service"
+set :passenger_restart_with_touch, true
 
 SSHKit.config.command_map[:rake] = 'bundle exec rake'
 set :branch, ENV['REVISION'] || ENV['BRANCH'] || ENV['BRANCH_NAME'] || 'master'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -101,14 +101,14 @@ namespace :deploy do
 end
 
 namespace :deploy do
-  desc "Add symblink for branding folder when variable is defined"
-  before :finishing, :create_branding_path_symblink do
+  desc "Add symlink for branding folder when variable is defined"
+  before :finishing, :create_branding_path_symlink do
     on roles(:app) do
-      symblink_path = fetch(:branding_symblink_path, 'unset')
-      if symblink_path != 'unset'
-        execute "ln -sf #{symblink_path} #{release_path}/public"
+      symlink_path = fetch(:branding_symlink_path, 'unset')
+      if symlink_path != 'unset'
+        execute "ln -sf #{symlink_path} #{release_path}/public"
       else
-        puts "branding_symblink_path is unset, skipping task *create_branding_path_symblink*"
+        puts "branding_symlink_path is unset, skipping task *create_branding_path_symlink*"
       end
     end
   end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -102,7 +102,7 @@ end
 namespace :deploy do
   desc "Add symblink for branding folder when variable is defined"
   after :finishing, :create_branding_path_symblink do
-    execute "ln -sf #{branding_symblink_path} #{release_path}/public"
+    execute "ln -sf #{fetch(:branding_symblink_path)} #{release_path}/public"
   end
 end
 # Default branch is :master

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -112,8 +112,6 @@ namespace :deploy do
     end
   end
 end
-
-
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -101,11 +101,10 @@ end
 
 namespace :deploy do
   desc "Add symblink for branding folder when variable is defined"
-  after :finishing do
+  after :finishing, :create_branding_path_symblink do
     execute "ln -sf #{branding_symblink_path} #{release_path}/public"
   end
 end
-
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -107,7 +107,7 @@ namespace :deploy do
       if symblink_path != 'unset'
         execute "ln -sf #{symblink_path} #{release_path}/public"
       else
-        logger.debug "branding_symblink_path is unset, skipping task"
+        puts "branding_symblink_path is unset, skipping task *create_branding_path_symblink*"
       end
     end
   end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -108,7 +108,7 @@ namespace :deploy do
       if symlink_path != 'unset'
         execute "ln -sf #{symlink_path} #{release_path}/public"
       else
-        puts "branding_symlink_path is unset, skipping task *create_branding_path_symlink*"
+        Rails.logger.debug "branding_symlink_path is unset, skipping task *create_branding_path_symlink*"
       end
     end
   end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -99,7 +99,7 @@ namespace :deploy do
   end
 end
 
-if exists?(:branding_symblink_path)
+if fetch(:branding_symblink_path)
   namespace :deploy do
     desc "Add symblink for branding folder when variable is defined"
     before :finishing, :create_branding_path_symblink do

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -102,9 +102,12 @@ end
 namespace :deploy do
   desc "Add symblink for branding folder when variable is defined"
   after :finishing, :create_branding_path_symblink do
-    execute "ln -sf #{fetch(:branding_symblink_path)} #{release_path}/public"
+    on roles(:app) do
+      execute "ln -sf #{fetch(:branding_symblink_path)} #{release_path}/public"
+    end
   end
 end
+
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -108,7 +108,7 @@ namespace :deploy do
       if symlink_path != 'unset'
         execute "ln -sf #{symlink_path} #{release_path}/public"
       else
-        Rails.logger.debug "branding_symlink_path is unset, skipping task *create_branding_path_symlink*"
+        info "branding_symlink_path is unset, skipping task *create_branding_path_symlink*"
       end
     end
   end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -99,11 +99,13 @@ namespace :deploy do
   end
 end
 
-namespace :deploy do
-  desc "Add symblink for branding folder when variable is defined"
-  after :finishing, :create_branding_path_symblink do
-    on roles(:app) do
-      execute "ln -sf #{fetch(:branding_symblink_path)} #{release_path}/public"
+if exists?(:branding_symblink_path)
+  namespace :deploy do
+    desc "Add symblink for branding folder when variable is defined"
+    before :finishing, :create_branding_path_symblink do
+      on roles(:app) do
+        execute "ln -sf #{fetch(:branding_symblink_path)} #{release_path}/public"
+      end
     end
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -99,16 +99,20 @@ namespace :deploy do
   end
 end
 
-if fetch(:branding_symblink_path)
-  namespace :deploy do
-    desc "Add symblink for branding folder when variable is defined"
-    before :finishing, :create_branding_path_symblink do
-      on roles(:app) do
-        execute "ln -sf #{fetch(:branding_symblink_path)} #{release_path}/public"
+namespace :deploy do
+  desc "Add symblink for branding folder when variable is defined"
+  before :finishing, :create_branding_path_symblink do
+    on roles(:app) do
+      symblink_path = fetch(:branding_symblink_path, 'unset')
+      if symblink_path != 'unset'
+        execute "ln -sf #{symblink_path} #{release_path}/public"
+      else
+        logger.debug "branding_symblink_path is unset, skipping task"
       end
     end
   end
 end
+
 
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -99,6 +99,13 @@ namespace :deploy do
   end
 end
 
+namespace :deploy do
+  desc "Add symblink for branding folder when variable is defined"
+  after :finishing do
+    execute "ln -sf #{branding_symblink_path} #{release_path}/public"
+  end
+end
+
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 

--- a/config/deploy/arch.rb
+++ b/config/deploy/arch.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 set :stage, :ARCH
-set :honeybadger_env, "curate-arch"
-set :branding_symblink_path, "/mnt/arch_efs/uploads/dlp-curate/branding/"
+set :honeybadger_env, 'curate-arch'
+set :branding_symblink_path, '/mnt/arch_efs/uploads/dlp-curate/branding/'
+
 ec2_role [:web, :app, :db, :redhatapp, :collection],
          user:        'deploy',
          ssh_options: {

--- a/config/deploy/arch.rb
+++ b/config/deploy/arch.rb
@@ -2,7 +2,7 @@
 
 set :stage, :ARCH
 set :honeybadger_env, 'curate-arch'
-set :branding_symblink_path, '/mnt/arch_efs/uploads/dlp-curate/branding/'
+set :branding_symblink_path, '/mnt/arch_efs/uploads/dlp-curate/branding'
 
 ec2_role [:web, :app, :db, :redhatapp, :collection],
          user:        'deploy',

--- a/config/deploy/arch.rb
+++ b/config/deploy/arch.rb
@@ -2,7 +2,7 @@
 
 set :stage, :ARCH
 set :honeybadger_env, 'curate-arch'
-set :branding_symblink_path, '/mnt/arch_efs/uploads/dlp-curate/branding'
+set :branding_symlink_path, '/mnt/arch_efs/uploads/dlp-curate/branding'
 
 ec2_role [:web, :app, :db, :redhatapp, :collection],
          user:        'deploy',

--- a/config/deploy/arch.rb
+++ b/config/deploy/arch.rb
@@ -2,7 +2,7 @@
 
 set :stage, :ARCH
 set :honeybadger_env, "curate-arch"
-
+set :branding_symblink_path, "/mnt/arch_efs/uploads/dlp-curate/branding/"
 ec2_role [:web, :app, :db, :redhatapp, :collection],
          user:        'deploy',
          ssh_options: {

--- a/config/deploy/localhost.rb
+++ b/config/deploy/localhost.rb
@@ -1,2 +1,4 @@
 # frozen_string_literal: true
+
+set :branding_symblink_path, ENV['BRANDING_SYMBLINK_PATH'] || 'unset'
 server '127.0.0.1', user: 'deploy', roles: [:web, :app, :db, :redhatapp, :collection]

--- a/config/deploy/localhost.rb
+++ b/config/deploy/localhost.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-set :branding_symblink_path, ENV['BRANDING_SYMBLINK_PATH'] || 'unset'
+set :branding_symlink_path, ENV['BRANDING_SYMLINK_PATH'] || 'unset'
 server '127.0.0.1', user: 'deploy', roles: [:web, :app, :db, :redhatapp, :collection]

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 set :stage, :PROD
-set :honeybadger_env, "curate"
+set :honeybadger_env, 'curate'
+set :branding_symblink_path, '/mnt/prod_efs/uploads/dlp-curate/branding/'
 
 ec2_role [:web, :app, :db, :redhatapp, :collection],
          user:        'deploy',

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -2,7 +2,7 @@
 
 set :stage, :PROD
 set :honeybadger_env, 'curate'
-set :branding_symblink_path, '/mnt/prod_efs/uploads/dlp-curate/branding/'
+set :branding_symblink_path, '/mnt/prod_efs/uploads/dlp-curate/branding'
 
 ec2_role [:web, :app, :db, :redhatapp, :collection],
          user:        'deploy',

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -2,7 +2,7 @@
 
 set :stage, :PROD
 set :honeybadger_env, 'curate'
-set :branding_symblink_path, '/mnt/prod_efs/uploads/dlp-curate/branding'
+set :branding_symlink_path, '/mnt/prod_efs/uploads/dlp-curate/branding'
 
 ec2_role [:web, :app, :db, :redhatapp, :collection],
          user:        'deploy',

--- a/config/deploy/test.rb
+++ b/config/deploy/test.rb
@@ -2,7 +2,7 @@
 
 set :stage, :TEST
 set :honeybadger_env, 'curate-test'
-set :branding_symblink_path, '/mnt/test_efs/uploads/dlp-curate/branding'
+set :branding_symlink_path, '/mnt/test_efs/uploads/dlp-curate/branding'
 
 ec2_role [:web, :app, :db, :redhatapp, :collection],
          user:        'deploy',

--- a/config/deploy/test.rb
+++ b/config/deploy/test.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 set :stage, :TEST
-set :honeybadger_env, "curate-test"
+set :honeybadger_env, 'curate-test'
+set :branding_symblink_path, '/mnt/test_efs/uploads/dlp-curate/branding/'
 
 ec2_role [:web, :app, :db, :redhatapp, :collection],
          user:        'deploy',

--- a/config/deploy/test.rb
+++ b/config/deploy/test.rb
@@ -2,7 +2,7 @@
 
 set :stage, :TEST
 set :honeybadger_env, 'curate-test'
-set :branding_symblink_path, '/mnt/test_efs/uploads/dlp-curate/branding/'
+set :branding_symblink_path, '/mnt/test_efs/uploads/dlp-curate/branding'
 
 ec2_role [:web, :app, :db, :redhatapp, :collection],
          user:        'deploy',

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -208,6 +208,9 @@ Hyrax.config do |config|
   # If you use a multi-server architecture, this MUST be a shared volume
   config.derivatives_path = ENV['DERIVATIVES_PATH'] || Rails.root.join('tmp', 'derivatives')
 
+  # Location where collection banner images will be saved after upload
+  config.branding_path = ENV['BRANDING_PATH'] || Rails.root.join('public', 'branding')
+
   # Should schema.org microdata be displayed?
   # config.display_microdata = true
 


### PR DESCRIPTION
This branch will add a new optional environment variable called BRANDING_PATH, this will control where curate save banners and other branding images after the ingest process. Additionally, an optional capistrano variable called branding_symlink_path will create a symlink at public/branding to where the path is defined.