### PR TITLE
Edits manifest jbuilder to ignore PDF and OCR files

### DIFF
--- a/app/views/manifest/manifest.json.jbuilder
+++ b/app/views/manifest/manifest.json.jbuilder
@@ -15,32 +15,35 @@ json.sequences [''] do
   json.set! :@id, "#{@root_url}/sequence/normal"
   json.canvases @image_concerns do |child_id|
     file_set = FileSet.find(child_id)
-    child_iiif_service = ManifestBuilderService.new(curation_concern: file_set)
-    canvas_uri = "#{@root_url}/canvas/#{child_id}"
-    json.set! :@id, canvas_uri
-    json.set! :@type, 'sc:Canvas'
-    json.label file_set.title.first
-    json.width file_set.original_file.width
-    json.height file_set.original_file.height
-    json.images [file_set] do
-      json.set! :@type, 'oa:Annotation'
-      json.motivation 'sc:painting'
-      json.resource do
-        json.set! :@type, 'dctypes:Image'
-        json.set! :@id, child_iiif_service.iiif_url
-        json.width 640
-        json.height 480
-        json.service do
-          json.set! :@context, 'http://iiif.io/api/image/2/context.json'
+    mime_types = ['pdf', 'xml']
+    unless mime_types.any? { |m| file_set.mime_type&.include?(m) }
+      child_iiif_service = ManifestBuilderService.new(curation_concern: file_set)
+      canvas_uri = "#{@root_url}/canvas/#{child_id}"
+      json.set! :@id, canvas_uri
+      json.set! :@type, 'sc:Canvas'
+      json.label file_set.title.first
+      json.width file_set.original_file.width
+      json.height file_set.original_file.height
+      json.images [file_set] do
+        json.set! :@type, 'oa:Annotation'
+        json.motivation 'sc:painting'
+        json.resource do
+          json.set! :@type, 'dctypes:Image'
+          json.set! :@id, child_iiif_service.iiif_url
+          json.width 640
+          json.height 480
+          json.service do
+            json.set! :@context, 'http://iiif.io/api/image/2/context.json'
 
-          # The base url for the info.json file
-          info_url = child_iiif_service.info_url
+            # The base url for the info.json file
+            info_url = child_iiif_service.info_url
 
-          json.set! :@id, info_url
-          json.profile 'http://iiif.io/api/image/2/level2.json'
+            json.set! :@id, info_url
+            json.profile 'http://iiif.io/api/image/2/level2.json'
+          end
         end
+        json.on canvas_uri
       end
-      json.on canvas_uri
     end
   end
 end

--- a/spec/fixtures/sample-ocr.xml
+++ b/spec/fixtures/sample-ocr.xml
@@ -1,0 +1,1 @@
+This is a sample ocr file

--- a/spec/views/manifest/manifest.json.jbuilder_spec.rb
+++ b/spec/views/manifest/manifest.json.jbuilder_spec.rb
@@ -13,9 +13,13 @@ RSpec.describe "manifest/manifest", type: :view do
   let(:presenter)       { Hyrax::CurateGenericWorkPresenter.new(solr_document, ability, request) }
   let(:solr_document)   { SolrDocument.new(attributes) }
   let(:file_set)        { FactoryBot.create(:file_set, id: '608hdr7qrt-cor', title: ['foo']) }
+  let(:file_set1)       { FactoryBot.create(:file_set, id: '608hdr7srt-cor', title: ['foo1']) }
+  let(:file_set2)       { FactoryBot.create(:file_set, id: '608hdr7rrt-cor', title: ['foo2']) }
   let(:pmf)             { File.open(fixture_path + '/book_page/0003_preservation_master.tif') }
   let(:sf)              { File.open(fixture_path + '/book_page/0003_service.jpg') }
   let(:imf)             { File.open(fixture_path + '/book_page/0003_intermediate.jp2') }
+  let(:pdf)             { File.open(fixture_path + '/sample-file.pdf') }
+  let(:ocr)             { File.open(fixture_path + '/sample-ocr.xml') }
   let(:manifest)        { ManifestOutput.new }
   let(:attributes) do
     { "id" => identifier,
@@ -33,7 +37,11 @@ RSpec.describe "manifest/manifest", type: :view do
     Hydra::Works::AddFileToFileSet.call(file_set, pmf, :preservation_master_file)
     Hydra::Works::AddFileToFileSet.call(file_set, sf, :service_file)
     Hydra::Works::AddFileToFileSet.call(file_set, imf, :intermediate_file)
+    Hydra::Works::AddFileToFileSet.call(file_set1, pdf, :preservation_master_file)
+    Hydra::Works::AddFileToFileSet.call(file_set2, ocr, :preservation_master_file)
     work.ordered_members << file_set
+    work.ordered_members << file_set1
+    work.ordered_members << file_set2
     work.save!
     assign(:solr_doc, solr_document)
     assign(:image_concerns, image_concerns)
@@ -52,5 +60,6 @@ RSpec.describe "manifest/manifest", type: :view do
     render
     doc = manifest.manifest_output(work, file_set).to_json
     expect(JSON.parse(rendered)).to eq(JSON.parse(doc))
+    expect(work.file_sets.count).to eq 3
   end
 end


### PR DESCRIPTION
* We have PDF, OCR, and METS files for books which we don't need to display in UV or create images for them in the manifest. We are now only generating image sequences for file_sets that are not of type
pdf or xml.