### PR TITLE
Corrects errors caused by preservation workflow field. 

### DIFF
--- a/app/indexers/curate_generic_work_indexer.rb
+++ b/app/indexers/curate_generic_work_indexer.rb
@@ -13,7 +13,7 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
 
   def generate_solr_document
     super.tap do |solr_doc|
-      solr_doc['preservation_workflow_terms_sim'] = preservation_workflow_terms
+      solr_doc['preservation_workflow_terms_tesim'] = preservation_workflow_terms
       solr_doc['failed_preservation_events_ssim'] = [failed_preservation_events]
       solr_doc['human_readable_content_type_ssim'] = [human_readable_content_type]
       solr_doc['human_readable_rights_statement_ssim'] = [human_readable_rights_statement]

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -9,7 +9,7 @@ class SolrDocument
   # removed Solrizer convention to be compliant with v3.0.0.pre.beta3
   # self.unique_key = 'id'
   def preservation_workflow_terms
-    self['preservation_workflow_terms_sim']
+    self['preservation_workflow_terms_tesim']
   end
 
   # Email uses the semantic field mappings below to generate the body of an email.


### PR DESCRIPTION
- app/models/solr_document.rb and app/models/solr_document.rb: swaps field ending with _sim instead of _tesim.