### PR TITLE
Delivers constrained size options in UV download dialoque

### DIFF
--- a/app/helpers/hyrax/iiif_helper.rb
+++ b/app/helpers/hyrax/iiif_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# [Hyrax overwrite]
+# Adds additional methods to configure UV
+
+module Hyrax
+  module IiifHelper
+    def iiif_viewer_display(work_presenter, locals = {})
+      render iiif_viewer_display_partial(work_presenter),
+             locals.merge(presenter: work_presenter)
+    end
+
+    def iiif_viewer_display_partial(work_presenter)
+      'hyrax/base/iiif_viewers/' + work_presenter.iiif_viewer.to_s
+    end
+
+    def universal_viewer_base_url
+      "#{request&.base_url}/uv/uv.html"
+    end
+
+    def universal_viewer_config_url
+      "#{request&.base_url}/uv-emory-config.json"
+    end
+  end
+end

--- a/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
+++ b/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
@@ -2,7 +2,7 @@
   <iframe
       width="100%"
       height="480"
-      src="/uv/uv.html#?manifest=<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>"
+      src="/uv/uv.html#?manifest=<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>&config=<%= universal_viewer_config_url %>"
       allowfullscreen="true"
       frameborder="0"
   ></iframe>

--- a/app/views/manifest/manifest.json.jbuilder
+++ b/app/views/manifest/manifest.json.jbuilder
@@ -20,8 +20,8 @@ json.sequences [''] do
     json.set! :@id, canvas_uri
     json.set! :@type, 'sc:Canvas'
     json.label file_set.title.first
-    json.width 640
-    json.height 480
+    json.width file_set.original_file.width
+    json.height file_set.original_file.height
     json.images [file_set] do
       json.set! :@type, 'oa:Annotation'
       json.motivation 'sc:painting'

--- a/public/uv-emory-config.json
+++ b/public/uv-emory-config.json
@@ -1,0 +1,24 @@
+{
+    "options": {
+
+    },
+    "modules": {
+        "footerPanel": {
+          "options": {
+            "shareEnabled": true,
+            "downloadEnabled": true,
+            "fullscreenEnabled": true
+          }
+        },
+        "downloadDialogue": {
+          "options": {
+
+          },
+          "content": {
+
+          }
+        }
+      }
+  }
+
+

--- a/spec/fixtures/manifest_output.rb
+++ b/spec/fixtures/manifest_output.rb
@@ -16,8 +16,8 @@ class ManifestOutput
               "@id":    "http://example.com/iiif/#{work.id}/manifest/canvas/#{file_set.id}",
               "@type":  "sc:Canvas",
               "label":  file_set.title.first,
-              "width":  640,
-              "height": 480,
+              "width":  file_set.original_file.width,
+              "height": file_set.original_file.height,
               "images": [
                 {
                   "@type":      "oa:Annotation",


### PR DESCRIPTION
Connected to #1054 
Connected to #984 

* Current view and Whole Image Low Res options are currently not working as expected because of the hardcoded 640x480 width and height. This commit changes those fixed values to preservation master file's width and height. This should now fix the issue where the current view would sometimes show negative pixels and not download correctly. Along with this, distortion when downloading whole image low res (where height gets fixed at 750px) should also be fixed.