### PR TITLE
Turn two uncertain decades into range of dates for Lux

### DIFF
--- a/app/indexers/year_parser.rb
+++ b/app/indexers/year_parser.rb
@@ -21,7 +21,9 @@ class YearParser
   end
 
   def self.years(input_string)
-    if date_range?(input_string)
+    if date_range?(input_string) && date_decade?(input_string)
+      expand_multiple_decades(input_string)
+    elsif date_range?(input_string)
       expand_date(input_string)
     elsif date_decade?(input_string)
       expand_decade(input_string)
@@ -41,6 +43,13 @@ class YearParser
     %r{\/} # a forward slash
   end
 
+  def self.years_to_array(range_start, range_end)
+    starting_year = parse_year(range_start)
+    ending_year = parse_year(range_end)
+
+    (starting_year..ending_year).to_a
+  end
+
   # If the string is a range of dates instead of a
   # single date, expand the range into an array of
   # values.
@@ -48,10 +57,16 @@ class YearParser
     range_start = input_string.match(/^(.*)#{range_separator}/).captures.first
     range_end = input_string.match(/^.*#{range_separator}(.*)/).captures.first
 
-    starting_year = parse_year(range_start)
-    ending_year = parse_year(range_end)
+    years_to_array(range_start, range_end)
+  end
 
-    (starting_year..ending_year).to_a
+  def self.expand_multiple_decades(input_string)
+    first_decade = input_string.match(/^(.*)#{range_separator}/).captures.first
+    second_decade = input_string.match(/^.*#{range_separator}(.*)/).captures.first
+    range_start = first_decade.tr('X', '0')
+    range_end = second_decade.tr('X', '9')
+
+    years_to_array(range_start, range_end)
   end
 
   # If the string has a known decade but an uncertain year within that decade
@@ -65,9 +80,7 @@ class YearParser
     range_start = range_base.tr('X', '0')
     range_end = range_base.tr('X', '9')
 
-    starting_year = parse_year(range_start)
-    ending_year = parse_year(range_end)
-    (starting_year..ending_year).to_a
+    years_to_array(range_start, range_end)
   end
 
   def self.parse_year(date_string)

--- a/spec/indexers/year_parser_spec.rb
+++ b/spec/indexers/year_parser_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe YearParser do
 
     context 'with two possible known decades, uncertain year' do
       let(:dates) { ['193X/194X'] }
-      it { is_expected.to eq [1930, 1931, 1932, 1933, 1934, 1935, 1936, 1937, 1938, 1939, 1940, 1941, 1942, 1943, 1944, 1945, 1946, 1947, 1948, 1949]}
+      it { is_expected.to eq [1930, 1931, 1932, 1933, 1934, 1935, 1936, 1937, 1938, 1939, 1940, 1941, 1942, 1943, 1944, 1945, 1946, 1947, 1948, 1949] }
     end
 
     context 'date ranges that aren\'t just years' do

--- a/spec/indexers/year_parser_spec.rb
+++ b/spec/indexers/year_parser_spec.rb
@@ -55,6 +55,11 @@ RSpec.describe YearParser do
       it { is_expected.to eq [1930, 1931, 1932, 1933, 1934, 1935, 1936, 1937, 1938, 1939] }
     end
 
+    context 'with two possible known decades, uncertain year' do
+      let(:dates) { ['193X/194X'] }
+      it { is_expected.to eq [1930, 1931, 1932, 1933, 1934, 1935, 1936, 1937, 1938, 1939, 1940, 1941, 1942, 1943, 1944, 1945, 1946, 1947, 1948, 1949]}
+    end
+
     context 'date ranges that aren\'t just years' do
       let(:dates) { '1934-06/1934-07' }
       it { is_expected.to eq [1934] }


### PR DESCRIPTION
Previously, dates recorded as "192X/193X" were parsed as "192" for Lux, leading to the date slider showing the wrong dates for these types of items
Before:
![image](https://user-images.githubusercontent.com/45948126/79506974-e9dcaf00-8004-11ea-9ebc-1c489b4e1e3f.png)

After:
![image](https://user-images.githubusercontent.com/45948126/79506810-9e2a0580-8004-11ea-907e-08499c503d1b.png)
