### PR TITLE
Remove test-created artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ public/branding
 # yard documentation
 /doc
 /.yardoc/**
+
+# fits artifacts
+fits.log

--- a/spec/jobs/check_binaries_job_spec.rb
+++ b/spec/jobs/check_binaries_job_spec.rb
@@ -2,7 +2,8 @@
 require 'rails_helper'
 
 RSpec.describe CheckBinariesJob, :clean do
-  let(:csv)           { IO.read(File.join("config/emory/check_binaries_results.csv")) }
+  let(:csv_path) { File.join("config/emory/check_binaries_results.csv") }
+  let(:csv)           { IO.read(csv_path) }
   let(:file)          { File.open(fixture_path + '/book_page/0003_preservation_master.tif') }
   let(:file_set)      { FactoryBot.create(:file_set) }
   let(:file_set2)     { FactoryBot.create(:file_set) }
@@ -16,6 +17,10 @@ RSpec.describe CheckBinariesJob, :clean do
     generic_work2.save
     generic_work.ordered_members << file_set2
     generic_work.save
+  end
+
+  after do
+    File.delete(csv_path) if File.exist?(csv_path)
   end
 
   context "file is present in s3" do

--- a/spec/jobs/file_set_clean_up_job_spec.rb
+++ b/spec/jobs/file_set_clean_up_job_spec.rb
@@ -2,9 +2,14 @@
 require 'rails_helper'
 
 RSpec.describe FileSetCleanUpJob, :clean do
-  let(:csv)         { IO.read(File.join("config/emory/index_file_set_results.csv")) }
+  let(:csv_path)    { File.join("config/emory/index_file_set_results.csv") }
+  let(:csv)         { IO.read(csv_path) }
   let(:file)        { File.open(fixture_path + '/book_page/0003_preservation_master.tif') }
   let(:file_set)    { FactoryBot.create(:file_set) }
+
+  after do
+    File.delete(csv_path) if File.exist?(csv_path)
+  end
 
   context 'file_set is indexed incorrectly' do
     before do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Collection do
+RSpec.describe Collection, clean: true do
   context "Solr document for collections" do
     let(:collection)     { FactoryBot.build(:collection_lw) }
     let(:work1)          { FactoryBot.build(:work, id: 'wk1', title: ['Work 1']) }


### PR DESCRIPTION
When a test creates an artifact, it should clean up after itself and remove any files that got created during the test run. Otherwise, this could lead to unexpected side effects, and it's easy for these artifacts to accidentally get added to version control.