### PR TITLE
Indexes banner path to the Solr query.

### DIFF
--- a/app/indexers/curate_collection_indexer.rb
+++ b/app/indexers/curate_collection_indexer.rb
@@ -22,7 +22,7 @@ class CurateCollectionIndexer < Hyrax::CollectionIndexer
 
   def banner_path
     cbi = branding_details
-    cbi.nil? || cbi&.local_path&.nil? ? '' : path_sanitized(cbi.local_path)
+    path_sanitized(cbi.local_path) unless cbi.nil? || cbi&.local_path&.nil?
   end
 
   def branding_details
@@ -30,6 +30,12 @@ class CurateCollectionIndexer < Hyrax::CollectionIndexer
   end
 
   def path_sanitized(path)
-    path.gsub ::Rails.root.to_s + '/public', ''
+    if ENV['BRANDING_PATH'].present? && path.include?(ENV['BRANDING_PATH'].to_s)
+      path.gsub ENV['BRANDING_PATH'], '/branding'
+    elsif path.include? Rails.root.join('public', 'branding').to_s
+      path.gsub Rails.root.join('public').to_s, ''
+    else
+      path
+    end
   end
 end

--- a/app/indexers/curate_collection_indexer.rb
+++ b/app/indexers/curate_collection_indexer.rb
@@ -11,11 +11,21 @@ class CurateCollectionIndexer < Hyrax::CollectionIndexer
       solr_doc['title_ssort'] = sort_title
       solr_doc['creator_ssort'] = object.creator.first
       solr_doc['generic_type_sim'] = ["Collection"]
+      solr_doc['banner_path_ss'] = banner_path
     end
   end
 
   def sort_title
     return unless object.title.first
     object.title.first.gsub(/^(an?|the)\s/i, '')
+  end
+
+  def banner_path
+    cbi = branding_details
+    cbi.nil? || cbi&.local_path&.nil? ? '' : cbi.local_path
+  end
+
+  def branding_details
+    CollectionBrandingInfo.find_by_collection_id_and_role object.id, 'banner'
   end
 end

--- a/app/indexers/curate_collection_indexer.rb
+++ b/app/indexers/curate_collection_indexer.rb
@@ -22,10 +22,14 @@ class CurateCollectionIndexer < Hyrax::CollectionIndexer
 
   def banner_path
     cbi = branding_details
-    cbi.nil? || cbi&.local_path&.nil? ? '' : cbi.local_path
+    cbi.nil? || cbi&.local_path&.nil? ? '' : path_sanitized(cbi.local_path)
   end
 
   def branding_details
     CollectionBrandingInfo.find_by_collection_id_and_role object.id, 'banner'
+  end
+
+  def path_sanitized(path)
+    path.gsub ::Rails.root.to_s + '/public', ''
   end
 end

--- a/spec/indexers/collection_indexer_spec.rb
+++ b/spec/indexers/collection_indexer_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe CurateCollectionIndexer do
       end
     end
 
+    it 'returns nil when collection has no banner attached' do
+      expect(solr_document['banner_path_ss']).to be_empty
+    end
+
     context 'when collection has banner attached' do
       let(:filename) { '/world.png' }
       let(:file)     { fixture_file_upload(filename, 'image/png') }
@@ -45,8 +49,7 @@ RSpec.describe CurateCollectionIndexer do
         banner_info.save file.local_path
 
         expect(solr_document['banner_path_ss']).to eq(
-          ::Rails.root.to_s +
-            '/public/branding/' +
+            '/branding/' +
             collection.id.to_s +
             '/banner' +
             filename

--- a/spec/indexers/collection_indexer_spec.rb
+++ b/spec/indexers/collection_indexer_spec.rb
@@ -32,5 +32,26 @@ RSpec.describe CurateCollectionIndexer do
         expect(solr_document['title_ssort']).to eq 'title'
       end
     end
+
+    context 'when collection has banner attached' do
+      let(:filename) { '/world.png' }
+      let(:file)     { fixture_file_upload(filename, 'image/png') }
+
+      it 'indexes the banner path for each collection' do
+        banner_info = CollectionBrandingInfo.new(
+          collection_id: collection.id, filename: filename,
+          role: "banner", target_url: ""
+        )
+        banner_info.save file.local_path
+
+        expect(solr_document['banner_path_ss']).to eq(
+          ::Rails.root.to_s +
+            '/public/branding/' +
+            collection.id.to_s +
+            '/banner' +
+            filename
+        )
+      end
+    end
   end
 end

--- a/spec/indexers/collection_indexer_spec.rb
+++ b/spec/indexers/collection_indexer_spec.rb
@@ -49,10 +49,10 @@ RSpec.describe CurateCollectionIndexer do
         banner_info.save file.local_path
 
         expect(solr_document['banner_path_ss']).to eq(
-            '/branding/' +
-            collection.id.to_s +
-            '/banner' +
-            filename
+          '/branding/' +
+          collection.id.to_s +
+          '/banner' +
+          filename
         )
       end
     end

--- a/spec/indexers/collection_indexer_spec.rb
+++ b/spec/indexers/collection_indexer_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CurateCollectionIndexer do
     end
 
     it 'returns nil when collection has no banner attached' do
-      expect(solr_document['banner_path_ss']).to be_empty
+      expect(solr_document['banner_path_ss']).to be_falsey
     end
 
     context 'when collection has banner attached' do


### PR DESCRIPTION
1. curate_collection_indexer.rb: adds the custom field to the indexer with two methods that pluck
the needed path from the document object.
2. collection_indexer_spec.rb: creates the tests for the new index field.