### PR TITLE
Moves File Details location and changes title #1034.

### DIFF
--- a/app/assets/stylesheets/curate.scss
+++ b/app/assets/stylesheets/curate.scss
@@ -34,3 +34,13 @@
 .preservation_failures_present {
   color: red;
 }
+
+.dl-horizontal-override dt {
+  float: left;
+  width: unset;
+  clear: left;
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/app/assets/stylesheets/curate.scss
+++ b/app/assets/stylesheets/curate.scss
@@ -35,12 +35,22 @@
   color: red;
 }
 
-.dl-horizontal-override dt {
-  float: left;
-  width: unset;
-  clear: left;
-  text-align: right;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+dl.file-show-details {
+  -moz-column-count: 1;
+  -webkit-column-count: 1;
+  column-count: 1;
+  -moz-column-width: unset;
+  -webkit-column-width: unset;
+  column-width: unset;
+  border-top: none;
+  padding-top: 0.70rem;
+
+  dt {
+    text-align: left;
+  }
+
+  dd {
+    padding-bottom: 0.70rem;
+  }
 }
+

--- a/app/views/hyrax/file_sets/_show_details.html.erb
+++ b/app/views/hyrax/file_sets/_show_details.html.erb
@@ -1,0 +1,19 @@
+<h2><%= t(".file_details") %></h2>
+<dl class="dl-horizontal-override file-show-term">
+  <dt><%= t(".depositor") %></dt>
+  <dd itemprop="accountablePerson" itemscope itemtype="http://schema.org/Person"><span itemprop="name"><%= link_to_profile @presenter.depositor %></span></dd>
+  <dt><%= t(".date_uploaded") %></dt>
+  <dd itemprop="datePublished"><%= @presenter.date_uploaded %></dd>
+  <dt><%= t(".date_modified") %></dt>
+  <dd itemprop="dateModified"><%= @presenter.date_modified %></dd>
+  <dt><%= t(".fixity_check") %></dt>
+  <dd><%= @presenter.fixity_check_status %></dd>
+  <dt><%= t(".characterization") %></dt>
+  <dd>
+    <% if @presenter.characterized? %>
+      <%= render 'show_characterization_details' %>
+    <% else %>
+      <%= t(".not_yet_characterized") %>
+    <% end %>
+  </dd>
+</dl>

--- a/app/views/hyrax/file_sets/_show_details.html.erb
+++ b/app/views/hyrax/file_sets/_show_details.html.erb
@@ -1,5 +1,5 @@
 <h2><%= t(".file_details") %></h2>
-<dl class="dl-horizontal-override file-show-term">
+<dl class="dl-horizontal file-show-term file-show-details">
   <dt><%= t(".depositor") %></dt>
   <dd itemprop="accountablePerson" itemscope itemtype="http://schema.org/Person"><span itemprop="name"><%= link_to_profile @presenter.depositor %></span></dd>
   <dt><%= t(".date_uploaded") %></dt>

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -12,7 +12,6 @@
         <%= render 'file_set_title', presenter: @presenter %>
       </header>
       <%# TODO: render 'show_descriptions' See https://github.com/samvera/hyrax/issues/1481 %>
-      <%= render 'show_details' %>
       <div id="fileset-category"><strong >FileSet category:</strong> <%= @fileset_use %></div>
       <%= link_to "Parent Work", @parent, class: 'btn btn-link' %>
       <table class="table table-striped table-bordered">
@@ -32,4 +31,5 @@
       <%= render 'hyrax/users/activity_log', events: @presenter.events %>
     </div><!-- /columns second -->
   </div> <!-- /.row -->
+  <%= render 'show_details' %>
 </div><!-- /.container-fluid -->

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -246,6 +246,8 @@ en:
     file_sets:
       form:
         pcdm_use: "FileSet use"
+      show_details:
+        file_details: "Preservation Master File Details"
     file_set:
       show:
         downloadable_content:

--- a/spec/system/show_file_spec.rb
+++ b/spec/system/show_file_spec.rb
@@ -48,6 +48,15 @@ RSpec.describe "Showing a file:", integration: true, clean: true, type: :system 
       expect(find('#fileset-category').text).to include('Primary Content')
     end
 
+    it 'shows a file details block' do
+      expect(page).to have_content('Preservation Master File Details')
+      expect(page).to have_content('Depositor')
+      expect(page).to have_content('Date Uploaded')
+      expect(page).to have_content('Date Modified')
+      expect(page).to have_content('Fixity Check')
+      expect(page).to have_content('Characterization')
+    end
+
     it 'shows pmf download link' do
       expect(first('#file_download').text).to eq('Download Preservation Master File')
     end


### PR DESCRIPTION
- app/assets/stylesheets/curate.scss: styles the section for spacing and alignment.
- _show_details.html.erb: overrides the title call in localization.
- show.html.erb: moves the render call to the bottom.
- config/locales/hyrax.en.yml: adds new title to override old one.
- spec/*: injects tests that capture the title and field keys.