### PR TITLE
Add rights status for parent works

### DIFF
--- a/config/authorities/rights_statements.yml
+++ b/config/authorities/rights_statements.yml
@@ -1,40 +1,40 @@
 terms:
-  - id: http://rightsstatements.org/vocab/InC/1.0/
-    term: "In Copyright"
-    active: true
-  - id: http://rightsstatements.org/vocab/InC-OW-EU/1.0/
-    term: "In Copyright - EU Orphan Work"
-    active: true
-  - id: http://rightsstatements.org/vocab/InC-EDU/1.0/
-    term: "In Copyright - Educational Use Permitted"
-    active: true
-  - id: http://rightsstatements.org/vocab/InC-NC/1.0/
-    term: "In Copyright - Non-Commercial Use Permitted"
-    active: true
-  - id: http://rightsstatements.org/vocab/InC-RUU/1.0/
-    term: "In Copyright - Rights-holder(s) Unlocatable or Unidentifiable"
-    active: true
-  - id: http://rightsstatements.org/vocab/NoC-CR/1.0/
-    term: "No Copyright - Contractual Restrictions"
-    active: true
-  - id: http://rightsstatements.org/vocab/NoC-NC/1.0/
-    term: "No Copyright - Non-Commercial Use Only "
-    active: true
-  - id: http://rightsstatements.org/vocab/NoC-OKLR/1.0/
-    term: "No Copyright - Other Known Legal Restrictions"
-    active: true
-  - id: http://rightsstatements.org/vocab/NoC-US/1.0/
-    term: "No Copyright - United States"
-    active: true
-  - id: http://rightsstatements.org/vocab/CNE/1.0/
-    term: "Copyright Not Evaluated"
-    active: true
-  - id: http://rightsstatements.org/vocab/UND/1.0/
-    term: "Copyright Undetermined"
-    active: true
-  - id: http://rightsstatements.org/vocab/NKC/1.0/
-    term: "No Known Copyright"
-    active: true
-  - id: "Not Applicable"
-    term: "Copyright Varies by Work"
-    active: true
+- id: http://rightsstatements.org/vocab/InC/1.0/
+  term: "In Copyright"
+  active: true
+- id: http://rightsstatements.org/vocab/InC-OW-EU/1.0/
+  term: "In Copyright - EU Orphan Work"
+  active: true
+- id: http://rightsstatements.org/vocab/InC-EDU/1.0/
+  term: "In Copyright - Educational Use Permitted"
+  active: true
+- id: http://rightsstatements.org/vocab/InC-NC/1.0/
+  term: "In Copyright - Non-Commercial Use Permitted"
+  active: true
+- id: http://rightsstatements.org/vocab/InC-RUU/1.0/
+  term: "In Copyright - Rights-holder(s) Unlocatable or Unidentifiable"
+  active: true
+- id: http://rightsstatements.org/vocab/NoC-CR/1.0/
+  term: "No Copyright - Contractual Restrictions"
+  active: true
+- id: http://rightsstatements.org/vocab/NoC-NC/1.0/
+  term: "No Copyright - Non-Commercial Use Only "
+  active: true
+- id: http://rightsstatements.org/vocab/NoC-OKLR/1.0/
+  term: "No Copyright - Other Known Legal Restrictions"
+  active: true
+- id: http://rightsstatements.org/vocab/NoC-US/1.0/
+  term: "No Copyright - United States"
+  active: true
+- id: http://rightsstatements.org/vocab/CNE/1.0/
+  term: "Copyright Not Evaluated"
+  active: true
+- id: http://rightsstatements.org/vocab/UND/1.0/
+  term: "Copyright Undetermined"
+  active: true
+- id: http://rightsstatements.org/vocab/NKC/1.0/
+  term: "No Known Copyright"
+  active: true
+- id: "Not Applicable"
+  term: "Copyright Varies by Work"
+  active: true

--- a/config/authorities/rights_statements.yml
+++ b/config/authorities/rights_statements.yml
@@ -1,37 +1,40 @@
 terms:
-- id: http://rightsstatements.org/vocab/InC/1.0/
-  term: "In Copyright"
-  active: true
-- id: http://rightsstatements.org/vocab/InC-OW-EU/1.0/
-  term: "In Copyright - EU Orphan Work"
-  active: true
-- id: http://rightsstatements.org/vocab/InC-EDU/1.0/
-  term: "In Copyright - Educational Use Permitted"
-  active: true
-- id: http://rightsstatements.org/vocab/InC-NC/1.0/
-  term: "In Copyright - Non-Commercial Use Permitted"
-  active: true
-- id: http://rightsstatements.org/vocab/InC-RUU/1.0/
-  term: "In Copyright - Rights-holder(s) Unlocatable or Unidentifiable"
-  active: true
-- id: http://rightsstatements.org/vocab/NoC-CR/1.0/
-  term: "No Copyright - Contractual Restrictions"
-  active: true
-- id: http://rightsstatements.org/vocab/NoC-NC/1.0/
-  term: "No Copyright - Non-Commercial Use Only "
-  active: true
-- id: http://rightsstatements.org/vocab/NoC-OKLR/1.0/
-  term: "No Copyright - Other Known Legal Restrictions"
-  active: true
-- id: http://rightsstatements.org/vocab/NoC-US/1.0/
-  term: "No Copyright - United States"
-  active: true
-- id: http://rightsstatements.org/vocab/CNE/1.0/
-  term: "Copyright Not Evaluated"
-  active: true
-- id: http://rightsstatements.org/vocab/UND/1.0/
-  term: "Copyright Undetermined"
-  active: true
-- id: http://rightsstatements.org/vocab/NKC/1.0/
-  term: "No Known Copyright"
-  active: true
+  - id: http://rightsstatements.org/vocab/InC/1.0/
+    term: "In Copyright"
+    active: true
+  - id: http://rightsstatements.org/vocab/InC-OW-EU/1.0/
+    term: "In Copyright - EU Orphan Work"
+    active: true
+  - id: http://rightsstatements.org/vocab/InC-EDU/1.0/
+    term: "In Copyright - Educational Use Permitted"
+    active: true
+  - id: http://rightsstatements.org/vocab/InC-NC/1.0/
+    term: "In Copyright - Non-Commercial Use Permitted"
+    active: true
+  - id: http://rightsstatements.org/vocab/InC-RUU/1.0/
+    term: "In Copyright - Rights-holder(s) Unlocatable or Unidentifiable"
+    active: true
+  - id: http://rightsstatements.org/vocab/NoC-CR/1.0/
+    term: "No Copyright - Contractual Restrictions"
+    active: true
+  - id: http://rightsstatements.org/vocab/NoC-NC/1.0/
+    term: "No Copyright - Non-Commercial Use Only "
+    active: true
+  - id: http://rightsstatements.org/vocab/NoC-OKLR/1.0/
+    term: "No Copyright - Other Known Legal Restrictions"
+    active: true
+  - id: http://rightsstatements.org/vocab/NoC-US/1.0/
+    term: "No Copyright - United States"
+    active: true
+  - id: http://rightsstatements.org/vocab/CNE/1.0/
+    term: "Copyright Not Evaluated"
+    active: true
+  - id: http://rightsstatements.org/vocab/UND/1.0/
+    term: "Copyright Undetermined"
+    active: true
+  - id: http://rightsstatements.org/vocab/NKC/1.0/
+    term: "No Known Copyright"
+    active: true
+  - id: "Not Applicable"
+    term: "Copyright Varies by Work"
+    active: true


### PR DESCRIPTION
- "Copyright Varies by Work" is now available as a rights status for parent works whose child works do not have the same rights status.
- Instead of a URL, the value for this field is "Not Applicable." Lux will check for the presence of this value and conditionally render the rights status as a link based on whether it is a URL or not.