### PR TITLE
Adds size class to job_io_wrapper

### DIFF
--- a/config/initializers/job_io_wrapper.rb
+++ b/config/initializers/job_io_wrapper.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# [Hyrax-model-overwrite]
+# [Hyrax-overwrite-v3.0.0.pre.beta3]
 # ingest_file method in the JobIoWrapper method is modified. We save the response
 # from the `file_actor.ingest_file` method call. If false is returned from L#16 in
 # `config/intializers/file_actor.rb` then a failure event is created, else success
@@ -35,6 +35,12 @@ JobIoWrapper.class_eval do
       details = "#{file_name} submitted for preservation storage"
     end
     file_set_preservation_event(file_set, event_start, outcome, details)
+  end
+
+  def size
+    return file.size.to_i if file.respond_to? :size
+    return file.stat.size.to_i if file.respond_to? :stat
+    nil # unable to determine
   end
 
   private

--- a/spec/models/job_io_wrapper_spec.rb
+++ b/spec/models/job_io_wrapper_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# [Hyrax-model-spec-overwrite]
+# [Hyrax-overwrite-v3.0.0.pre.beta3]
 # We are only testing the `ingest_file` method here.
 
 require 'rails_helper'
@@ -30,6 +30,49 @@ RSpec.describe JobIoWrapper, type: :model do
       expect(file_set.preservation_event.pluck(:event_details)).to include ['0003_preservation_master.tif submitted for preservation storage']
       expect(file_set.preservation_event.pluck(:outcome)).to include ['Failure']
       expect(file_set.preservation_event.pluck(:outcome)).to include ['Success']
+    end
+  end
+
+  # spec taken from hyrax3-beta3
+  # we are changing the output expectations on line 55 and 65 to integers in our test
+  # which were previously strings in hyrax3-beta3. This is because we want our output
+  # of the size method in job_io_wrapper to always be an integer.
+  describe '#size' do
+    let(:user) { FactoryBot.build(:user) }
+    let(:path) { fixture_path + '/world.png' }
+    let(:file_set_id) { 'bn999672v' }
+    let(:args) { { file_set_id: file_set_id, user: user, path: path } }
+
+    subject(:wrapper) { described_class.new(args) }
+
+    context 'when file responds to :size' do
+      before do
+        allow(subject.file).to receive(:size).and_return(123)
+        allow(subject.file).to receive(:respond_to?).with(:size).and_return(true)
+        allow(subject.file).to receive(:respond_to?).with(:stat).and_return(false)
+      end
+      it 'returns the size of the file' do
+        expect(subject.size).to eq(123)
+      end
+    end
+    context 'when file responds to :stat' do
+      before do
+        allow(subject.file).to receive_message_chain(:stat, :size).and_return(456) # rubocop:disable RSpec/MessageChain
+        allow(subject.file).to receive(:respond_to?).with(:size).and_return(false)
+        allow(subject.file).to receive(:respond_to?).with(:stat).and_return(true)
+      end
+      it 'returns the size of the file' do
+        expect(subject.size).to eq(456)
+      end
+    end
+    context 'when file responds to neither :size nor :stat' do
+      before do
+        allow(subject.file).to receive(:respond_to?).with(:size).and_return(false)
+        allow(subject.file).to receive(:respond_to?).with(:stat).and_return(false)
+      end
+      it 'returns nil' do
+        expect(subject.size).to eq nil
+      end
     end
   end
 end


### PR DESCRIPTION
* When the size method in job_io_wrapper is called from active_fedora, we need it to return an integer instead of a string (it returns a string in Hyrax3-beta3 right now). We suspect that this works fine in beta3 since size method is called on an instance of Hyrax::UploadedFile class, and we are calling size method on a raw file. Therefore, we need to make sure its always an integer to successfully ingest files using AF.