### PR TITLE
Removes http from purl

### DIFF
--- a/app/presenters/hyrax/curate_generic_work_presenter.rb
+++ b/app/presenters/hyrax/curate_generic_work_presenter.rb
@@ -35,7 +35,7 @@ module Hyrax
         { "label" => "Provided by", "value" => holding_repository },
         { "label" => "Rights Status", "value" => rights_statement },
         { "label" => "Identifier", "value" => id },
-        { "label" => "Persistent URL", "value" => "<a href=\"http://#{purl}\">#{purl}</a>" }
+        { "label" => "Persistent URL", "value" => "<a href=\"#{purl}\">#{purl}</a>" }
       ]
     end
   end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -2,7 +2,7 @@
 <div>
   Persistent URL
   <ul class="tabular">
-    <li><a href="http://<%= presenter.purl %>" target="_blank"><%= presenter.purl %></a></li>
+    <li><a href="<%= presenter.purl %>" target="_blank"><%= presenter.purl %></a></li>
   </ul>
 </div>
 <!-- Persistent URL block end -->

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe IiifController, type: :controller, clean: true, iiif: true do
       work.ordered_members << file_set
       work.save!
       allow(SolrDocument).to receive(:find).and_return(solr_document)
-      ENV['LUX_BASE_URL'] = 'example.com'
+      ENV['LUX_BASE_URL'] = 'https://example.com'
     end
 
     it "saves manifest file in a cache" do
@@ -252,7 +252,7 @@ RSpec.describe IiifController, type: :controller, clean: true, iiif: true do
       expect(response_values["metadata"][2]["label"]).to eq "Identifier"
       expect(response_values["metadata"][2]["value"]).to eq work.id
       expect(response_values["metadata"][3]["label"]).to eq "Persistent URL"
-      expect(response_values["metadata"][3]["value"]).to eq "<a href=\"example.com/purl/#{work.id}\">example.com/purl/#{work.id}</a>"
+      expect(response_values["metadata"][3]["value"]).to eq "<a href=\"https://example.com/purl/#{work.id}\">https://example.com/purl/#{work.id}</a>"
       expect(response_values).to include "sequences"
       expect(response_values["sequences"].first["@type"]).to include "sc:Sequence"
       expect(response_values["sequences"].first["@id"]).to include "/iiif/#{work.id}/manifest/sequence/normal"

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe IiifController, type: :controller, clean: true, iiif: true do
       work.ordered_members << file_set
       work.save!
       allow(SolrDocument).to receive(:find).and_return(solr_document)
-      ENV['LUX_BASE_URL'] = 'empl.com'
+      ENV['LUX_BASE_URL'] = 'example.com'
     end
 
     it "saves manifest file in a cache" do
@@ -252,7 +252,7 @@ RSpec.describe IiifController, type: :controller, clean: true, iiif: true do
       expect(response_values["metadata"][2]["label"]).to eq "Identifier"
       expect(response_values["metadata"][2]["value"]).to eq work.id
       expect(response_values["metadata"][3]["label"]).to eq "Persistent URL"
-      expect(response_values["metadata"][3]["value"]).to eq "<a href=\"http://empl.com/purl/#{work.id}\">empl.com/purl/#{work.id}</a>"
+      expect(response_values["metadata"][3]["value"]).to eq "<a href=\"example.com/purl/#{work.id}\">example.com/purl/#{work.id}</a>"
       expect(response_values).to include "sequences"
       expect(response_values["sequences"].first["@type"]).to include "sc:Sequence"
       expect(response_values["sequences"].first["@id"]).to include "/iiif/#{work.id}/manifest/sequence/normal"

--- a/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
+++ b/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
     let(:presenter) { described_class.new(solr_document, ability) }
 
     before do
-      ENV['LUX_BASE_URL'] = "empl.com"
+      ENV['LUX_BASE_URL'] = "example.com"
     end
 
     describe "#manifest_metadata" do
@@ -61,13 +61,13 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
 
       it {
         is_expected.to eq [{ "label" => "Provided by", "value" => ["test holding repo"] }, { "label" => "Rights Status", "value" => ["empl.com"] },
-                           { "label" => "Identifier", "value" => "888888" }, { "label" => "Persistent URL", "value" => "<a href=\"http://empl.com/purl/888888\">empl.com/purl/888888</a>" }]
+                           { "label" => "Identifier", "value" => "888888" }, { "label" => "Persistent URL", "value" => "<a href=\"example.com/purl/888888\">example.com/purl/888888</a>" }]
       }
     end
 
     describe "#purl" do
       subject { presenter.purl }
-      it { is_expected.to eq "empl.com/purl/888888" }
+      it { is_expected.to eq "example.com/purl/888888" }
     end
   end
 end

--- a/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
+++ b/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
     let(:presenter) { described_class.new(solr_document, ability) }
 
     before do
-      ENV['LUX_BASE_URL'] = "example.com"
+      ENV['LUX_BASE_URL'] = "https://example.com"
     end
 
     describe "#manifest_metadata" do
@@ -61,13 +61,14 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
 
       it {
         is_expected.to eq [{ "label" => "Provided by", "value" => ["test holding repo"] }, { "label" => "Rights Status", "value" => ["empl.com"] },
-                           { "label" => "Identifier", "value" => "888888" }, { "label" => "Persistent URL", "value" => "<a href=\"example.com/purl/888888\">example.com/purl/888888</a>" }]
+                           { "label" => "Identifier", "value" => "888888" },
+                           { "label" => "Persistent URL", "value" => "<a href=\"https://example.com/purl/888888\">https://example.com/purl/888888</a>" }]
       }
     end
 
     describe "#purl" do
       subject { presenter.purl }
-      it { is_expected.to eq "example.com/purl/888888" }
+      it { is_expected.to eq "https://example.com/purl/888888" }
     end
   end
 end


### PR DESCRIPTION
* We are removing http from persistent URLs since this will be included in the env variable.