### PR TITLE
Adds preservation status block to work view page

### DIFF
--- a/app/views/hyrax/base/_preservation_status.html.erb
+++ b/app/views/hyrax/base/_preservation_status.html.erb
@@ -1,0 +1,16 @@
+<!-- Preservation status block -->
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-xs-4 col-sm-4 col-md-4 col-lg-4">
+      <div>
+        <b><%= t('hyrax.base.show.date_uploaded') %>: </b><%= presenter.date_uploaded %>
+      </div>
+      <div>
+        <b><%= t('hyrax.base.show.date_modified') %>: </b><%= presenter.date_modified %>
+      </div>
+      <div>
+        <b><%= t('hyrax.base.show.depositor') %>: </b><%= presenter.depositor.first %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -44,6 +44,15 @@
 
     <div class="panel panel-default">
       <div class="panel-heading">
+        <h3 class="panel-title"><%= t('hyrax.base.show.preservation_status') %></h3>
+      </div>
+      <div class="panel-body">
+        <%= render 'preservation_status', presenter: @presenter %>
+      </div>
+    </div>
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
         <h3 class="panel-title"><%= t('hyrax.base.show.relationships') %></h3>
       </div>
       <div class="panel-body">

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -216,6 +216,11 @@ en:
         required_agreement: Check distribution license
       items:
         empty: 'This %{type} has no files associated with it. (If you just created this %{type}, it may take a few minutes for the files to display. Try refreshing the page again.) Otherwise, click edit to add more files.'
+      show:
+        preservation_status: "Preservation Status"
+        date_modified: "Date Modified"
+        date_uploaded: "Date Uploaded"
+        depositor: "Depositor"
     account_name: My Institution Account Id
     directory:
       suffix: "@example.org"

--- a/spec/system/viewing_a_work_spec.rb
+++ b/spec/system/viewing_a_work_spec.rb
@@ -202,4 +202,14 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
       end
     end
   end
+
+  describe 'preservation status block' do
+    it 'has status block with details' do
+      visit "/concern/curate_generic_works/#{work.id}"
+      expect(page).to have_content('Preservation Status')
+      expect(page).to have_content('Date Uploaded')
+      expect(page).to have_content('Date Modified')
+      expect(page).to have_content('Depositor')
+    end
+  end
 end


### PR DESCRIPTION
* Also, adds preliminary details like date uploaded, modified, depositor info to the new preservation status block.

Connected to: #1024 #1025 

Output:
![image](https://user-images.githubusercontent.com/17075287/82596887-193b8a00-9b76-11ea-8dc1-5d6733048ae9.png)
