### PR TITLE
Restrict delete methods to admins

### DIFF
--- a/app/controllers/hyrax/curate_generic_works_controller.rb
+++ b/app/controllers/hyrax/curate_generic_works_controller.rb
@@ -43,6 +43,16 @@ module Hyrax
       end
     end
 
+    def destroy
+      if current_user.admin?
+        title = curation_concern.to_s
+        env = Actors::Environment.new(curation_concern, current_ability, {})
+        return unless actor.destroy(env)
+        Hyrax.config.callback.run(:after_destroy, curation_concern.id, current_user, warn: false)
+        after_destroy_response(title)
+      end
+    end
+
     def manifest
       headers['Access-Control-Allow-Origin'] = '*'
       render json: ManifestBuilderService.build_manifest(presenter: presenter, curation_concern: _curation_concern_type.find(params[:id]))

--- a/app/controllers/hyrax/curate_generic_works_controller.rb
+++ b/app/controllers/hyrax/curate_generic_works_controller.rb
@@ -43,19 +43,33 @@ module Hyrax
       end
     end
 
+    def manifest
+      headers['Access-Control-Allow-Origin'] = '*'
+      render json: ManifestBuilderService.build_manifest(presenter: presenter, curation_concern: _curation_concern_type.find(params[:id]))
+    end
+
+    # [Hyrax-overwrite-v3.0.0-beta1] Restrict deletion to admins only
     def destroy
+      title = curation_concern.to_s
       if current_user.admin?
-        title = curation_concern.to_s
         env = Actors::Environment.new(curation_concern, current_ability, {})
         return unless actor.destroy(env)
         Hyrax.config.callback.run(:after_destroy, curation_concern.id, current_user, warn: false)
         after_destroy_response(title)
+      else
+        after_destroy_error(title)
       end
     end
 
-    def manifest
-      headers['Access-Control-Allow-Origin'] = '*'
-      render json: ManifestBuilderService.build_manifest(presenter: presenter, curation_concern: _curation_concern_type.find(params[:id]))
+    def after_destroy_error(title)
+      respond_to do |wants|
+        wants.html do
+          build_form
+          flash[:notice] = "#{title} could not be deleted"
+          render 'edit', status: :unprocessable_entity
+        end
+        wants.json { render_json_response(response_type: :unprocessable_entity, options: { errors: curation_concern.errors }) }
+      end
     end
   end
 end

--- a/app/controllers/hyrax/dashboard/collections_controller_override.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller_override.rb
@@ -18,7 +18,7 @@ module Hyrax
         banner_info.save f.collection_banner_url
       end
 
-      # [Hyrax-overwrite-v3.0.0-beta1] Restrict delete method to admins only
+      # [Hyrax-overwrite-v3.0.0-beta1] Restrict deletion to admins only
       def destroy
         if current_user.admin? && @collection.destroy
           after_destroy(params[:id])

--- a/app/controllers/hyrax/dashboard/collections_controller_override.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller_override.rb
@@ -17,6 +17,15 @@ module Hyrax
         )
         banner_info.save f.collection_banner_url
       end
+
+      # [Hyrax-overwrite-v3.0.0-beta1] Restrict delete method to admins only
+      def destroy
+        if current_user.admin? && @collection.destroy
+          after_destroy(params[:id])
+        else
+          after_destroy_error(params[:id])
+        end
+      end
     end
   end
 end

--- a/spec/controllers/hyrax/curate_generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/curate_generic_works_controller_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Hyrax::CurateGenericWorksController, :clean do
         expect(response).to have_http_status(:found)
         expect(response).to redirect_to(Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
         expect(flash[:notice]).to eq "Deleted Test title"
+        expect(CurateGenericWork.count).to eq 0
       end
     end
 
@@ -35,6 +36,7 @@ RSpec.describe Hyrax::CurateGenericWorksController, :clean do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template(:edit)
         expect(flash[:notice]).to eq "Test title could not be deleted"
+        expect(CurateGenericWork.count).to eq 1
       end
     end
   end

--- a/spec/controllers/hyrax/curate_generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/curate_generic_works_controller_spec.rb
@@ -2,9 +2,10 @@
 
 require 'rails_helper'
 
-RSpec.describe Hyrax::CurateGenericWorksController do
-  let(:work) { FactoryBot.create(:public_generic_work, id: '888889') }
+RSpec.describe Hyrax::CurateGenericWorksController, :clean do
+  let(:work) { FactoryBot.create(:public_generic_work, id: '888889', user: user) }
   let(:user) { FactoryBot.create(:user) }
+  let(:admin) { FactoryBot.create(:admin) }
 
   describe "GET #manifest" do
     before { ENV['IIIF_MANIFEST_CACHE'] = "./tmp" }
@@ -13,6 +14,28 @@ RSpec.describe Hyrax::CurateGenericWorksController do
       sign_in user
       get :manifest, params: { id: work.id, format: 'json' }
       expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "#delete" do
+    context "when logged in as an admin" do
+      it "redirects to My Works" do
+        sign_in admin
+        delete :destroy, params: { id: work }
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
+        expect(flash[:notice]).to eq "Deleted Test title"
+      end
+    end
+
+    context "when logged in as a non-admin user" do
+      it "redirects to the edit view" do
+        sign_in user
+        delete :destroy, params: { id: work }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to render_template(:edit)
+        expect(flash[:notice]).to eq "Test title could not be deleted"
+      end
     end
   end
 end

--- a/spec/controllers/hyrax/dashboard/collections_controller_override_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_override_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::Dashboard::CollectionsController, :clean do
+  routes { Hyrax::Engine.routes }
+  let(:admin) { FactoryBot.create(:admin) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:collection) { FactoryBot.create(:public_collection_lw, id: '888889', user: user, with_permission_template: true) }
+
+  describe "#delete" do
+    context "when logged in as an admin" do
+      before { sign_in admin }
+      it "destroys the collection" do
+        delete :destroy, params: { id: collection }
+        expect(response).to have_http_status(:found)
+        expect(Collection.count).to eq 0
+      end
+    end
+
+    context "when logged in as a non-admin user" do
+      before { sign_in user }
+      it "does not destroy the collection" do
+        delete :destroy, params: { id: collection }
+        expect(response).not_to be_successful
+        expect(Collection.count).to eq 1
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Only admins can delete works and collections. When a non-admin user tries to submit an HTTP request for deletion, they get an unsuccessful response and are redirected to the Edit page.