### PR TITLE
Ignore gc during code profile generation

### DIFF
--- a/app/jobs/transfer_works_job.rb
+++ b/app/jobs/transfer_works_job.rb
@@ -2,7 +2,7 @@
 
 class TransferWorksJob < Hyrax::ApplicationJob
   def perform(import_col_id, true_col_id)
-    StackProf.run(mode: :cpu, out: 'tmp/stackprof-curate.dump', raw: true) do
+    StackProf.run(mode: :cpu, out: 'tmp/stackprof-curate.dump', raw: true, ignore_gc: true) do
       import_col = Collection.find(import_col_id)
       true_col = Collection.find(true_col_id)
       import_col.member_works.each do |work|


### PR DESCRIPTION
* A large number of samples get generated when running our codeinside the profiler block. By passing the ignore_gc param we are hoping to ignore gc frames when generating a profile which might help to bring the number of frames down.