### PR TITLE
Changes file download link text

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -243,6 +243,15 @@ en:
     file_sets:
       form:
         pcdm_use: "FileSet use"
+    file_set:
+      show:
+        downloadable_content:
+          image_link: "Download Preservation Master File"
+          video_link: "Download Preservation Master File"
+          pdf_link: "Download Preservation Master File"
+          office_link: "Download Preservation Master File"
+          audio_link: "Download Preservation Master File"
+        download: "Download Preservation Master File"
   simple_form:
     hints:
       admin_set:

--- a/spec/system/show_file_spec.rb
+++ b/spec/system/show_file_spec.rb
@@ -31,8 +31,11 @@ RSpec.describe "Showing a file:", integration: true, clean: true, type: :system 
   end
 
   context 'on a fileset view page' do
-    it 'shows additional files' do
+    before do
       visit hyrax_file_set_path(file_set)
+    end
+
+    it 'shows additional files' do
       expect(page).to have_content('sun.png')
       expect(page).to have_content('Service File')
       expect(page).to have_content('image.jp2')
@@ -40,8 +43,11 @@ RSpec.describe "Showing a file:", integration: true, clean: true, type: :system 
     end
 
     it 'shows fileset category' do
-      visit hyrax_file_set_path(file_set)
       expect(find('#fileset-category').text).to include('Primary Content')
+    end
+
+    it 'shows pmf download link' do
+      expect(first('#file_download').text).to eq('Download Preservation Master File')
     end
   end
 


### PR DESCRIPTION
* This commit changes the download link text on fileset page from `download image` to `Download Preservation Master File`.

Connected to: #1033 

Before:
![image](https://user-images.githubusercontent.com/17075287/83460098-9d71f500-a433-11ea-8bb4-2517802f98a8.png)

After:
![image](https://user-images.githubusercontent.com/17075287/83460040-7f0bf980-a433-11ea-93e4-ae21fb87489d.png)
