### PR TITLE
Updates all model overrides and gem method calls to newer versions (#1239).

### DIFF
--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -52,16 +52,21 @@ module Hyrax
       self.collection_type_gid = new_collection_type.gid
     end
 
+    # This method pulled from v3.0.0.pre.beta3
     # Add members using the members association.
     def add_members(new_member_ids)
       return if new_member_ids.blank?
-      members << ActiveFedora::Base.find(new_member_ids)
+      members << Hyrax.query_service.custom_queries.find_many_by_alternate_ids(alternate_ids: new_member_ids, use_valkyrie: false)
     end
 
+    # This method pulled from v3.0.0.pre.beta3
     # Add member objects by adding this collection to the objects' member_of_collection association.
+    # @param [Enumerable<String>] the ids of the new child collections and works collection ids
+    # Valkyrie Version: Wings::CollectionBehavior#add_collections_and_works aliased to #add_member_objects
+    #                   lib/wings/models/concerns/collection_behavior.rb
     def add_member_objects(new_member_ids)
       Array(new_member_ids).collect do |member_id|
-        member = ActiveFedora::Base.find(member_id)
+        member = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: member_id, use_valkyrie: false)
         message = Hyrax::MultipleMembershipChecker.new(item: member).check(collection_ids: id, include_current_members: true)
         if message
           member.errors.add(:collections, message)
@@ -75,6 +80,16 @@ module Hyrax
 
     def member_objects
       ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id}")
+    end
+
+    # This method pulled from v3.0.0.pre.beta3
+    # Use this query to get the ids of the member objects (since the containment
+    # association has been flipped)
+    # Valkyrie Version: Wings::CollectionBehavior#child_collections_and_works_ids aliased to #member_object_ids
+    #                   lib/wings/models/concerns/collection_behavior.rb
+    def member_object_ids
+      return [] unless id
+      member_objects.map(&:id)
     end
 
     def to_s
@@ -91,6 +106,7 @@ module Hyrax
         end
       end
 
+      # This method updated to match v3.0.0.pre.beta3
       def collection_type_gid_document_field_name
         "collection_type_gid_ssim"
       end
@@ -149,9 +165,10 @@ module Hyrax
         []
       end
 
+      # This method pulled from v3.0.0.pre.beta3
       # Solr field name works use to index member ids
       def member_ids_field
-        Solrizer.solr_name('member_ids', :symbol)
+        "member_ids_ssim"
       end
 
       def destroy_permission_template

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -92,7 +92,7 @@ module Hyrax
       end
 
       def collection_type_gid_document_field_name
-        Solrizer.solr_name('collection_type_gid', *index_collection_type_gid_as)
+        "collection_type_gid_ssim"
       end
     end
 

--- a/app/models/concerns/hyrax/collection_nesting.rb
+++ b/app/models/concerns/hyrax/collection_nesting.rb
@@ -46,8 +46,9 @@ module Hyrax
       _run_update_index_callbacks { super }
     end
 
+    # This method updated to match v3.0.0.pre.beta3
     def find_children_of(destroyed_id:)
-      ActiveFedora::SolrService.query(ActiveFedora::SolrQueryBuilder.construct_query(member_of_collection_ids_ssim: destroyed_id))
+      Hyrax::SolrService.query(Hyrax::SolrQueryBuilderService.construct_query(member_of_collection_ids_ssim: destroyed_id))
     end
 
     # Only models which include Hyrax::CollectionNesting will respond to this method.

--- a/app/models/concerns/hyrax/file_set/characterization.rb
+++ b/app/models/concerns/hyrax/file_set/characterization.rb
@@ -24,7 +24,7 @@ module Hyrax
           :format_label, :file_size, :height, :width, :filename, :well_formed,
           :page_count, :file_title, :last_modified, :original_checksum,
           :duration, :sample_rate, :file_path, :creating_application_name,
-          :creating_os, :puid
+          :creating_os, :puid, :alpha_channels
         ]
         self.characterization_proxy = :preservation_master_file
 
@@ -54,6 +54,16 @@ module Hyrax
 
         def mime_type; end
       end
+
+      # Added alpha channel support for iiif, if direction is needed on how to implement
+      # alpha channels, see the link below:
+      # https://github.com/samvera/hyrax/commit/83dc1ea89b7c512b8bd5b807809ca5f2da368434
+      # Add Alpha Channels to the Schema
+      class AlphaChannelsSchema < ActiveTriples::Schema
+        property :alpha_channels, predicate: ::RDF::URI.new('http://vocabulary.samvera.org/ns#alphaChannels')
+      end
+
+      ActiveFedora::WithMetadata::DefaultMetadataClassFactory.file_metadata_schemas << AlphaChannelsSchema
     end
   end
 end

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -35,7 +35,6 @@ class FileSet < ActiveFedora::Base
 
   include ::Hyrax::FileSetBehavior
   include PreservationEvents
-  include Hyrax::VirusCheckerService
   self.indexer = Curate::FileSetIndexer
 
   directly_contains_one :preservation_master_file, through: :files, type: ::RDF::URI('http://pcdm.org/use#PreservationMasterFile'), class_name: 'Hydra::PCDM::File'

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -35,7 +35,7 @@ class FileSet < ActiveFedora::Base
 
   include ::Hyrax::FileSetBehavior
   include PreservationEvents
-  include ::Hyrax::VirusCheckerService
+  include Hyrax::VirusCheckerService
   self.indexer = Curate::FileSetIndexer
 
   directly_contains_one :preservation_master_file, through: :files, type: ::RDF::URI('http://pcdm.org/use#PreservationMasterFile'), class_name: 'Hydra::PCDM::File'

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -58,7 +58,8 @@ class FileSet < ActiveFedora::Base
   def viruses?
     return false unless preservation_master_file&.new_record? # We have a new file to check
     event_start = DateTime.current
-    result = Hydra::Works::VirusCheckerService.file_has_virus?(preservation_master_file)
+    # This method updated to match v3.0.0.pre.beta3
+    result = Hyrax::VirusCheckerService.file_has_virus?(preservation_master_file)
     file_set = FileSet.find(preservation_master_file.id&.partition("/files")&.first)
     event = { 'type' => 'Virus Check', 'start' => event_start, 'outcome' => result, 'software_version' => 'ClamAV 0.101.4', 'user' => file_set.depositor }
     if result == false

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -35,6 +35,7 @@ class FileSet < ActiveFedora::Base
 
   include ::Hyrax::FileSetBehavior
   include PreservationEvents
+  include ::Hyrax::VirusCheckerService
   self.indexer = Curate::FileSetIndexer
 
   directly_contains_one :preservation_master_file, through: :files, type: ::RDF::URI('http://pcdm.org/use#PreservationMasterFile'), class_name: 'Hydra::PCDM::File'

--- a/app/models/hyrax/uploaded_file.rb
+++ b/app/models/hyrax/uploaded_file.rb
@@ -6,6 +6,7 @@ module Hyrax
   # Store a file uploaded by a user. Eventually these files get
   # attached to FileSets and pushed into Fedora.
   class UploadedFile < ApplicationRecord
+    # removed before_destroy since it wasd deemed unnecessary in v3.0.0.pre.beta3
     self.table_name = 'uploaded_files'
     mount_uploader :service_file, UploadedFileUploader
     mount_uploader :preservation_master_file, UploadedFileUploader
@@ -20,7 +21,5 @@ module Hyrax
              class_name: 'JobIoWrapper',
              dependent:  :destroy
     belongs_to :user, class_name: '::User'
-
-    before_destroy :remove_file!
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -6,9 +6,10 @@ class SolrDocument
   # Adds Hyrax behaviors to the SolrDocument.
   include Hyrax::SolrDocumentBehavior
 
+  # removed Solrizer convention to be compliant with v3.0.0.pre.beta3
   # self.unique_key = 'id'
   def preservation_workflow_terms
-    self[Solrizer.solr_name('preservation_workflow_terms')]
+    self['preservation_workflow_terms_sim']
   end
 
   # Email uses the semantic field mappings below to generate the body of an email.

--- a/config/initializers/file_actor.rb
+++ b/config/initializers/file_actor.rb
@@ -2,6 +2,7 @@
 
 # [Hyrax-overwrite] FileActor ingest_file method in Hyrax::Actors
 # Perform characterize job only on preservation_master_file
+require 'wings'
 Hyrax::Actors::FileActor.class_eval do
   # Persists file as part of file_set and spawns async job to characterize and create derivatives.
   # @param [JobIoWrapper] io the file to save in the repository, with mime_type and original_name

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe FileSet, :perform_enqueued, :clean do
 
     context 'with an infected file' do
       before do
-        expect(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?).and_return(true)
+        expect(Hyrax::VirusCheckerService).to receive(:file_has_virus?).and_return(true)
       end
       it 'fails to save' do
         expect(file_set.save).to eq false
@@ -121,7 +121,7 @@ RSpec.describe FileSet, :perform_enqueued, :clean do
 
     context 'with a clean file' do
       it 'does not detect viruses' do
-        expect(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?).and_return(false)
+        expect(Hyrax::VirusCheckerService).to receive(:file_has_virus?).and_return(false)
         expect(file_set).not_to be_viruses
         expect(file_set_with_id.preservation_event.first.event_details).to eq ['No viruses found']
         expect(file_set_with_id.preservation_event.first.outcome).to eq ['Success']


### PR DESCRIPTION
- curate.scss and _preservation_events.html.erb: incorporates commit left out of this branch that fixes lack of table row. 
- collection_behavior.rb: shifts away from Solrizer and ActiveFedora.base methods and institutes explicit field keys and new Hyrax.query_service calls.
- collection_nesting.rb: swaps out to newly defined Hyrax::SolrService method.
- characterization.rb: introduces alpha channel capability into manifests.
- app/models/file_set.rb: corrects the VirusChecker method call to the new module location.
- uploaded_file.rb: cleans up unnecessary callback.
- solr_document.rb: removes the Solrizer call in favor of explicitly naming field name.