### PR TITLE
Removes social media links

### DIFF
--- a/app/views/hyrax/file_sets/_show_actions.html.erb
+++ b/app/views/hyrax/file_sets/_show_actions.html.erb
@@ -1,0 +1,15 @@
+<% # [Hyrax-overwrite-v3.0.0-beta1] Remove social media partial rendering %>
+<div class="form-actions">
+  <% if Hyrax.config.analytics? %>
+    <%= link_to "Analytics", @presenter.stats_path, id: 'stats', class: 'btn btn-default' %>
+  <% end %>
+
+  <% if @presenter.editor? %>
+      <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]),
+                  class: 'btn btn-default' %>
+      <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter],
+                  class: 'btn btn-danger', data: { confirm: "Delete this #{@presenter.human_readable_type}?" },
+                  method: :delete %>
+  <% end %>
+
+</div>

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -4,6 +4,7 @@
     <div class="col-xs-12 col-sm-4">
       <%= media_display @presenter %>
       <%= render 'show_actions', presenter: @presenter %>
+      <br>
       <div><%= button_to 'Run Fixity check', file_set_fixity_checks_path(file_set_id: @presenter.id), method: :post, class: 'btn btn-primary' %></div>
       <%= render 'single_use_links', presenter: @presenter if @presenter.editor? %>
     </div>

--- a/spec/system/show_file_spec.rb
+++ b/spec/system/show_file_spec.rb
@@ -101,4 +101,14 @@ RSpec.describe "Showing a file:", integration: true, clean: true, type: :system 
       expect(page).to have_http_status(:success)
     end
   end
+
+  context 'social media share options are not present' do
+    it 'doesnt show share buttons' do
+      visit hyrax_file_set_path(file_set)
+      expect(page).not_to have_link(title: "Facebook", exact: true)
+      expect(page).not_to have_link(title: "Twitter", exact: true)
+      expect(page).not_to have_link(title: "Google+", exact: true)
+      expect(page).not_to have_link(title: "Tumblr", exact: true)
+    end
+  end
 end


### PR DESCRIPTION
* This commit removes social media sharing links from file_set show page as per requirements.

Before:
![image](https://user-images.githubusercontent.com/17075287/83686717-b526b600-a5b8-11ea-83e6-75e95d2221b7.png)

After:
![image](https://user-images.githubusercontent.com/17075287/83686752-c4a5ff00-a5b8-11ea-95b5-f41310a57a70.png)
