### PR TITLE
X forwarded for

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -32,6 +32,14 @@ class IiifController < ApplicationController
   end
 
   def user_ip
+    Rails.logger.info "-----------------------------------------------------------------------------------"
+    Rails.logger.info "X-Forwarded-For"
+    Rails.logger.info request.headers["X-Forwarded-For"]
+    Rails.logger.info "REMOTE_ADDR"
+    Rails.logger.info request.headers["REMOTE_ADDR"]
+    Rails.logger.info request.headers
+    Rails.logger.info "-----------------------------------------------------------------------------------"
+
     if request.headers["X-Forwarded-For"]
       request.headers["X-Forwarded-For"]
     elsif request.headers["REMOTE_ADDR"]

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -28,8 +28,15 @@ class IiifController < ApplicationController
   end
 
   def check_ip
-    user_ip = request.headers["REMOTE_ADDR"]
     rose_reading_room_ips.include? user_ip
+  end
+
+  def user_ip
+    if request.headers["X-Forwarded-For"]
+      request.headers["X-Forwarded-For"]
+    elsif request.headers["REMOTE_ADDR"]
+      request.headers["REMOTE_ADDR"]
+    end
   end
 
   def rose_reading_room_ips

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -29,14 +29,13 @@ class IiifController < ApplicationController
 
   def user_ip_rose_reading_room?
     rose_reading_room_ips.include? user_ip
+  rescue
+    false
   end
 
   def user_ip
-    if request.headers["X-Forwarded-For"]
-      request.headers["X-Forwarded-For"]
-    elsif request.headers["REMOTE_ADDR"]
-      request.headers["REMOTE_ADDR"]
-    end
+    return request.headers["X-Forwarded-For"] if request.headers["X-Forwarded-For"]
+    return request.headers["REMOTE_ADDR"] if request.headers["REMOTE_ADDR"]
   end
 
   def rose_reading_room_ips

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -10,6 +10,11 @@ class IiifController < ApplicationController
   end
 
   def show
+    Rails.logger.info "-----------------------------------------------------------------------------------"
+    Rails.logger.info visibility
+    Rails.logger.info request.headers
+    Rails.logger.info "-----------------------------------------------------------------------------------"
+
     case visibility
     when "open", "low_res"
       return send_image

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -20,14 +20,22 @@ class IiifController < ApplicationController
       return head :forbidden unless current_user&.admin?
       send_image
     when "rose_high"
-      return head :forbidden unless check_ip || current_user&.admin?
+      Rails.logger.info "-----------------------------------------------------------------------------------"
+      Rails.logger.info "X-Forwarded-For"
+      Rails.logger.info request.headers["X-Forwarded-For"]
+      Rails.logger.info "REMOTE_ADDR"
+      Rails.logger.info request.headers["REMOTE_ADDR"]
+      Rails.logger.info request.headers
+      Rails.logger.info "-----------------------------------------------------------------------------------"
+
+      return head :forbidden unless user_ip_rose_reading_room? # || current_user&.admin?
       send_image
     else
       head :forbidden
     end
   end
 
-  def check_ip
+  def user_ip_rose_reading_room?
     rose_reading_room_ips.include? user_ip
   end
 

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -10,11 +10,6 @@ class IiifController < ApplicationController
   end
 
   def show
-    Rails.logger.info "-----------------------------------------------------------------------------------"
-    Rails.logger.info visibility
-    Rails.logger.info request.headers
-    Rails.logger.info "-----------------------------------------------------------------------------------"
-
     case visibility
     when "open", "low_res"
       return send_image
@@ -25,15 +20,7 @@ class IiifController < ApplicationController
       return head :forbidden unless current_user&.admin?
       send_image
     when "rose_high"
-      Rails.logger.info "-----------------------------------------------------------------------------------"
-      Rails.logger.info "X-Forwarded-For"
-      Rails.logger.info request.headers["X-Forwarded-For"]
-      Rails.logger.info "REMOTE_ADDR"
-      Rails.logger.info request.headers["REMOTE_ADDR"]
-      Rails.logger.info request.headers
-      Rails.logger.info "-----------------------------------------------------------------------------------"
-
-      return head :forbidden unless user_ip_rose_reading_room? # || current_user&.admin?
+      return head :forbidden unless user_ip_rose_reading_room? || current_user&.admin?
       send_image
     else
       head :forbidden
@@ -45,14 +32,6 @@ class IiifController < ApplicationController
   end
 
   def user_ip
-    Rails.logger.info "-----------------------------------------------------------------------------------"
-    Rails.logger.info "X-Forwarded-For"
-    Rails.logger.info request.headers["X-Forwarded-For"]
-    Rails.logger.info "REMOTE_ADDR"
-    Rails.logger.info request.headers["REMOTE_ADDR"]
-    Rails.logger.info request.headers
-    Rails.logger.info "-----------------------------------------------------------------------------------"
-
     if request.headers["X-Forwarded-For"]
       request.headers["X-Forwarded-For"]
     elsif request.headers["REMOTE_ADDR"]

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -15,7 +15,7 @@ SSHKit.config.command_map[:rake] = 'bundle exec rake'
 set :branch, ENV['REVISION'] || ENV['BRANCH'] || ENV['BRANCH_NAME'] || 'master'
 
 append :linked_dirs, "log", "public/assets", "tmp/pids", "tmp/cache", "tmp/sockets", "config/emory/groups", "tmp/csv_uploads", "tmp/csv_uploads_cache"
-append :linked_files, ".env.production", "config/secrets.yml"
+append :linked_files, ".env.production", "config/secrets.yml",  "config/reading_room_ips.yml"
 
 set :default_env,
     PATH:                            '$PATH:/opt/rh/rh-ruby25/root/usr/local/bin:/opt/rh/rh-ruby25/root/usr/bin',

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -15,7 +15,7 @@ SSHKit.config.command_map[:rake] = 'bundle exec rake'
 set :branch, ENV['REVISION'] || ENV['BRANCH'] || ENV['BRANCH_NAME'] || 'master'
 
 append :linked_dirs, "log", "public/assets", "tmp/pids", "tmp/cache", "tmp/sockets", "config/emory/groups", "tmp/csv_uploads", "tmp/csv_uploads_cache"
-append :linked_files, ".env.production", "config/secrets.yml",  "config/reading_room_ips.yml"
+append :linked_files, ".env.production", "config/secrets.yml", "config/reading_room_ips.yml"
 
 set :default_env,
     PATH:                            '$PATH:/opt/rh/rh-ruby25/root/usr/local/bin:/opt/rh/rh-ruby25/root/usr/bin',

--- a/spec/requests/iiif_requests_spec.rb
+++ b/spec/requests/iiif_requests_spec.rb
@@ -228,14 +228,14 @@ RSpec.describe "IIIF requests", :clean, type: :request, iiif: true do
       end
 
       context "within the Rose Reading Room" do
-        it "returns the image for a work with 'Rose High View' visibility" do
+        it "returns the image for a work with 'Rose High View' visibility with Remote Address" do
           get("/iiif/2/#{image_sha}/#{region}/#{size}/#{rotation}/#{quality}.#{format}", headers: { "REMOTE_ADDR": reading_room_ip })
 
           expect(request.headers["REMOTE_ADDR"]).to eq reading_room_ip
           expect(response.status).to eq 200
         end
 
-        it "returns the image for a work with 'Rose High View' visibility" do
+        it "returns the image for a work with 'Rose High View' visibility with X-Forwarded-For" do
           get("/iiif/2/#{image_sha}/#{region}/#{size}/#{rotation}/#{quality}.#{format}", headers: { "X-Forwarded-For": reading_room_ip })
 
           expect(request.headers["X-Forwarded-For"]).to eq reading_room_ip
@@ -244,13 +244,13 @@ RSpec.describe "IIIF requests", :clean, type: :request, iiif: true do
       end
 
       context "not in the Rose Reading Room" do
-        it "does not return the image for a work with 'Rose High View' visibility" do
+        it "does not return the image for a work with 'Rose High View' visibility with Remote Address" do
           get("/iiif/2/#{image_sha}/#{region}/#{size}/#{rotation}/#{quality}.#{format}", headers: { "REMOTE_ADDR": non_reading_room_ip })
           expect(response.status).to eq 403
           expect(response.body).to be_empty
         end
 
-        it "does not return the image for a work with 'Rose High View' visibility" do
+        it "does not return the image for a work with 'Rose High View' visibility with X-Forwarded-For" do
           get("/iiif/2/#{image_sha}/#{region}/#{size}/#{rotation}/#{quality}.#{format}", headers: { "X-Forwarded-For": non_reading_room_ip })
           expect(response.status).to eq 403
           expect(response.body).to be_empty
@@ -260,7 +260,7 @@ RSpec.describe "IIIF requests", :clean, type: :request, iiif: true do
       context "a Curate admin not in the Rose reading room" do
         let(:admin_user) { FactoryBot.create(:admin) }
 
-        it "does return the image for a work with 'Rose High View' visibility" do
+        it "does return the image for a work with 'Rose High View' visibility with Remote Address" do
           login_as admin_user
           get("/iiif/2/#{image_sha}/#{region}/#{size}/#{rotation}/#{quality}.#{format}", headers: { "REMOTE_ADDR": non_reading_room_ip })
           expect(response.status).to eq 200

--- a/spec/requests/iiif_requests_spec.rb
+++ b/spec/requests/iiif_requests_spec.rb
@@ -234,11 +234,24 @@ RSpec.describe "IIIF requests", :clean, type: :request, iiif: true do
           expect(request.headers["REMOTE_ADDR"]).to eq reading_room_ip
           expect(response.status).to eq 200
         end
+
+        it "returns the image for a work with 'Rose High View' visibility" do
+          get("/iiif/2/#{image_sha}/#{region}/#{size}/#{rotation}/#{quality}.#{format}", headers: { "X-Forwarded-For": reading_room_ip })
+
+          expect(request.headers["X-Forwarded-For"]).to eq reading_room_ip
+          expect(response.status).to eq 200
+        end
       end
 
       context "not in the Rose Reading Room" do
         it "does not return the image for a work with 'Rose High View' visibility" do
           get("/iiif/2/#{image_sha}/#{region}/#{size}/#{rotation}/#{quality}.#{format}", headers: { "REMOTE_ADDR": non_reading_room_ip })
+          expect(response.status).to eq 403
+          expect(response.body).to be_empty
+        end
+
+        it "does not return the image for a work with 'Rose High View' visibility" do
+          get("/iiif/2/#{image_sha}/#{region}/#{size}/#{rotation}/#{quality}.#{format}", headers: { "X-Forwarded-For": non_reading_room_ip })
           expect(response.status).to eq 403
           expect(response.body).to be_empty
         end


### PR DESCRIPTION
Per Emory middleware, need to include X-Forwarded-For headers to capture user's IP address for "Rose High View" IP restrictions, rather than the Load Balancer's IP address.