### PR TITLE
Revise human readable date ranges

### DIFF
--- a/app/services/date_service.rb
+++ b/app/services/date_service.rb
@@ -22,7 +22,7 @@ class DateService
   def handle_date_range(date)
     years = date.split("\/")
     return date if years.length > 2
-    return "within the #{handle_unspecified_digit(years[0])} or #{handle_unspecified_digit(years[1])}" if date.end_with?("X")
+    return "#{handle_unspecified_digit(years[0])} to #{handle_unspecified_digit(years[1])}" if date.end_with?("X")
     return "between #{years[0].tr('?', '')} and #{years[1].tr('?', '')}" if date.end_with?("?")
     return Date.edtf(date).humanize unless Date.edtf(date).nil?
     date

--- a/spec/models/curate_generic_work_spec.rb
+++ b/spec/models/curate_generic_work_spec.rb
@@ -1419,7 +1419,7 @@ RSpec.describe CurateGenericWork do
       expect(solr_doc['conference_dates_tesim']).to contain_exactly params[:conference_dates]
 
       # Check conference_dates_tesim also saved as human_readable_conference_dates_tesim
-      expect(solr_doc['human_readable_conference_dates_tesim']).to eq ['within the 1940s or 1950s']
+      expect(solr_doc['human_readable_conference_dates_tesim']).to eq ['1940s to 1950s']
 
       # Check copyright_date_tesim also saved as date entered
       expect(solr_doc['copyright_date_tesim']).to contain_exactly params[:copyright_date]

--- a/spec/services/date_service_spec.rb
+++ b/spec/services/date_service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe DateService do
     end
 
     it 'provides a string for year ranges with unspecified digits' do
-      expect(service.human_readable_date('194X/195X')).to eq('within the 1940s or 1950s')
+      expect(service.human_readable_date('194X/195X')).to eq('1940s to 1950s')
     end
 
     it 'provides a string for uncertain year ranges' do


### PR DESCRIPTION
- Corrects the human-readable format of date ranges with the type "193X/194X" from "within the 1930s or 1940s" to "1930s to 1940s"