### PR TITLE
Removes http from purl on collection show page

### DIFF
--- a/app/views/hyrax/collections/_show_descriptions.html.erb
+++ b/app/views/hyrax/collections/_show_descriptions.html.erb
@@ -3,7 +3,7 @@
 <div>
   <b>Persistent URL</b>
   <ul class="tabular">
-    <li><a href="http://<%= @presenter.purl %>" target="_blank"><%= @presenter.purl %></a></li>
+    <li><a href="<%= @presenter.purl %>" target="_blank"><%= @presenter.purl %></a></li>
   </ul>
 </div>
 <!-- Persistent URL block end -->

--- a/spec/system/show_collection_spec.rb
+++ b/spec/system/show_collection_spec.rb
@@ -43,13 +43,13 @@ RSpec.describe 'viewing a collection', :clean, type: :system, js: true do
   before do
     private_work.member_of_collections = [collection]
     private_work.save!
-    ENV['LUX_BASE_URL'] = 'empl.com'
+    ENV['LUX_BASE_URL'] = 'https://example.com'
   end
 
   it 'has all the expected metadata fields' do
     login_as user
     visit "/collections/#{collection.id}"
-    expect(page).to have_content("empl.com/purl/#{collection.id}")
+    expect(page).to have_content("https://example.com/purl/#{collection.id}")
     expect(page).to have_content 'Robert Langmuir African American Photograph Collection'
     expect(page).to have_content 'Created by: Langmuir, Robert, collector'
     expect(page).to have_content 'Rose Library'


### PR DESCRIPTION
* We are removing http from persistent URLs since this will be included in the env variable.

Connected to: #1144 