### PR TITLE
Restrict visibility of delete buttons

### DIFF
--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,0 +1,53 @@
+<% # [Hyrax-overwrite-v3.0.0-beta1] Only display delete button if user is an admin L#44 %>
+<div class="row show-actions button-row-top-two-column">
+  <div class="col-sm-6">
+    <% if presenter.show_deposit_for?(collections: @user_collections) %>
+      <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
+      <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
+                    class: 'btn btn-default submits-batches submits-batches-add',
+                    data: { toggle: "modal", target: "#collection-list-container" } %>
+    <% end %>
+    <% if presenter.work_featurable? %>
+      <%= link_to t('.feature'), hyrax.featured_work_path(presenter, format: :json),
+          data: { behavior: 'feature' },
+          class: presenter.display_feature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>
+
+      <%= link_to t('.unfeature'), hyrax.featured_work_path(presenter, format: :json),
+          data: { behavior: 'unfeature' },
+          class: presenter.display_unfeature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>
+    <% end %>
+    <% if Hyrax.config.analytics? %>
+      <% # turbolinks needs to be turned off or the page will use the cache and the %>
+      <% # analytics graph will not show unless the page is refreshed. %>
+      <%= link_to t('.analytics'), presenter.stats_path, id: 'stats', class: 'btn btn-default', data: { turbolinks: false } %>
+    <% end %>
+  </div>
+  <div class="col-sm-6 text-right">
+    <% if presenter.editor? %>
+      <%= link_to t('.edit'), edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
+      <% if presenter.member_presenters.size > 1 %>
+          <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-default' %>
+      <% end %>
+      <% if presenter.valid_child_concerns.length > 0 %>
+        <div class="btn-group">
+          <button type="button" class="btn btn-default dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <%= t('.attach_child') %> <span class="caret"></span></button>
+            <ul class="dropdown-menu">
+              <% presenter.valid_child_concerns.each do |concern| %>
+                <li>
+                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
+                </li>
+              <% end %>
+            </ul>
+        </div>
+      <% end %>
+      <% if current_user.admin? %>
+        <%= link_to t('.delete'), [main_app, presenter], class: 'btn btn-danger', data: { confirm: t('.confirm_delete', work_type: presenter.human_readable_type) }, method: :delete %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+<!-- COinS hook for Zotero -->
+  <span class="Z3988" title="<%= export_as_openurl_ctx_kev(presenter) %>"></span>
+<!-- Render Modals -->
+  <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>

--- a/app/views/hyrax/dashboard/collections/_show_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_actions.html.erb
@@ -1,0 +1,29 @@
+<% # [Hyrax-overwrite-v3.0.0-beta1] Only display delete button if user is an admin L#22 %>
+<h2 class="sr-only"><%= t('hyrax.collection.actions.header') %></h2>
+<% if can? :edit, presenter.solr_document %>
+    <%= link_to t('hyrax.collection.actions.edit.label'),
+                hyrax.edit_dashboard_collection_path(presenter),
+                title: t('hyrax.collection.actions.edit.desc'),
+                class: 'btn btn-primary' %>
+<% end %>
+
+<% if presenter.collection_type_is_nestable? && presenter.user_can_nest_collection? %>
+<!-- The user should have deposit access to the parent and read access to the child (the collection we are already showing, so no test is necessary). -->
+    <%= button_tag '',
+                  class: 'btn btn-primary add-to-collection',
+                  title: t("hyrax.collection.actions.nested_subcollection.desc"),
+                  type: 'button',
+                  data: { nestable: presenter.collection_type_is_nestable?,
+                          hasaccess: true } do %>
+                  <%= t('hyrax.collection.actions.nested_subcollection.button_label') %>
+                <% end %>
+<% end %>
+
+<% if can?(:destroy, presenter.solr_document) && current_user.admin? %>
+    <%= link_to t('hyrax.collection.actions.delete.label'),
+                hyrax.dashboard_collection_path(presenter),
+                title: t('hyrax.collection.actions.delete.desc'),
+                class: 'btn btn-danger',
+                data: { confirm: t('hyrax.collection.actions.delete.confirmation'),
+                        method: :delete } %>
+<% end %>

--- a/app/views/hyrax/my/_collection_action_menu.html.erb
+++ b/app/views/hyrax/my/_collection_action_menu.html.erb
@@ -1,0 +1,63 @@
+<% # [Hyrax-overwrite-v3.0.0-beta1] Only display delete button if user is an admin L#37 %>
+<% id = collection_presenter.id %>
+<% ul_id = 'collection-action-dropdown-ul-' + id %>
+
+<div class="btn-group">
+  <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= id %>" aria-haspopup="true" aria-expanded="false" aria-controls="<%= ul_id %>">
+    <span class="sr-only"><%= t("hyrax.dashboard.my.sr.press_to") %> </span>
+    <%= t("hyrax.dashboard.my.action.select") %> <span class="caret" aria-hidden="true"></span>
+  </button>
+
+  <ul role="menu" id="<%= ul_id %>" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= id %>">
+    <li role="menuitem" tabindex="-1">
+      <%= link_to hyrax.dashboard_collection_path(id),
+                  class: 'itemicon itemedit',
+                  title: t("hyrax.dashboard.my.action.view_collection") do %>
+        <%= t("hyrax.dashboard.my.action.view_collection") %>
+      <% end %>
+    </li>
+    <% if can? :edit, collection_presenter.solr_document %>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to hyrax.edit_dashboard_collection_path(id),
+                    class: 'itemicon itemedit',
+                    title: t("hyrax.dashboard.my.action.edit_collection")  do %>
+          <%= t("hyrax.dashboard.my.action.edit_collection") %>
+        <% end %>
+      </li>
+    <% else %>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to "#",
+                    class: 'itemicon itemedit edit-collection-deny-button',
+                    title: t("hyrax.dashboard.my.action.edit_collection") do %>
+          <%= t("hyrax.dashboard.my.action.edit_collection") %>
+        <% end %>
+      </li>
+    <% end %>
+
+    <% if current_user.admin? %>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to "#",
+                    class: 'itemicon itemtrash delete-collection-button',
+                    title: t("hyrax.dashboard.my.action.delete_collection"),
+                    data: { totalitems: collection_presenter.total_items ,
+                            membership: collection_presenter.collection_type_is_require_membership? ,
+                            hasaccess: (can?(:edit, collection_presenter.solr_document)) } do %>
+          <%= t("hyrax.dashboard.my.action.delete_collection") %>
+        <% end %>
+      </li>
+    <% end %>
+
+    <% if Hyrax::CollectionType.any_nestable? %>
+      <% # The user should have deposit access to the parent we are adding, and read access to the child (the collection we are linking here). %>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to "#",
+                    class: 'itemicon add-to-collection',
+                    title: t("hyrax.dashboard.my.action.add_to_collection"),
+                    data: { nestable: collection_presenter.collection_type_is_nestable? ,
+                            hasaccess: (can?(:read, collection_presenter.solr_document)) } do %>
+          <%= t("hyrax.dashboard.my.action.add_to_collection") %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/hyrax/my/_work_action_menu.html.erb
+++ b/app/views/hyrax/my/_work_action_menu.html.erb
@@ -1,0 +1,50 @@
+<% # [Hyrax-overwrite-v3.0.0-beta1] Only display delete button if user is an admin L#22 %>
+<% ul_id = 'admin-set-action-dropdown-ul-' + document.id %>
+
+<div class="btn-group">
+
+  <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= document.id %>" aria-haspopup="true" aria-expanded="false" aria-controls="<%= ul_id %>">
+    <span class="sr-only"><%= t("hyrax.dashboard.my.sr.press_to") %> </span>
+    <%= t("hyrax.dashboard.my.action.select") %>
+    <span class="caret" aria-hidden="true"></span>
+  </button>
+
+  <ul role="menu" id="<%= ul_id %>" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= document.id %>">
+
+    <% if can? :edit, document.id %>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to [main_app, :edit, document] do %>
+          <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
+          <span> <%= t("hyrax.dashboard.my.action.edit_work") %> </span>
+        <% end %>
+      </li>
+
+      <% if current_user.admin? %>
+        <li role="menuitem" tabindex="-1">
+          <%= link_to [main_app, document],
+                      method: :delete,
+                      data: {
+                        confirm: t("hyrax.dashboard.my.action.work_confirmation", application_name: application_name) } do %>
+            <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
+            <span> <%= t("hyrax.dashboard.my.action.delete_work") %> </span>
+          <% end %>
+        </li>
+      <% end %>
+    <% end %>
+
+    <li role="menuitem" tabindex="-1">
+      <%= display_trophy_link(current_user, document.id) do |text| %>
+        <i class="glyphicon glyphicon-star" aria-hidden="true"></i> <%= text %>
+      <% end %>
+    </li>
+
+    <% if can? :transfer, document.id %>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to(hyrax.new_work_transfer_path(document.id), class: 'itemicon itemtransfer', title: t("hyrax.dashboard.my.action.transfer")) do %>
+          <i class="glyphicon glyphicon-transfer" aria-hidden="true"></i>
+          <span> <%= t("hyrax.dashboard.my.action.transfer") %> </span>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/spec/system/viewing_a_collection_spec.rb
+++ b/spec/system/viewing_a_collection_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Viewing collections', type: :system, clean: true do
     before do
       login_as admin_user
     end
-    
+
     it 'has a delete action on the my collections dashboard' do
       visit "/dashboard/my/collections"
       expect(page).to have_selector(:css, 'a[title="Delete collection"]')

--- a/spec/system/viewing_a_collection_spec.rb
+++ b/spec/system/viewing_a_collection_spec.rb
@@ -43,13 +43,13 @@ RSpec.describe 'Viewing collections', type: :system, clean: true do
       expect(page).not_to have_selector(:css, 'a[title="Delete collection"]')
     end
 
-    it ' does not have a delete action on the all collections dashboard' do
+    it 'does not have a delete action on the all collections dashboard' do
       login_as user
       visit "/dashboard/collections"
       expect(page).not_to have_selector(:css, 'a[title="Delete collection"]')
     end
 
-    it 'has a delete action on the individual collection dashboard page' do
+    it 'does not have a delete action on the individual collection dashboard page' do
       login_as user
       visit "/dashboard/collections/#{user_collection.id}"
       expect(page).to have_selector(:css, 'a[title="Edit this collection"]')

--- a/spec/system/viewing_a_collection_spec.rb
+++ b/spec/system/viewing_a_collection_spec.rb
@@ -16,41 +16,45 @@ RSpec.describe 'Viewing collections', type: :system, clean: true do
   end
 
   context 'when logged in as an admin' do
-    it 'has a delete action on the my collections dashboard' do
+    before do
       login_as admin_user
+    end
+    
+    it 'has a delete action on the my collections dashboard' do
       visit "/dashboard/my/collections"
       expect(page).to have_selector(:css, 'a[title="Delete collection"]')
     end
 
     it 'has a delete action on the all collections dashboard' do
-      login_as admin_user
       visit "/dashboard/collections"
       expect(page).to have_selector(:css, 'a[title="Delete collection"]')
     end
 
     it 'has a delete action on the individual collection dashboard page' do
-      login_as admin_user
       visit "/dashboard/collections/#{admin_collection.id}"
+      expect(page).to have_selector(:css, 'a[title="Delete this collection"]')
+      visit "/dashboard/collections/#{user_collection.id}"
       expect(page).to have_selector(:css, 'a[title="Delete this collection"]')
     end
   end
 
   context 'when logged in as a non-admin user' do
-    it 'does not have a delete action on the my collections dashboard' do
+    before do
       login_as user
+    end
+
+    it 'does not have a delete action on the my collections dashboard' do
       visit "/dashboard/my/collections"
       expect(page).to have_selector(:css, 'a[title="Edit collection"]')
       expect(page).not_to have_selector(:css, 'a[title="Delete collection"]')
     end
 
     it 'does not have a delete action on the all collections dashboard' do
-      login_as user
       visit "/dashboard/collections"
       expect(page).not_to have_selector(:css, 'a[title="Delete collection"]')
     end
 
     it 'does not have a delete action on the individual collection dashboard page' do
-      login_as user
       visit "/dashboard/collections/#{user_collection.id}"
       expect(page).to have_selector(:css, 'a[title="Edit this collection"]')
       expect(page).not_to have_selector(:css, 'a[title="Delete this collection"]')

--- a/spec/system/viewing_a_collection_spec.rb
+++ b/spec/system/viewing_a_collection_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Viewing collections', type: :system, clean: true do
+  let(:admin_user) { FactoryBot.create(:admin) }
+  let(:admin_collection) { FactoryBot.build(:public_collection_lw, user: admin_user, with_permission_template: true) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:user_collection) { FactoryBot.build(:public_collection_lw, user: user, with_permission_template: true) }
+
+  before do
+    admin_collection.save!
+    admin_collection.reload
+    user_collection.save!
+    user_collection.reload
+  end
+
+  context 'when logged in as an admin' do
+    it 'has a delete action on the my collections dashboard' do
+      login_as admin_user
+      visit "/dashboard/my/collections"
+      expect(page).to have_selector(:css, 'a[title="Delete collection"]')
+    end
+
+    it 'has a delete action on the all collections dashboard' do
+      login_as admin_user
+      visit "/dashboard/collections"
+      expect(page).to have_selector(:css, 'a[title="Delete collection"]')
+    end
+
+    it 'has a delete action on the individual collection dashboard page' do
+      login_as admin_user
+      visit "/dashboard/collections/#{admin_collection.id}"
+      expect(page).to have_selector(:css, 'a[title="Delete this collection"]')
+    end
+  end
+
+  context 'when logged in as a non-admin user' do
+    it 'does not have a delete action on the my collections dashboard' do
+      login_as user
+      visit "/dashboard/my/collections"
+      expect(page).to have_selector(:css, 'a[title="Edit collection"]')
+      expect(page).not_to have_selector(:css, 'a[title="Delete collection"]')
+    end
+
+    it ' does not have a delete action on the all collections dashboard' do
+      login_as user
+      visit "/dashboard/collections"
+      expect(page).not_to have_selector(:css, 'a[title="Delete collection"]')
+    end
+
+    it 'has a delete action on the individual collection dashboard page' do
+      login_as user
+      visit "/dashboard/collections/#{user_collection.id}"
+      expect(page).to have_selector(:css, 'a[title="Edit this collection"]')
+      expect(page).not_to have_selector(:css, 'a[title="Delete this collection"]')
+    end
+  end
+end

--- a/spec/system/viewing_a_work_spec.rb
+++ b/spec/system/viewing_a_work_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
     before do
       login_as user
     end
-    
+
     it 'does not have a delete button on the show page' do
       visit "/concern/curate_generic_works/#{user_work.id}"
       expect(page).not_to have_selector(:css, 'a[data-method="delete"]')

--- a/spec/system/viewing_a_work_spec.rb
+++ b/spec/system/viewing_a_work_spec.rb
@@ -100,40 +100,42 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
   end
 
   context 'when logged in as an admin' do
-    it 'has a delete button on the show page' do
+    before do
       login_as admin_user
+    end
+
+    it 'has a delete button on the show page' do
       visit "/concern/curate_generic_works/#{user_work.id}"
       expect(page).to have_selector(:css, 'a[data-method="delete"]')
     end
 
     it 'has a delete action on the all works dashboard' do
-      login_as admin_user
       visit "/dashboard/works"
       expect(page).to have_selector(:css, 'a[data-method="delete"]')
     end
 
     it 'has a delete action on the my works dashboard' do
-      login_as admin_user
       visit "/dashboard/my/works"
       expect(page).to have_selector(:css, 'a[data-method="delete"]')
     end
   end
 
   context 'when logged in as a non-admin user' do
-    it 'does not have a delete button on the show page' do
+    before do
       login_as user
+    end
+    
+    it 'does not have a delete button on the show page' do
       visit "/concern/curate_generic_works/#{user_work.id}"
       expect(page).not_to have_selector(:css, 'a[data-method="delete"]')
     end
 
     it 'does not have a delete action on the all works dashboard' do
-      login_as user
       visit "/dashboard/works"
       expect(page).not_to have_selector(:css, 'a[data-method="delete"]')
     end
 
     it 'does not have a delete action on the my works dashboard' do
-      login_as user
       visit "/dashboard/my/works"
       expect(page).not_to have_selector(:css, 'a[data-method="delete"]')
     end


### PR DESCRIPTION
- Only allow admin users to see delete buttons and actions on work show page, my works dashboard page, all works dashboard page, my collections dashboard page, all collections dashboard page, and individual collection dashboard page