### PR TITLE
Creates new Preservation Events table in FileSet view #1037.

### DIFF
--- a/app/indexers/curate/file_set_indexer.rb
+++ b/app/indexers/curate/file_set_indexer.rb
@@ -8,6 +8,7 @@ module Curate
         solr_doc['file_path_ssim'] = object.file_path if object.file_path.present?
         solr_doc['creating_application_name_ssim'] = object.creating_application_name if object.creating_application_name.present?
         solr_doc['puid_ssim'] = object.puid if object.puid.present?
+        solr_doc['preservation_event_tesim'] = [object&.preservation_event&.map(&:preservation_event_terms)]
         if object.preservation_master_file.present?
           solr_doc['file_name_ssim'] = object.preservation_master_file.file_name
           solr_doc['file_size_ssim'] = object.preservation_master_file.file_size

--- a/app/indexers/curate_generic_work_indexer.rb
+++ b/app/indexers/curate_generic_work_indexer.rb
@@ -38,9 +38,9 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
   end
 
   def failed_preservation_events
-    return unless object.preservation_event&.any? { |event| event.outcome == ["Failure"] }
-    needed_events = object.preservation_event.select { |event| event.outcome == ["Failure"] }
-    needed_events.map { |event| "{ \"event_details\": \"#{event['event_details'].first}\", \"event_start\": \"#{event['event_start'].first.strftime('%F')}\" }" }
+    failures = object.preservation_event.select { |event| event.outcome == ["Failure"] }
+    return unless failures.present?
+    failures.map(&:failed_event_json)
   end
 
   def preservation_workflow_terms

--- a/app/models/preservation_event.rb
+++ b/app/models/preservation_event.rb
@@ -15,4 +15,19 @@ class PreservationEvent < ActiveTriples::Resource
   property :outcome, predicate: "http://metadata.emory.edu/vocab/cor-terms#eventOutcome", multiple: false
   property :software_version, predicate: "http://metadata.emory.edu/vocab/cor-terms#softwareVersion", multiple: false
   property :workflow_id, predicate: "http://metadata.emory.edu/vocab/cor-terms#workflowRelatedObject", multiple: false
+
+  def preservation_event_terms
+    attributes_map = { 'event_details' => event_details.first,
+                       'event_end' => event_end.first,
+                       'event_start' => event_start.first,
+                       'event_type' => event_type.first,
+                       'initiating_user' => initiating_user.first,
+                       'outcome' => outcome.first,
+                       'software_version' => software_version.first }
+    attributes_map.to_json
+  end
+
+  def failed_event_json
+    { "event_details" => event_details.first, "event_start" => event_start.first }.to_json
+  end
 end

--- a/app/presenters/curate/file_set_presenter.rb
+++ b/app/presenters/curate/file_set_presenter.rb
@@ -4,6 +4,6 @@ module Curate
   class FileSetPresenter < Hyrax::FileSetPresenter
     delegate :pcdm_use, :file_name, :file_path, :file_size, :created, :valid, :well_formed,
              :creating_application_name, :puid, :date_modified, :character_set,
-             :byte_order, :color_space, :compression, :profile_name, :profile_version, to: :solr_document
+             :byte_order, :color_space, :compression, :profile_name, :profile_version, :preservation_event, to: :solr_document
   end
 end

--- a/app/views/hyrax/file_sets/_preservation_events.html.erb
+++ b/app/views/hyrax/file_sets/_preservation_events.html.erb
@@ -1,0 +1,29 @@
+<h2 class="fs-preservation-events-header"><%= t('.header') %></h2>
+<% if presenter.preservation_event.present? %>
+  <table id="fs-preservation-event-table" class="table table-striped table-bordered">
+    <thead>
+      <th><%= t('.preservation_event_table.event') %></th>
+      <th><%= t('.preservation_event_table.time') %></th>
+      <th><%= t('.preservation_event_table.outcome') %></th>
+      <th><%= t('.preservation_event_table.detail') %></th>
+      <th><%= t('.preservation_event_table.user') %></th>
+      <th><%= t('.preservation_event_table.software') %></th>
+    </thead>
+    <tbody>
+      <% presenter.preservation_event.each do |event| %>
+        <% parsed_event = JSON.parse(event) %>
+        <td><%= parsed_event['event_type'] %></td>
+        <td>
+            Start: <%= DateTime.parse(parsed_event['event_start']).strftime('%FT%T%:z') %><br>
+            End: <%= DateTime.parse(parsed_event['event_end']).strftime('%FT%T%:z') %>
+        </td>
+        <td><%= parsed_event['outcome'] %></td>
+        <td><%= parsed_event['event_details'] %></td>
+        <td><%= parsed_event['initiating_user'] %></td>
+        <td><%= parsed_event['software_version'] %></td>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p><%= t('.no_events') %></p>
+<% end %>

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -33,4 +33,5 @@
   <%= render 'show_details' %>
   <h2 class="activity-header"><%= t(".activity") %></h2><br>
   <%= render 'hyrax/users/activity_log', events: @presenter.events %>
+  <%= render 'preservation_events', presenter: @presenter %>
 </div><!-- /.container-fluid -->

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -249,6 +249,16 @@ en:
       show_details:
         file_details: "Preservation Master File Details"
         activity: "Activity"
+      preservation_events:
+        header: "Preservation Events"
+        no_events: "No Preservation Events found."
+        preservation_event_table:
+          event: "Event"
+          time: "Timestamp"
+          outcome: "Outcome"
+          detail: "Detail"
+          user: "User"
+          software: "Software"
     file_set:
       show:
         downloadable_content:

--- a/spec/indexers/curate_generic_work_spec.rb
+++ b/spec/indexers/curate_generic_work_spec.rb
@@ -183,17 +183,20 @@ RSpec.describe CurateGenericWorkIndexer do
     end
 
     context 'when preservation_event has failures' do
+      let(:different_event_start) { DateTime.current.strftime('%FT%T%:z') }
       let(:attributes) do
         {
           id:                            '123',
           title:                         ['A title'],
-          preservation_event_attributes: [{ 'event_type' => 'Yackety', 'event_start' => DateTime.current, 'outcome' => 'Failure',
+          preservation_event_attributes: [{ 'event_type' => 'Yackety', 'event_start' => different_event_start, 'outcome' => 'Failure',
               'event_details' => "Smackety", 'software_version' => 'FITS v1.5.0', 'initiating_user' => "10" }]
         }
       end
 
       it 'returns an array of hashes' do
-        expect(solr_document['failed_preservation_events_ssim'].first).to eq(["{ \"event_details\": \"Smackety\", \"event_start\": \"#{DateTime.current.strftime('%F')}\" }"])
+        expect(solr_document['failed_preservation_events_ssim'].first).to eq(
+          ["{\"event_details\":\"#{attributes[:preservation_event_attributes].first['event_details']}\",\"event_start\":\"#{different_event_start}\"}"]
+        )
       end
     end
   end

--- a/spec/models/preservation_event_spec.rb
+++ b/spec/models/preservation_event_spec.rb
@@ -66,5 +66,37 @@ RSpec.describe PreservationEvent do
       preservation_event.event_details = [event_details]
       expect(preservation_event.event_details).to eq [event_details]
     end
+
+    context 'class methods' do
+      let(:different_event_start) { DateTime.current.strftime('%FT%T%:z') }
+      let(:preservation_event) do
+        work.preservation_event.build(
+          event_type:       event_type,
+          initiating_user:  initiating_user,
+          event_start:      different_event_start,
+          event_end:        event_end,
+          outcome:          outcome,
+          software_version: software_version,
+          event_details:    event_details
+        )
+      end
+
+      describe '#preservation_event_terms' do
+        it 'creates a hash of preservation_event key/values in json' do
+          expect(preservation_event.preservation_event_terms).to eq(
+            "{\"event_details\":\"#{event_details}\",\"event_end\":\"#{event_end}\",\"event_start\":\"#{different_event_start}\",\"event_type\":\"#{event_type}\"" \
+            ",\"initiating_user\":\"#{initiating_user}\",\"outcome\":\"#{outcome}\",\"software_version\":\"#{software_version}\"}"
+          )
+        end
+      end
+
+      describe '#failed_event_json' do
+        it 'creates a hash of needed key/values for failed events in json' do
+          expect(preservation_event.failed_event_json).to eq(
+            "{\"event_details\":\"#{event_details}\",\"event_start\":\"#{different_event_start}\"}"
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/system/show_file_spec.rb
+++ b/spec/system/show_file_spec.rb
@@ -67,6 +67,36 @@ RSpec.describe "Showing a file:", integration: true, clean: true, type: :system 
     it 'shows pmf download link' do
       expect(first('#file_download').text).to eq('Download Preservation Master File')
     end
+
+    context 'within the preservation events block' do
+      it 'shows the right header' do
+        expect(page).to have_content('Preservation Events')
+      end
+
+      context 'when there are events' do
+        it 'shows a table with the right headers' do
+          table_headers = all('#fs-preservation-event-table th').map(&:text)
+
+          expect(table_headers).to eq(["Event", "Timestamp", "Outcome", "Detail", "User", "Software"])
+        end
+
+        it 'shows a table with the right values' do
+          table_values = all('#fs-preservation-event-table td').map(&:text)
+          preservation_event = file_set.preservation_event.first
+
+          expect(table_values).to eq(
+            [
+              preservation_event.event_type.first,
+              "Start: #{preservation_event.event_start.first} End: #{preservation_event.event_end.first}",
+              preservation_event.outcome.first,
+              preservation_event.event_details.first,
+              preservation_event.initiating_user.first,
+              preservation_event.software_version.first
+            ]
+          )
+        end
+      end
+    end
   end
 
   context 'when fixity check passes' do


### PR DESCRIPTION
Also refactors preservation events work on Generic Works Page.
- file_set_indexer.rb: adds preservation_event into solr_doc.
- curate_generic_work_indexer.rb: refactors method that provides the failed events json.
- preservation_event.rb: creates two new json mapping methods.
- file_set_presenter.rb: delegates :preservation_event to the solr_document.
- _preservation_events.html.erb: generates partial for the preservation events table.
- show.html.erb: calls the new partial from the show page.
- config/locales/hyrax.en.yml: institutes multiple headers for use in the new partial.
- spec/*: creates and refactors tests for the new partial.