### PR TITLE
Limits job retries to one by default

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,6 +6,8 @@
 
 :timeout: 300
 
+:max_retries: 1
+
 test: # n/a
   :concurrency: <%= ENV['SIDEKIQ_WORKERS'] || 1 %>
 


### PR DESCRIPTION
Some of our jobs are retrying multiple times very quickly, and we are
not changing code so quickly that we would expect the outcome to change.
Therefore, these retries are effectively spamming Honeybadger, making it
harder to sort through information to debug the underliying problem.

By changing to one retry by default, we should cut down on that spam,
and still get an opportunity for flaky errors to pass.