### PR TITLE
Curate users should be able to see images of any visibility

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -26,6 +26,7 @@ class IiifController < ApplicationController
         head :forbidden
       when "rose_high"
         return head :forbidden unless user_ip_rose_reading_room?
+        send_image
       else
         head :forbidden
       end

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -12,20 +12,23 @@ class IiifController < ApplicationController
   end
 
   def show
-    case visibility
-    when "open", "low_res"
-      return send_image
-    when "authenticated", "emory_low" # authenticated is also called "Emory High Download"
-      return head :forbidden unless valid_cookie?
-      return send_image
-    when "restricted"
-      return head :forbidden unless current_user&.admin?
-      send_image
-    when "rose_high"
-      return head :forbidden unless user_ip_rose_reading_room? || current_user&.admin?
+    case user_signed_in?
+    when true
       send_image
     else
-      head :forbidden
+      case visibility
+      when "open", "low_res"
+        return send_image
+      when "authenticated", "emory_low" # authenticated is also called "Emory High Download"
+        return head :forbidden unless valid_cookie?
+        return send_image
+      when "restricted"
+        head :forbidden
+      when "rose_high"
+        return head :forbidden unless user_ip_rose_reading_room?
+      else
+        head :forbidden
+      end
     end
   end
 

--- a/spec/system/iiif_access_controls_spec.rb
+++ b/spec/system/iiif_access_controls_spec.rb
@@ -81,6 +81,16 @@ RSpec.describe 'iiif access controls', type: :system, iiif: true do
         expect(page.body).to be_empty
       end
     end
+
+    context "As a Curate user" do
+      let(:user) { FactoryBot.create(:user) }
+
+      it 'visits a iiif_url', clean: true do
+        login_as user
+        visit iiif_url
+        expect(page).to have_http_status(200)
+      end
+    end
   end
 
   context "for Emory High Download objects" do
@@ -167,8 +177,7 @@ RSpec.describe 'iiif access controls', type: :system, iiif: true do
       it 'visits a iiif_url', clean: true do
         login_as user
         visit iiif_url
-        expect(page).to have_http_status(403)
-        expect(page.body).to be_empty
+        expect(page).to have_http_status(200)
       end
     end
   end


### PR DESCRIPTION
See issue #450 in Lux 
https://app.zenhub.com/workspaces/dlp-lux-5c75900b135e053ed882c4d0/issues/emory-libraries/dlp-lux/450

