### PR TITLE
Restricts addition of private fs in manifests

### DIFF
--- a/app/views/manifest/manifest.json.jbuilder
+++ b/app/views/manifest/manifest.json.jbuilder
@@ -21,7 +21,7 @@ json.sequences [''] do
   json.canvases @image_concerns do |child_id|
     file_set = FileSet.find(child_id)
     mime_types = ['pdf', 'xml']
-    unless mime_types.any? { |m| file_set.mime_type&.include?(m) }
+    unless mime_types.any? { |m| file_set.mime_type&.include?(m) } || file_set.visibility == 'restricted'
       child_iiif_service = ManifestBuilderService.new(curation_concern: file_set)
       canvas_uri = "#{@root_url}/canvas/#{child_id}"
       json.set! :@id, canvas_uri

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe IiifController, type: :controller, clean: true, iiif: true do
 
   describe "#manifest" do
     let(:work)          { FactoryBot.create(:public_generic_work, id: identifier) }
-    let(:file_set)      { FactoryBot.create(:file_set) }
+    let(:file_set)      { FactoryBot.create(:file_set, read_groups: ['public']) }
     let(:pmf)           { File.open(fixture_path + '/book_page/0003_preservation_master.tif') }
     let(:sf)            { File.open(fixture_path + '/book_page/0003_service.jpg') }
     let(:solr_document) { SolrDocument.new(attributes) }

--- a/spec/services/manifest_builder_service_spec.rb
+++ b/spec/services/manifest_builder_service_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe ManifestBuilderService, :clean do
       "rights_statement_tesim" => ["example.com"],
       "hasFormat_ssim" => ["608hdr7srt-cor"] }
   end
-  let(:file_set)  { FactoryBot.create(:file_set) }
-  let(:file_set2) { FactoryBot.create(:file_set) }
-  let(:file_set3) { FactoryBot.create(:file_set, id: '608hdr7srt-cor') }
+  let(:file_set)  { FactoryBot.create(:file_set, read_groups: ['public']) }
+  let(:file_set2) { FactoryBot.create(:file_set, read_groups: ['public']) }
+  let(:file_set3) { FactoryBot.create(:file_set, id: '608hdr7srt-cor', read_groups: ['public']) }
   let(:pmf) { File.open(fixture_path + '/book_page/0003_preservation_master.tif') }
   let(:sf) { File.open(fixture_path + '/book_page/0003_service.jpg') }
   let(:pdf) { File.open(fixture_path + '/sample-file.pdf') }


### PR DESCRIPTION
* Sometimes we might need to hide file_sets from UV and not add them to manifests. We are adding a condition to check if the visibility for a file_set is restricted, if it is, do not add to manifest nor display in UV.

Connected to: #1044 