### PR TITLE
Disable SolrSuggest

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -314,6 +314,9 @@
       </analyzer>
     </fieldType>
 
+<!-- SolrSuggest disabled due to performance penalties -->
+<!--
+
     <fieldType class="solr.TextField" name="textSuggest" positionIncrementGap="100">
        <analyzer>
           <tokenizer class="solr.KeywordTokenizerFactory"/>
@@ -322,6 +325,7 @@
           <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
        </analyzer>
     </fieldType>
+-->
 
     <!-- charFilter + WhitespaceTokenizer  -->
     <!--
@@ -529,7 +533,10 @@
    <dynamicField name="*_sort" type="alphaOnlySort" indexed="true" stored="false" multiValued="false" />
    <dynamicField name="*_unstem_search" type="text_general" indexed="true" stored="false" multiValued="true" />
    <dynamicField name="*spell" type="textSpell" indexed="true" stored="false" multiValued="true" />
+<!-- SolrSuggest disabled due to performance penalties -->
+<!--
    <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="false" multiValued="true" />
+-->
 
    <!-- uncomment the following to ignore any fields that don't already match an existing
         field name or dynamic field, rather than reporting them as an error.
@@ -596,9 +603,12 @@
    <copyField source="subject_t" dest="opensearch_display"/>
    <copyField source="subject_addl_t" dest="opensearch_display"/>
 
+<!-- SolrSuggest disabled due to performance penalties -->
    <!-- for suggestions -->
+<!--
    <copyField source="*_t" dest="suggest"/>
    <copyField source="*_facet" dest="suggest"/>
+-->
 
    <!-- Above, multiple source fields are copied to the [text] field.
 	  Another way to map multiple source fields to the same

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -386,6 +386,8 @@
       -->
   </searchComponent>
 
+<!-- suggest searchComponent and requestHandler disabled due to performance penalties -->
+<!--
   <searchComponent name="suggest" class="solr.SuggestComponent">
     <lst name="suggester">
       <str name="name">mySuggester</str>
@@ -406,6 +408,7 @@
       <str>suggest</str>
     </arr>
   </requestHandler>
+-->
 
 </config>
 

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -165,6 +165,8 @@
       </analyzer>
     </fieldType>
 
+<!-- SolrSuggest disabled due to performance penalties -->
+<!--
     <fieldType class="solr.TextField" name="textSuggest" positionIncrementGap="100">
       <analyzer>
         <tokenizer class="solr.KeywordTokenizerFactory"/>
@@ -173,6 +175,7 @@
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>
     </fieldType>
+-->
   </types>
 
 
@@ -320,8 +323,10 @@
     <dynamicField name="*_llsm" type="location" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_llsi" type="location" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_llsim" type="location" stored="true" indexed="true" multiValued="true"/>
-
+<!-- SolrSuggest disabled due to performance penalties -->
+<!--
     <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="false" multiValued="true" />
+-->
 
     <!-- you must define copyField source and dest fields explicity or schemaBrowser doesn't work -->
     <field name="all_text_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
@@ -345,9 +350,12 @@
     copyField also supports a maxChars to copy setting.  -->
 
    <!-- <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/> -->
+<!-- SolrSuggest disabled due to performance penalties -->
    <!-- for suggestions -->
+<!--
    <copyField source="*_tesim" dest="suggest"/>
    <copyField source="*_ssim" dest="suggest"/>
+-->
 
  <!-- Similarity is the scoring routine for each document vs. a query.
       A custom similarity may be specified here, but the default is fine

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -284,6 +284,8 @@
       -->
   </searchComponent>
 
+<!-- suggest searchComponent and requestHandler disabled due to performance penalties -->
+<!--
   <searchComponent name="suggest" class="solr.SuggestComponent">
     <lst name="suggester">
       <str name="name">mySuggester</str>
@@ -304,6 +306,7 @@
       <str>suggest</str>
     </arr>
   </requestHandler>
+-->
 
   <requestHandler name="/update/extract" class="org.apache.solr.handler.extraction.ExtractingRequestHandler">
     <lst name="defaults">


### PR DESCRIPTION
* SolrSuggest may be responsible for slowdown in ingest pace. Disabling SolrSuggest might help to decrease time taken to create and add a work to a collection. Refer:
https://docs.google.com/presentation/d/1Jj0aC8LhfbcWxe0g8bBhTj1wxKMbkU6v11iJRBKNV3E/edit?copiedFromTrash#slide=id.g44d37b2273_2_0
and
https://docs.google.com/presentation/d/1Jj0aC8LhfbcWxe0g8bBhTj1wxKMbkU6v11iJRBKNV3E/edit?copiedFromTrash#slide=id.g44d37b2273_2_7
and
https://github.com/samvera/active_fedora/pull/1311/files