### PR TITLE
Adds a job to transfer works from one col to another

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'riiif', '~> 2.0'
 gem 'rsolr', '>= 1.0'
 gem 'sass-rails', '~> 5.0'
 gem 'sidekiq', '~> 5.2'
+gem 'stackprof'
 gem 'turbolinks', '~> 5'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby] # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1657,6 +1657,7 @@ GEM
     sshkit (1.20.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    stackprof (0.2.15)
     sxp (1.0.2)
       rdf (~> 3.0)
     temple (0.8.2)
@@ -1775,6 +1776,7 @@ DEPENDENCIES
   sidekiq (~> 5.2)
   solr_wrapper (>= 0.3)
   sqlite3 (~> 1.3.7)
+  stackprof
   turbolinks (~> 5)
   twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
   tzinfo-data

--- a/app/jobs/transfer_works_job.rb
+++ b/app/jobs/transfer_works_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class TransferWorksJob < Hyrax::ApplicationJob
+  def perform(import_col_id, true_col_id)
+    StackProf.run(mode: :cpu, out: 'tmp/stackprof-curate.dump', raw: true) do
+      import_col = Collection.find(import_col_id)
+      true_col = Collection.find(true_col_id)
+      import_col.member_works.each do |work|
+        work.member_of_collections << true_col unless true_col.member_work_ids.include?(work.id)
+        work.member_of_collections.delete(import_col)
+        work.save!
+      end
+    end
+  end
+end

--- a/lib/tasks/work_transfer.rake
+++ b/lib/tasks/work_transfer.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :curate do
+  namespace :works do
+    desc "Transfer works from one collection to another"
+    task transfer_works: :environment do
+      import_col = ENV['import_col']
+      true_col = ENV['true_col']
+      TransferWorksJob.perform_later(import_col, true_col)
+    end
+  end
+end

--- a/spec/jobs/transfer_works_job_spec.rb
+++ b/spec/jobs/transfer_works_job_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe TransferWorksJob, :clean do
+  let(:import_col) { FactoryBot.create(:collection_lw) }
+  let(:true_col)   { FactoryBot.create(:collection_lw) }
+  let(:work)       { FactoryBot.create(:public_generic_work) }
+
+  before do
+    work.member_of_collections << import_col
+    work.save!
+  end
+
+  after do
+    FileUtils.rm('tmp/stackprof-curate.dump')
+  end
+
+  it 'transfers work from import collection to true collection' do
+    expect(import_col.member_works).to include(work)
+    described_class.perform_now(import_col.id, true_col.id)
+    expect(File).to exist('tmp/stackprof-curate.dump')
+    expect(import_col.member_works.count).to eq 0
+    expect(import_col.member_works).not_to include(work)
+    expect(true_col.member_works.count).to eq 1
+    expect(true_col.member_works).to include(work)
+  end
+end


### PR DESCRIPTION
* We are also adding a call-stack profiler called stackprof to be able to study our internal classes and methods that are taking long durations to execute.

Once the job finishes running, it will create a stackprof dump file which can be viewed/examined using following two methods:

**1) Using a web ui** (This is the quickest way to view results locally): https://github.com/alisnic/stackprof-webnav
TLDR;
**install gem locally** 
```
$ gem install stackprof-webnav
```
**run the web ui server**
```
$ stackprof-webnav -f path/to/stackprof.dump
```
**go to web port**
```
localhost:9292
```
Result:
![image](https://user-images.githubusercontent.com/17075287/82094273-b60bac80-96ca-11ea-82f9-81dba7f198cb.png)
![image](https://user-images.githubusercontent.com/17075287/82094284-b9069d00-96ca-11ea-9f61-2f619d3f9a01.png)

**2) Using console:** 
After running `bundle install` on your local machine, run the background job and follow steps to view stackprof dump file in the console and flamegraph in a viewer:
```
stackprof tmp/stackprof-curate.dump --text
```
output:
![image](https://user-images.githubusercontent.com/17075287/82094512-3af6c600-96cb-11ea-9875-5876da04e2b1.png)

Next, flamegraph:
```
stackprof --flamegraph tmp/stackprof-curate.dump > tmp/flamegraph
```
Next, flamegraphviewer:
```
stackprof --flamegraph-viewer=tmp/flamegraph
```
Output:
![image](https://user-images.githubusercontent.com/17075287/82094723-9de85d00-96cb-11ea-9421-a6e78e29770b.png)
