### PR TITLE
Adds preservation workflow info to status block

### DIFF
--- a/app/presenters/hyrax/curate_generic_work_presenter.rb
+++ b/app/presenters/hyrax/curate_generic_work_presenter.rb
@@ -42,5 +42,13 @@ module Hyrax
     def visibility
       solr_document.human_readable_visibility
     end
+
+    def preservation_workflows
+      final = []
+      preservation_workflow_terms&.each do |pwf|
+        final << JSON.parse(pwf)
+      end
+      final
+    end
   end
 end

--- a/app/presenters/hyrax/curate_generic_work_presenter.rb
+++ b/app/presenters/hyrax/curate_generic_work_presenter.rb
@@ -48,7 +48,21 @@ module Hyrax
       preservation_workflow_terms&.each do |pwf|
         final << JSON.parse(pwf)
       end
-      final
+      accession = final.select { |pwf| pwf["workflow_type"] == "Accession" }.first # get accession worfklow
+      accession_result = workflow_hash(accession.compact) if accession # make non nil value keys displayable
+      ingest = final.select { |pwf| pwf["workflow_type"] == "Ingest" }.first # get ingest workflow
+      ingest_result = workflow_hash(ingest.compact) if ingest # make non nil value keys displayable
+      [accession_result || { "Type" => "Accession" }, ingest_result || { "Type" => "Ingest" }] # send result or only type if a result is nil
     end
+
+    private
+
+      def workflow_hash(wf)
+        wf_copy = wf.clone
+        wf.each_key do |key|
+          wf_copy[key.split('_').map(&:capitalize).join(' ').remove('Workflow ')] = wf_copy.delete(key) # alter keys as per display requirements
+        end
+        wf_copy
+      end
   end
 end

--- a/app/views/hyrax/base/_preservation_status.html.erb
+++ b/app/views/hyrax/base/_preservation_status.html.erb
@@ -12,24 +12,20 @@
         <b><%= t('hyrax.base.show.depositor') %>: </b><%= presenter.depositor.first %>
       </div>
       <div>
-        <% unless presenter.preservation_workflows.empty? %>
-          <% presenter.preservation_workflows.each do |pwf| %>
-            <b><%= pwf["workflow_type"] %>:</b>
-              <% if pwf.values.compact.count > 1 %>
-                <% pwf.each do |k, v| %> 
-                  <div><%= "#{k.split('_').map(&:capitalize).join(' ').remove('Workflow ')}: #{v}" if v && k != "workflow_type" %></div>
-                <% end %>
-              <% else %>
-                <div>No information supplied</div>
-              <% end %>
+        <!-- iterate through workflows -->
+        <% presenter.preservation_workflows.each do |pwf| %>
+        <!-- display workflow type-->
+        <b><%= pwf["Type"] %>:</b>
+          <!-- display key value pairs only if workflow details exist -->
+          <% unless pwf.values.count > 1 %>
+            <div>No information supplied</div>
+          <% else %>
+            <% pwf.each do |key, value| %>
+              <!-- display all key value pairs except type to match display requirements -->
+              <div><%= "#{key}: #{value}" unless key == "Type" %></div>
+            <% end %>
           <% end %>
-        <% else %>
-          <b>Accession: </b>
-          <div>No information supplied</div>
-          <b>Ingest: </b>
-          <div>No information supplied</div>
         <% end %>
-      </div>
     </div>
   </div>
 </div>

--- a/app/views/hyrax/base/_preservation_status.html.erb
+++ b/app/views/hyrax/base/_preservation_status.html.erb
@@ -1,7 +1,7 @@
 <!-- Preservation status block -->
 <div class="container-fluid">
   <div class="row">
-    <div class="col-xs-4 col-sm-4 col-md-4 col-lg-4">
+    <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6">
       <div>
         <b><%= t('hyrax.base.show.date_uploaded') %>: </b><%= presenter.date_uploaded %>
       </div>
@@ -10,6 +10,25 @@
       </div>
       <div>
         <b><%= t('hyrax.base.show.depositor') %>: </b><%= presenter.depositor.first %>
+      </div>
+      <div>
+        <% unless presenter.preservation_workflows.empty? %>
+          <% presenter.preservation_workflows.each do |pwf| %>
+            <b><%= pwf["workflow_type"] %>:</b>
+              <% if pwf.values.compact.count > 1 %>
+                <% pwf.each do |k, v| %> 
+                  <div><%= "#{k.split('_').map(&:capitalize).join(' ').remove('Workflow ')}: #{v}" if v && k != "workflow_type" %></div>
+                <% end %>
+              <% else %>
+                <div>No information supplied</div>
+              <% end %>
+          <% end %>
+        <% else %>
+          <b>Accession: </b>
+          <div>No information supplied</div>
+          <b>Ingest: </b>
+          <div>No information supplied</div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
+++ b/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
@@ -17,7 +17,10 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
       "date_created_tesim" => ['an unformatted date'],
       "depositor_tesim" => user_key,
       "holding_repository_tesim" => ["test holding repo"],
-      "rights_statement_tesim" => ["empl.com"] }
+      "rights_statement_tesim" => ["empl.com"],
+      "preservation_workflow_terms_tesim" => ["{\"workflow_type\":\"Ingest\",\"workflow_notes\":\"Migrated to Cor repository from Extensis Portfolio\",
+        \"workflow_rights_basis\":\"Administrative Signo\",\"workflow_rights_basis_note\":\"This is a sample note. This field isn't always populated.\",
+        \"workflow_rights_basis_date\":\"2016-03-01\",\"workflow_rights_basis_reviewer\":\"Scholarly Communications Office\",\"workflow_rights_basis_uri\":null}"] }
   end
 
   describe '#manifest_url' do
@@ -69,6 +72,16 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
     describe "#purl" do
       subject { presenter.purl }
       it { is_expected.to eq "https://example.com/purl/888888" }
+    end
+
+    describe "#preservation_workflows" do
+      subject :workflows do
+        presenter.preservation_workflows
+      end
+      it "returns preservation workflows" do
+        expect(workflows.any? { |pwf| pwf['workflow_type'] == 'Ingest' }).to be_truthy
+        expect(workflows.any? { |pwf| pwf['workflow_type'] == 'Accession' }).to be_falsy
+      end
     end
   end
 end

--- a/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
+++ b/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
       "holding_repository_tesim" => ["test holding repo"],
       "rights_statement_tesim" => ["empl.com"],
       "preservation_workflow_terms_tesim" => ["{\"workflow_type\":\"Ingest\",\"workflow_notes\":\"Migrated to Cor repository from Extensis Portfolio\",
-        \"workflow_rights_basis\":\"Administrative Signo\",\"workflow_rights_basis_note\":\"This is a sample note. This field isn't always populated.\",
+        \"workflow_rights_basis\":\"Administrative Signo\",\"workflow_rights_basis_note\":\"Ingest note\",
         \"workflow_rights_basis_date\":\"2016-03-01\",\"workflow_rights_basis_reviewer\":\"Scholarly Communications Office\",\"workflow_rights_basis_uri\":null}"] }
   end
 
@@ -79,8 +79,8 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
         presenter.preservation_workflows
       end
       it "returns preservation workflows" do
-        expect(workflows.any? { |pwf| pwf['workflow_type'] == 'Ingest' }).to be_truthy
-        expect(workflows.any? { |pwf| pwf['workflow_type'] == 'Accession' }).to be_falsy
+        expect(workflows.any? { |pwf| pwf['Rights Basis Note'] == 'Ingest note' }).to be_truthy
+        expect(workflows.any? { |pwf| pwf['Rights Basis Note'] == 'Accession note' }).to be_falsy
       end
     end
   end

--- a/spec/system/viewing_a_work_spec.rb
+++ b/spec/system/viewing_a_work_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
 
       it 'has no pwf information' do
         visit "/concern/curate_generic_works/#{work.id}"
-        expect(page).to have_content('No information supplied')
+        expect(page).to have_content('No information supplied').twice
       end
     end
 
@@ -231,7 +231,7 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
         visit "/concern/curate_generic_works/#{work.id}"
         expect(page).to have_content('Ingest')
         expect(page).to have_content('Ingest notes')
-        expect(page).to have_content('No information supplied')
+        expect(page).to have_content('No information supplied').once
       end
     end
 

--- a/spec/system/viewing_a_work_spec.rb
+++ b/spec/system/viewing_a_work_spec.rb
@@ -211,5 +211,42 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
       expect(page).to have_content('Date Modified')
       expect(page).to have_content('Depositor')
     end
+
+    context 'when no pwf is supplied' do
+      let(:work) { CurateGenericWork.create(title: ['foo'], depositor: 'example') }
+
+      it 'has no pwf information' do
+        visit "/concern/curate_generic_works/#{work.id}"
+        expect(page).to have_content('No information supplied')
+      end
+    end
+
+    context 'when only ingest pwf is supplied' do
+      let(:work) do
+        CurateGenericWork.create(title: ['foo'], depositor: 'example', preservation_workflow_attributes: [{ "workflow_type" => "Ingest", "workflow_notes" => "Ingest notes" },
+                                                                                                          { "workflow_type" => "Accession" }])
+      end
+
+      it 'has only ingest and no accession pwf information' do
+        visit "/concern/curate_generic_works/#{work.id}"
+        expect(page).to have_content('Ingest')
+        expect(page).to have_content('Ingest notes')
+        expect(page).to have_content('No information supplied')
+      end
+    end
+
+    context 'when both pwf are supplied' do
+      let(:work) do
+        CurateGenericWork.create(title: ['foo'], depositor: 'example', preservation_workflow_attributes: [{ "workflow_type" => "Ingest", "workflow_rights_basis_date" => "02/02/2012" },
+                                                                                                          { "workflow_type" => "Accession", "workflow_rights_basis_note" => "Accession notes" }])
+      end
+
+      it 'has both pwf information' do
+        visit "/concern/curate_generic_works/#{work.id}"
+        expect(page).to have_content('Ingest')
+        expect(page).to have_content('Accession')
+        expect(page).to have_content('Accession notes')
+      end
+    end
   end
 end


### PR DESCRIPTION
* We are adding preservation workflow information for a work to the status block. The information is populated if it is supplied.

Output examples:
![image](https://user-images.githubusercontent.com/17075287/83173229-b5b9db00-a0e6-11ea-80b4-d2b0645972b3.png)
![image](https://user-images.githubusercontent.com/17075287/83173246-bbafbc00-a0e6-11ea-9e28-983dd3416082.png)
