### PR TITLE
Adds more retries for background jobs before failing the job

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,7 +6,7 @@
 
 :timeout: 300
 
-:max_retries: 1
+:max_retries: 3
 
 test: # n/a
   :concurrency: <%= ENV['SIDEKIQ_WORKERS'] || 1 %>


### PR DESCRIPTION
Previously, jobs were only allowed to retry once before being pronounced dead. Now, they can retry three times. Each retry allows more time between the job failing and its next retry. Now, a job will spend 152 seconds total waiting between retries- up from just 30 before.