### PR TITLE
Adds wings requirement

### DIFF
--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -92,7 +92,7 @@ module Hyrax
       end
 
       def collection_type_gid_document_field_name
-        Solrizer.solr_name('collection_type_gid', *index_collection_type_gid_as)
+        "collection_type_gid_ssim"
       end
     end
 

--- a/config/initializers/file_actor.rb
+++ b/config/initializers/file_actor.rb
@@ -2,6 +2,7 @@
 
 # [Hyrax-overwrite] FileActor ingest_file method in Hyrax::Actors
 # Perform characterize job only on preservation_master_file
+require 'wings'
 Hyrax::Actors::FileActor.class_eval do
   # Persists file as part of file_set and spawns async job to characterize and create derivatives.
   # @param [JobIoWrapper] io the file to save in the repository, with mime_type and original_name


### PR DESCRIPTION
* Adds wings requirement to file_actor. Also corrects solr field name in collection behavior. We should now be able to run all rails commands and sidekiq.

Note: There is still an error running rubocop.
`Error: unrecognized cop Rails`