### PR TITLE
Display preservation master file in files table

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -202,6 +202,7 @@ module Hyrax
       end
 
       def files
+        @pm = @file_set.preservation_master_file unless @file_set.preservation_master_file.nil?
         @sf = @file_set.service_file unless @file_set.service_file.nil?
         @if = @file_set.intermediate_file unless @file_set.intermediate_file.nil?
         @et = @file_set.extracted unless @file_set.extracted.nil?

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -15,23 +15,21 @@
       <%= render 'show_details' %>
       <div id="fileset-category"><strong >FileSet category:</strong> <%= @fileset_use %></div>
       <%= link_to "Parent Work", @parent, class: 'btn btn-link' %>
+      <table class="table table-striped table-bordered">
+        <thead>
+          <th>File name</th>
+          <th>Use</th>
+          <th>Uploaded</th>
+        </thead>
+        <tbody>
+          <%= render partial: 'file_details', locals: { use: "Preservation Master File", file: @pm } unless @pm.nil? %>
+          <%= render partial: 'file_details', locals: { use: "Service File", file: @sf } unless @sf.nil? %>
+          <%= render partial: 'file_details', locals: { use: "Intermediate File", file: @if } unless @if.nil? %>
+          <%= render partial: 'file_details', locals: { use: "Extracted Text", file: @et } unless @et.nil? %>
+          <%= render partial: 'file_details', locals: { use: "Transcript File", file: @tf } unless @tf.nil? %>
+        </tbody>
+      </table>
       <%= render 'hyrax/users/activity_log', events: @presenter.events %>
     </div><!-- /columns second -->
   </div> <!-- /.row -->
-  <div><h3>Additional Files</h3></div>
-  <div>
-    <table class="table table-striped table-bordered">
-      <thead>
-        <th>File name</th>
-        <th>Use</th>
-        <th>Uploaded</th>
-      </thead>
-      <tbody>
-        <%= render partial: 'file_details', locals: { use: "Service File", file: @sf } unless @sf.nil? %>
-        <%= render partial: 'file_details', locals: { use: "Intermediate File", file: @if } unless @if.nil? %>
-        <%= render partial: 'file_details', locals: { use: "Extracted Text", file: @et } unless @et.nil? %>
-        <%= render partial: 'file_details', locals: { use: "Transcript File", file: @tf } unless @tf.nil? %>
-      </tbody>
-    </table>
-  </div>
 </div><!-- /.container-fluid -->

--- a/spec/system/show_file_spec.rb
+++ b/spec/system/show_file_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe "Showing a file:", integration: true, clean: true, type: :system 
     end
 
     it 'shows additional files' do
+      expect(page).to have_content('world.png')
+      expect(page).to have_content('Preservation Master File')
       expect(page).to have_content('sun.png')
       expect(page).to have_content('Service File')
       expect(page).to have_content('image.jp2')


### PR DESCRIPTION
- If a preservation master file for a fileset exists, display it in the files table on the fileset show page
- Move the files table to the desired place on the fileset show page