### PR TITLE
Updates collection spec

### DIFF
--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# [Hyrax-overwrite]
+# [Hyrax-overwrite-v3.0.0.pre.beta3]
 module Hyrax
   module Forms
     class CollectionForm
@@ -74,14 +74,6 @@ module Hyrax
           return ""
         end
         super
-      end
-
-      def multiple?(field)
-        if [:title].include?(field.to_sym)
-          false
-        else
-          super
-        end
       end
 
       def permission_template

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# [Hyrax-overwrite]
+# [Hyrax-overwrite-v3.0.0.pre.beta3]
 module Hyrax
   module CollectionBehavior
     extend ActiveSupport::Concern

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -110,7 +110,7 @@ FactoryBot.define do
       with_nesting_attributes { nil }
       with_solr_document { false }
     end
-    sequence(:title) { |n| ["Collection Title #{n}"] }
+    title { ['Testing Collection'] }
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)

--- a/spec/system/iiif_access_controls_spec.rb
+++ b/spec/system/iiif_access_controls_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'iiif access controls', type: :system, iiif: true do
         headers: {
           'Connection' => 'close',
           'Host' => 'iiif-cor-arch.library.emory.edu',
-          'User-Agent' => 'http.rb/4.3.0'
+          'User-Agent' => 'http.rb/4.4.1'
         }
       )
       .to_return(status: 200, body: "I am returning an image, but for now I'm words", headers: {})


### PR DESCRIPTION
* app/forms/hyrax/forms/collection_form.rb: Removes `multiple` method which was previously causing error when loading collection form.
* app/models/concerns/hyrax/collection_behavior.rb: Updates hyrax version.
* spec/factories/collections.rb: updates collection title
* spec/system/iiif_access_controls_spec.rb: Updates `User-Agent`