### PR TITLE
Updates Capistrano

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # config valid for current version and patch releases of Capistrano
-lock "~> 3.11.0"
+lock "~> 3.14.0"
 
 set :application, "dlp-curate"
 set :repo_url, "https://github.com/emory-libraries/dlp-curate.git"


### PR DESCRIPTION
In our `Gemfile`, Capistrano is allowed to update relatively liberally, but in the `config/deploy.rb`, it is more strictly locked. This change allows a more recent version.