### PR TITLE
Include additional fields in dashboard search

### DIFF
--- a/app/views/hyrax/my/_search_form.html.erb
+++ b/app/views/hyrax/my/_search_form.html.erb
@@ -1,0 +1,23 @@
+<% # [Hyrax-overwrite-v3.0.0.pre.beta3] %>
+<% # Allow all fields to be searched in dashboard search bar L#7 %>
+
+<%= form_tag search_action_url, method: :get, class: "search-query-form form-horizontal search-form", role: "search" do %>
+
+  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
+  <%= hidden_field_tag :search_field, 'all_fields' %>
+  <div class="form-group">
+    <label class="control-label col-sm-3" for="search-field-header">
+      <%= t("hyrax.search.form.q.label", application_name: application_name) %>
+    </label>
+
+    <div class="input-group">
+      <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
+
+      <div class="input-group-btn">
+        <button type="submit" class="btn btn-primary" id="search-submit-header">
+          <%= t('hyrax.search.button.html') %>
+        </button>
+      </div>
+    </div><!-- /.input-group -->
+  </div><!-- /.form-group -->
+<% end %>

--- a/spec/factories/curate_generic_works.rb
+++ b/spec/factories/curate_generic_works.rb
@@ -64,7 +64,7 @@ FactoryBot.define do
       date_uploaded { '2001' }
       deduplication_key { 'dedupestring' }
       edition { 'first' }
-      emory_ark { ['25'] }
+      emory_ark { ['255555'] }
       emory_rights_statements { ['This is my rights statement text'] }
       extent { 'A very large extent' }
       final_published_versions { ['http://example.com'] }
@@ -81,7 +81,7 @@ FactoryBot.define do
       legacy_rights { 'no' }
       local_call_number { '1234' }
       notes { ['Many found'] }
-      other_identifiers { ['1'] }
+      other_identifiers { ['184975'] }
       page_range_end { '1' }
       page_range_start { '0' }
       parent_title { 'A parent title' }
@@ -109,7 +109,7 @@ FactoryBot.define do
       subject_time_periods { ['Neolithic'] }
       subject_topics { ['Photographs'] }
       sublocation { 'Emory 2' }
-      system_of_record_ID { '1' }
+      system_of_record_ID { '1976578' }
       table_of_contents { '1. A Toc' }
       technical_note { '1mb' }
       transfer_engineer { 'yes' }

--- a/spec/system/search_for_work_spec.rb
+++ b/spec/system/search_for_work_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.describe 'Search', type: :system, js: true do
+RSpec.describe 'Search', type: :system, js: true, clean: true do
   let(:admin) { FactoryBot.create(:admin) }
   let(:work) { FactoryBot.build(:work_with_full_metadata, :public) }
   let(:title) { work.title.first }
@@ -12,12 +12,53 @@ RSpec.describe 'Search', type: :system, js: true do
     work.save!
   end
 
-  it 'finds a work by ID' do
-    login_as admin
-    visit '/'
-    fill_in "search-field-header", with: work.id
-    click_button "search-submit-header"
-    expect(page).to have_content "1 entry found"
-    expect(page).to have_content title
+  context 'in the main search bar' do
+    before { visit '/' }
+
+    it 'finds a work by ID' do
+      fill_in "search-field-header", with: work.id
+      click_button "search-submit-header"
+      expect(page).to have_content "1 entry found"
+      expect(page).to have_content title
+    end
+  end
+
+  context 'in the dashboard search bar' do
+    before { visit '/dashboard/works' }
+
+    it 'finds a work by ID' do
+      fill_in "search-field-header", with: work.id
+      click_button "search-submit-header"
+      expect(page).to have_content "1 works in the repository"
+      expect(page).to have_content title
+    end
+
+    it 'finds a work by Emory ARK' do
+      fill_in "search-field-header", with: work.emory_ark.first
+      click_button "search-submit-header"
+      expect(page).to have_content "1 works in the repository"
+      expect(page).to have_content title
+    end
+
+    it 'finds a work by other identifiers' do
+      fill_in "search-field-header", with: work.other_identifiers.first
+      click_button "search-submit-header"
+      expect(page).to have_content "1 works in the repository"
+      expect(page).to have_content title
+    end
+
+    it 'finds a work by deduplication key' do
+      fill_in "search-field-header", with: work.deduplication_key
+      click_button "search-submit-header"
+      expect(page).to have_content "1 works in the repository"
+      expect(page).to have_content title
+    end
+
+    it 'finds a work by system of record ID' do
+      fill_in "search-field-header", with: work.system_of_record_ID
+      click_button "search-submit-header"
+      expect(page).to have_content "1 works in the repository"
+      expect(page).to have_content title
+    end
   end
 end


### PR DESCRIPTION
- The metadata fields included in the dashboard search bar are now brought in line with the fields searched in the main search bar. The following desired fields are explicitly tested:
    - `deduplication_key`
    - `other_identifiers`
    - `id`
    - `system_of_record_ID`
    - `emory_ark`
- The values for three metadata fields in the `work_with_full_metadata` factory are made longer and unique so that their search functionality can be tested more accurately.