### PR TITLE
Changes reindex-extent to limited for collection nesting callbacks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,5 +75,6 @@ end
 group :test do
   gem 'capybara'
   gem 'rspec_junit_formatter'
+  gem 'shoulda-callback-matchers', '~> 1.1.1'
   gem 'show_me_the_cookies'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1599,6 +1599,8 @@ GEM
       rdf-xsd (>= 2.2, < 4.0)
       sparql (>= 2.2, < 4.0)
       sxp (~> 1.0)
+    shoulda-callback-matchers (1.1.4)
+      activesupport (>= 3)
     show_me_the_cookies (5.0.0)
       capybara (>= 2, < 4)
     sidekiq (5.2.7)
@@ -1767,6 +1769,7 @@ DEPENDENCIES
   rubocop-rspec
   sass-rails (~> 5.0)
   selenium-webdriver
+  shoulda-callback-matchers (~> 1.1.1)
   show_me_the_cookies
   sidekiq (~> 5.2)
   solr_wrapper (>= 0.3)

--- a/app/models/concerns/hyrax/collection_nesting.rb
+++ b/app/models/concerns/hyrax/collection_nesting.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+# [Hyrax-overwrite] Changing reindex-extent to limited instead of full in order
+# to speed up collection indexing.
+
+module Hyrax
+  # Responsible for adding the necessary callbacks for updating the nested collection information
+  # This is part of the after update index because it is a potentially very expensive process.
+  #
+  # @todo Consider extracting the update_index callback to ActiveFedora::Base
+  module CollectionNesting
+    extend ActiveSupport::Concern
+
+    included do
+      extend ActiveModel::Callbacks
+      include ActiveModel::Validations::Callbacks
+
+      define_model_callbacks :update_index, only: :after
+      after_update_index :update_nested_collection_relationship_indices
+      after_destroy :update_child_nested_collection_relationship_indices
+      before_save :before_update_nested_collection_relationship_indices
+      after_save :after_update_nested_collection_relationship_indices
+
+      def before_update_nested_collection_relationship_indices
+        @during_save = true
+      end
+
+      def after_update_nested_collection_relationship_indices
+        @during_save = false
+        reindex_nested_relationships_for(id: id, extent: reindex_extent)
+      end
+
+      def update_nested_collection_relationship_indices
+        return if @during_save
+        reindex_nested_relationships_for(id: id, extent: reindex_extent)
+      end
+
+      def update_child_nested_collection_relationship_indices
+        children = find_children_of(destroyed_id: id)
+        children.each do |child|
+          reindex_nested_relationships_for(id: child.id, extent: Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)
+        end
+      end
+    end
+
+    def update_index(*args)
+      _run_update_index_callbacks { super }
+    end
+
+    def find_children_of(destroyed_id:)
+      ActiveFedora::SolrService.query(ActiveFedora::SolrQueryBuilder.construct_query(member_of_collection_ids_ssim: destroyed_id))
+    end
+
+    # Only models which include Hyrax::CollectionNesting will respond to this method.
+    # Used to determine whether a model gets reindexed via Samvera::NestingIndexer during full repository reindexing,
+    def use_nested_reindexing?
+      true
+    end
+
+    # The following methods allow an option to reindex an object only if the nesting indexer fields are not
+    # already in the object's solr document. Added to prevent unnecessary indexing of all ancestors of a parent
+    # when one child gets added to the parent. By default, we do the full graph indexing.
+    def reindex_extent
+      @reindex_extent ||= Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
+    end
+
+    def reindex_extent=(val)
+      @reindex_extent = val
+    end
+
+    private
+
+      def reindex_nested_relationships_for(id:, extent:)
+        Hyrax.config.nested_relationship_reindexer.call(id: id, extent: extent)
+      end
+  end
+end

--- a/app/models/concerns/hyrax/collection_nesting.rb
+++ b/app/models/concerns/hyrax/collection_nesting.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# [Hyrax-overwrite] Changing reindex-extent to limited instead of full in order
+# [Hyrax-overwrite-v3.0.0-beta1] Changing reindex-extent to limited instead of full in order
 # to speed up collection indexing.
 
 module Hyrax

--- a/spec/models/concerns/hyrax/collection_nesting_spec.rb
+++ b/spec/models/concerns/hyrax/collection_nesting_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+# [Hyrax-overwrite] Changing reindex-extent to limited instead of full in order
+# to speed up collection indexing.
+require 'rails_helper'
+require 'shoulda/callback/matchers'
+
+RSpec.describe Hyrax::CollectionNesting do
+  describe 'including this module' do
+    subject :collection do
+      klass.new.tap { |obj| obj.id = collection.id }
+    end
+
+    let(:klass) do
+      Class.new do
+        extend ActiveModel::Callbacks
+        include ActiveModel::Validations::Callbacks
+        # Because we need these declared before we include the Hyrax::CollectionNesting
+        define_model_callbacks :destroy, only: :after
+        define_model_callbacks :save, only: :after
+        define_model_callbacks :save, only: :before
+
+        def destroy
+          true
+        end
+
+        def update_index
+          true
+        end
+
+        def before_save
+          false
+        end
+
+        def after_save
+          true
+        end
+        include Hyrax::CollectionNesting
+
+        attr_accessor :id
+      end
+    end
+
+    let(:user) { FactoryBot.create(:user) }
+    let!(:collection) { FactoryBot.create(:collection_lw, collection_type_settings: [:nestable]) }
+    let!(:child_collection) { FactoryBot.create(:collection_lw, collection_type_settings: [:nestable]) }
+    let(:extent) { Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX }
+
+    before do
+      Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: collection, child: child_collection)
+    end
+
+    it { is_expected.to callback(:update_nested_collection_relationship_indices).after(:update_index) }
+    it { is_expected.to callback(:update_child_nested_collection_relationship_indices).after(:destroy) }
+    it { is_expected.to callback(:before_update_nested_collection_relationship_indices).before(:save) }
+    it { is_expected.to callback(:after_update_nested_collection_relationship_indices).after(:save) }
+    it { is_expected.to respond_to(:update_nested_collection_relationship_indices) }
+    it { is_expected.to respond_to(:update_child_nested_collection_relationship_indices) }
+    it { is_expected.to respond_to(:use_nested_reindexing?) }
+    it { is_expected.to respond_to(:reindex_extent) }
+    it { is_expected.to respond_to(:reindex_extent=) }
+
+    context 'after_update_index callback' do
+      describe '#update_nested_collection_relationship_indices' do
+        it 'will call Hyrax.config.nested_relationship_reindexer' do
+          expect(Hyrax.config.nested_relationship_reindexer).to receive(:call).with(id: collection.id, extent: extent).and_call_original
+          collection.update_nested_collection_relationship_indices
+        end
+
+        it 'will not call during save' do
+          allow(klass).to receive(:before_save).and_return(true)
+          expect(Hyrax.config.nested_relationship_reindexer).not_to receive(:call)
+        end
+      end
+    end
+
+    context 'after_destroy callback', with_nested_reindexing: true do
+      describe '#update_child_nested_collection_relationship_indices' do
+        it 'will call Hyrax.config.nested_relationship_reindexer' do
+          expect(Hyrax.config.nested_relationship_reindexer).to receive(:call).with(id: child_collection.id, extent: extent).and_call_original
+          collection.update_child_nested_collection_relationship_indices
+        end
+      end
+
+      describe '#find_children_of' do
+        it 'will return an array containing the child collection ids' do
+          expect(collection.find_children_of(destroyed_id: collection.id).first.id).to eq(child_collection.id)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/concerns/hyrax/collection_nesting_spec.rb
+++ b/spec/models/concerns/hyrax/collection_nesting_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# [Hyrax-overwrite] Changing reindex-extent to limited instead of full in order
+# [Hyrax-overwrite-v3.0.0-beta1] Changing reindex-extent to limited instead of full in order
 # to speed up collection indexing.
 require 'rails_helper'
 require 'shoulda/callback/matchers'


### PR DESCRIPTION
* When we save/update a collection, all its nested objects get reindexed. This slows down the process of saving a work. We update the save,update,delete callbacks to make sure we are using the limited reindexing strategy provided by Samvera:: NestingIndexer class instead of full. Refer: https://samvera.github.io/nested-indexing.html#nested-indexing-details