### PR TITLE
Removes workflow metadata from main object block and spaces out Acces…

### DIFF
--- a/app/controllers/hyrax/curate_generic_works_controller.rb
+++ b/app/controllers/hyrax/curate_generic_works_controller.rb
@@ -14,14 +14,6 @@ module Hyrax
     def show # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       @user_collections = user_collections
       @parent = main_app.polymorphic_path(parent_presenter) if parent_presenter
-      if presenter.preservation_workflow_terms
-        @preservation_workflow_display = JSON.parse(presenter.preservation_workflow_terms[0]) if presenter.preservation_workflow_terms
-        preservation_workflow_display_copy = @preservation_workflow_display.clone
-        @preservation_workflow_display.each_key do |key|
-          preservation_workflow_display_copy[key.split('_').map(&:capitalize).join(' ')] = preservation_workflow_display_copy.delete(key)
-        end
-        @preservation_workflow_display = preservation_workflow_display_copy
-      end
       respond_to do |wants|
         wants.html { presenter && parent_presenter }
         wants.json do

--- a/app/views/hyrax/base/_preservation_status.html.erb
+++ b/app/views/hyrax/base/_preservation_status.html.erb
@@ -11,7 +11,7 @@
       <div>
         <b><%= t('hyrax.base.show.depositor') %>: </b><%= presenter.depositor.first %>
       </div>
-      <div>
+      <div><br>
         <!-- iterate through workflows -->
         <% presenter.preservation_workflows.each do |pwf| %>
         <!-- display workflow type-->
@@ -25,7 +25,9 @@
               <div><%= "#{key}: #{value}" unless key == "Type" %></div>
             <% end %>
           <% end %>
+          <br>
         <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -29,14 +29,6 @@
           <div class="col-sm-9">
             <%= render 'work_description', presenter: @presenter %>
             <%= render 'metadata', presenter: @presenter %>
-            <% if @preservation_workflow_display %>
-            <% @preservation_workflow_display.each do |key, value| %>
-            <%= key %>
-            <ul class="tabular"><li class="attribute"><span itemprop="dateCreated">
-            <%= value %>
-            </span></li></ul>
-            <% end %>
-            <% end %>
           </div>
         </div>
       </div>

--- a/spec/system/viewing_a_work_spec.rb
+++ b/spec/system/viewing_a_work_spec.rb
@@ -89,14 +89,6 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
     expect(page).to have_content 'title (Title)'
     expect(page).to have_content 'transfer_engineer (Transfer Engineer)'
     expect(page).to have_content 'Volume'
-    # preservation workflow
-    expect(page).to have_content 'Workflow Type'
-    expect(page).to have_content 'Workflow Notes'
-    expect(page).to have_content 'Workflow Rights Basis'
-    expect(page).to have_content 'Workflow Rights Basis Note'
-    expect(page).to have_content 'Workflow Rights Basis Date'
-    expect(page).to have_content 'Workflow Rights Basis Reviewer'
-    expect(page).to have_content 'Workflow Rights Basis Uri'
   end
 
   context 'when logged in as an admin' do


### PR DESCRIPTION
…sion and Ingest details in Preservation Block #1204.
- curate_generic_works_controller.rb: extracts unneeded instance variable definition.
- _preservation_status.html.erb: adds line breaks and forgotten div ending.
- app/views/hyrax/base/show.html.erb: strips outputting logic no longer required.
- spec/system/viewing_a_work_spec.rb: takes out tests for elements that no longer exist.