### PR TITLE
Upgrades overwritten jobs to beta3

### DIFF
--- a/app/models/concerns/hyrax/file_set/characterization.rb
+++ b/app/models/concerns/hyrax/file_set/characterization.rb
@@ -24,7 +24,7 @@ module Hyrax
           :format_label, :file_size, :height, :width, :filename, :well_formed,
           :page_count, :file_title, :last_modified, :original_checksum,
           :duration, :sample_rate, :file_path, :creating_application_name,
-          :creating_os, :puid
+          :creating_os, :puid, :alpha_channels
         ]
         self.characterization_proxy = :preservation_master_file
 
@@ -41,6 +41,13 @@ module Hyrax
         def mime_type
           @mime_type ||= characterization_proxy.mime_type
         end
+
+        # Add Alpha Channels to the Schema
+        class AlphaChannelsSchema < ActiveTriples::Schema
+          property :alpha_channels, predicate: ::RDF::URI.new('http://vocabulary.samvera.org/ns#alphaChannels')
+        end
+
+        ActiveFedora::WithMetadata::DefaultMetadataClassFactory.file_metadata_schemas << AlphaChannelsSchema
       end
 
       class NullCharacterizationProxy

--- a/app/presenters/hyrax/characterization_behavior.rb
+++ b/app/presenters/hyrax/characterization_behavior.rb
@@ -16,7 +16,7 @@ module Hyrax
           :color_space, :compression, :profile_name, :profile_version, :orientation,
           :color_map, :image_producer, :capture_device, :scanning_software,
           :gps_timestamp, :latitude, :longitude, :file_format, :duration,
-          :sample_rate, :filename
+          :sample_rate, :filename, :alpha_channels
         ]
       end
     end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# [Hyrax-collections-factory]
+# [Hyrax-v3.0.0.beta3-overwrite]
 FactoryBot.define do
   # Tests that create a Fedora Object are very slow.  This factory lets you control which parts of the object ecosystem
   # get built.
@@ -109,33 +109,8 @@ FactoryBot.define do
       with_permission_template { false }
       with_nesting_attributes { nil }
       with_solr_document { false }
-      collection_type { Hyrax::CollectionType.find_or_create_default_collection_type }
     end
-    # sequence(:title) { |n| ["Collection Title #{n}"] }
-    title { ['Testing Collection'] }
-    holding_repository { ['Emory'] }
-    administrative_unit { ['Library'] }
-    creator { ['Someone'] }
-    contributors { ['Someone else'] }
-    abstract { 'A detailed abstract' }
-    primary_language { 'English' }
-    finding_aid_link { 'https://my-finding-aid.com' }
-    institution { 'Emory' }
-    local_call_number { '90210' }
-    keywords { ['test collection'] }
-    subject_topics { ['Topics'] }
-    subject_names { ['Someone'] }
-    subject_geo { ['Atlanta'] }
-    subject_time_periods { ['Anthropocene'] }
-    notes { ['a brief note'] }
-    rights_documentation { 'http://example.com/rights' }
-    sensitive_material { 'very sensitive' }
-    internal_rights_note { 'Do not publish' }
-    contact_information { 'telex' }
-    staff_notes { ['dictated but not read'] }
-    system_of_record_ID { '1' }
-    emory_ark { ['2'] }
-    primary_repository_ID { '3' }
+    sequence(:title) { |n| ["Collection Title #{n}"] }
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)
@@ -330,7 +305,7 @@ FactoryBot.define do
     def self.process_with_solr_document(collection, evaluator)
       return unless evaluator.with_solr_document
       return if evaluator.with_nesting_attributes.present? && collection.nestable? # will create the solr document there instead
-      ActiveFedora::SolrService.add(solr_document_with_permissions(collection, evaluator), commit: true)
+      Hyrax::SolrService.add(solr_document_with_permissions(collection, evaluator), commit: true)
     end
 
     # Return the collection's solr document with permissions added, such that...

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -1,5 +1,5 @@
-# [Hyrax-overwrite]
 # frozen_string_literal: true
+# [Hyrax-3.0.0.pre.beta3-overwrite]
 require 'rails_helper'
 
 RSpec.describe CharacterizeJob, :clean do
@@ -24,6 +24,8 @@ RSpec.describe CharacterizeJob, :clean do
   before do
     allow(FileSet).to receive(:find).with(file_set_id).and_return(file_set)
     allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+    # commenting out because we are doing this in file_actor and not characterize_job
+    # allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
   end
 
   context 'with valid filepath param' do
@@ -41,6 +43,8 @@ RSpec.describe CharacterizeJob, :clean do
       expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
       expect(file).to receive(:save!)
       expect(file_set).to receive(:update_index)
+      # commenting out because we are doing this in file_actor and not characterize_job
+      # expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
       described_class.perform_now(file_set, file.id)
     end
   end


### PR DESCRIPTION
* We are upgrading all previous overwritten files in `app/jobs` to hyrax3 beta3 with the new hyrax overwrite tag on top of files.
* Also, updating collections factory since it was copied from the previous hyrax version.

Adapting Brad's PR writing style:
`app/jobs/characterize_job.rb`: We are calling `alpha_channels` on the file and assigning it the file format. This is an addition in beta3.
`app/models/concerns/hyrax/file_set/characterization.rb`: defining new `alpha_channels` property.
`app/presenters/hyrax/characterization_behavior.rb`: Adding `alpha_channels` to characterization terms.
`spec/factories/collections.rb`: Updating collections factory to match beta3 collections factory.
`spec/jobs/characterize_job_spec.rb`: updating overwrite version tag and tests to match beta3 characterize_job_spec.