### PR TITLE
Edits activity-display class styling

### DIFF
--- a/app/assets/stylesheets/curate.scss
+++ b/app/assets/stylesheets/curate.scss
@@ -54,3 +54,16 @@ dl.file-show-details {
   }
 }
 
+// Set bottom padding to 0px for user activity table
+// [Hyrax-overwrite-v3.0.0.pre.beta3]
+.activity-display {
+  max-height: 100%;
+  overflow: scroll;
+  padding-bottom: 0px !important; // adding important so it doesn't fall back on hyrax's styling
+  position: relative;
+
+  .activity-date {
+    padding-right: 130px;
+  }
+}
+


### PR DESCRIPTION
* Bottom padding style has been set to 300px in hyrax, however, that causes a big height gap between the user activity table and preservation events table on the fileset page. We are setting that to 0px and overriding hyrax's style for the activity-display class.

Connected to: #1307 