### PR TITLE
Fixes RDF::JSON::LD issue

### DIFF
--- a/config/initializers/rdf_uri_to_json.rb
+++ b/config/initializers/rdf_uri_to_json.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+# [Valkyrie-overwrite-v1.7.1] This is fixed in Valkyrie-v2.1.0. Remove this
+# when we upgrade to v2.1.0 or higher.
 ##
 # These patches are necessary for the postgres adapter to build JSON-LD versions
 # of RDF objects when `to_json` is called on them - that way they're stored in

--- a/config/initializers/rdf_uri_to_json.rb
+++ b/config/initializers/rdf_uri_to_json.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+##
+# These patches are necessary for the postgres adapter to build JSON-LD versions
+# of RDF objects when `to_json` is called on them - that way they're stored in
+# the database as a standard format.
+# Refer: https://github.com/samvera/valkyrie/pull/810
+module RDF
+  class Literal
+    def as_json(*_args)
+      ::JSON::LD::API.fromRdf([RDF::Statement.new(RDF::URI(""), RDF::URI(""), self)])[0][""][0]
+    end
+  end
+  class URI
+    def as_json(*_args)
+      ::JSON::LD::API.fromRdf([RDF::Statement.new(RDF::URI(""), RDF::URI(""), self)])[0][""][0]
+    end
+  end
+end


### PR DESCRIPTION
* When calling `as_json` or `to_json` on an object, sometimes `RDF::JSON` already exists, which leads to name resolution failure. To stop this from happening, we are patching `JSON::LD` module with `::` in the beginning to ensure functions are performed at top level without `RDF` module.
Refer: https://github.com/samvera/valkyrie/pull/810