### PR TITLE
Matches the configuration of Curate UV to Lux (#1290).

### DIFF
--- a/app/assets/javascripts/uv_width.js
+++ b/app/assets/javascripts/uv_width.js
@@ -1,0 +1,7 @@
+$(document).on('turbolinks:load', function() {
+  $('#universal-viewer-iframe').width($('.view-wrapper').width())
+
+  $(window).on('resize', function(){
+    $('#universal-viewer-iframe').width($('.view-wrapper').width())
+  })
+})

--- a/app/assets/stylesheets/curate.scss
+++ b/app/assets/stylesheets/curate.scss
@@ -67,3 +67,11 @@ dl.file-show-details {
   }
 }
 
+.view-wrapper {
+  max-width: 1200px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,5 +14,82 @@ class ApplicationController < ActionController::Base
   with_themed_layout '1_column'
 
   protect_from_forgery with: :exception
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: [:uv_config, :resource_id_param, :default_config, :uv_config_liberal, :uv_config_liberal_low, :visibility_lookup]
+
+  # GET /uv/config
+  # Retrieve the UV configuration for a given resource
+  def uv_config
+    config = case visibility_lookup(resource_id_param)
+             when 'open', 'authenticated'
+               uv_config_liberal
+             when 'emory_low'
+               uv_config_liberal_low
+             else
+               default_config
+             end
+
+    respond_to do |format|
+      format.json { render json: config }
+    end
+  end
+
+  private
+
+    def resource_id_param
+      params[:id]
+    end
+
+    # Construct a UV configuration with the default options (conservative)
+    # @return [UvConfiguration]
+    def default_config
+      UvConfiguration.new
+    end
+
+    # Construct a UV configuration with downloads and share enabled
+    # @return [UvConfiguration]
+    def uv_config_liberal
+      UvConfiguration.new(
+        modules: {
+          footerPanel: {
+            options: {
+              shareEnabled:      true,
+              downloadEnabled:   true,
+              fullscreenEnabled: true
+            }
+          }
+        }
+      )
+    end
+
+    # Construct a UV configuration for emory_low visibility with downloads and share enabled,
+    # and download dialogue options/content modifications
+    # @return [UvConfiguration]
+    def uv_config_liberal_low # rubocop:disable Metrics/MethodLength
+      UvConfiguration.new(
+        modules: {
+          footerPanel:      {
+            options: {
+              shareEnabled:      true,
+              downloadEnabled:   true,
+              fullscreenEnabled: true
+            }
+          },
+          downloadDialogue: {
+            options: {
+              currentViewDisabledPercentage: 0, # set to an unreasonably low value so that Current View option is hidden
+              confinedImageSize:             100_000 # set to an unreasonably high value so that Whole Image Low Res option is hidden
+            },
+            content: {
+              wholeImageHighRes: "Whole Image 400px"
+            }
+          }
+        }
+      )
+    end # rubocop:enable Metrics/MethodLength
+
+    def visibility_lookup(resource_id)
+      return nil if resource_id.nil?
+      response = Blacklight.default_index.connection.get 'select', params: { q: "id:#{resource_id}" }
+      response["response"]["docs"].first["visibility_ssi"]
+    end
 end

--- a/app/helpers/hyrax/iiif_helper.rb
+++ b/app/helpers/hyrax/iiif_helper.rb
@@ -18,8 +18,8 @@ module Hyrax
       "#{request&.base_url}/uv/uv.html"
     end
 
-    def universal_viewer_config_url
-      "#{request&.base_url}/uv-emory-config.json"
+    def universal_viewer_config_url(id)
+      "#{request&.base_url}/uv/config/#{id}"
     end
   end
 end

--- a/app/values/uv_configuration.rb
+++ b/app/values/uv_configuration.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+# Class modeling configuration options for the Universal Viewer
+class UvConfiguration < ActiveSupport::HashWithIndifferentAccess
+  # Provides the default values for the viewer
+  # @return [Hash]
+  def self.default_values # rubocop:disable Metrics/MethodLength
+    {
+      "modules" =>
+      {
+        "footerPanel" =>
+        {
+          "options" =>
+          {
+            "shareEnabled" => false,
+            "downloadEnabled" => false,
+            "fullscreenEnabled" => false
+          }
+        },
+        "pagingHeaderPanel" => {
+          "options" => {
+            "pagingToggleEnabled" => true
+          }
+        },
+        "moreInfoRightPanel" => {
+          "content" => {
+            "manifestHeader" => nil
+          }
+        }
+      }
+    }
+  end # rubocop:enable Metrics/MethodLength
+
+  # Constructor
+  # @param values [Hash] configuration options for the Universal Viewer
+  # @see https://github.com/UniversalViewer/universalviewer/wiki/Configuration
+  def initialize(values = {})
+    build_values = self.class.default_values.deep_merge(values.with_indifferent_access)
+
+    super(build_values)
+  end
+end

--- a/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
+++ b/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
@@ -1,8 +1,9 @@
 <div class="view-wrapper">
   <iframe
-      width="100%"
-      height="480"
-      src="/uv/uv.html#?manifest=<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>&config=<%= universal_viewer_config_url %>"
+      class="universal-viewer-iframe"
+      width="1140px"
+      height="668px"
+      src="/uv/uv.html#?manifest=<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>&config=<%= universal_viewer_config_url(presenter.id) %>"
       allowfullscreen="true"
       frameborder="0"
   ></iframe>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,5 +62,7 @@ Rails.application.routes.draw do
     end
   end
 
+  get "/uv/config/:id", to: "application#uv_config", as: "uv_config", defaults: { format: :json }
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/uv/uv-config.json
+++ b/config/uv/uv-config.json
@@ -1,2 +1,19 @@
 {
+    "options": {
+        "rightPanelEnabled": true
+    },
+    "modules": {
+        "footerPanel": {
+            "options": {
+                "downloadEnabled": false,
+                "fullscreenEnabled": false,
+                "shareEnabled": false
+            }
+        }
+        "pagingHeaderPanel": {
+          "options": {
+            "pagingToggleEnabled": true
+          }
+        },
+    }
 }

--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -1,9 +1,9 @@
-
+<!DOCTYPE html>
 <!--
     This is what the embed iframe src links to. It doesn't need to communicate with the parent page, only fill the available space and look for #? parameters
 -->
 
-<html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
         <link rel="icon" href="favicon.ico">
@@ -17,10 +17,19 @@
                 padding: 0;
                 overflow: hidden;
             }
+            .uv .mobileFooterPanel .options .btn.fullScreen {
+              display: inline !important;
+              margin-right: 0;
+              float: right;
+            }
+
+            .uv .mobileFooterPanel .options {
+              width: auto !important;
+            }
         </style>
         <script type="text/javascript">
         window.addEventListener('uvLoaded', function(e) {
-                urlDataProvider = new UV.URLDataProvider(true);
+                urlDataProvider = new UV.URLDataProvider(false);
                 var formattedLocales;
                 var locales = urlDataProvider.get('locales', '');
 
@@ -41,10 +50,13 @@
                     ]
                 }
 
+                manifestUri = urlDataProvider.get('manifest');
+                configUri = '/uv/config/' + manifestUri.replace('/manifest','').replace(/.*\//,'') + '.json';
+
                 uv = createUV('#uv', {
                     root: '.',
-                    iiifResourceUri: urlDataProvider.get('manifest'),
-                    configUri: urlDataProvider.get('config'),
+                    iiifResourceUri: manifestUri,
+                    configUri: configUri,
                     collectionIndex: Number(urlDataProvider.get('c', 0)),
                     manifestIndex: Number(urlDataProvider.get('m', 0)),
                     sequenceIndex: Number(urlDataProvider.get('s', 0)),
@@ -60,28 +72,28 @@
     </head>
     <body>
 
-        <div id="uv" class="uv"></div>
+      <div id="uv" class="uv"></div>
 
-        <script>
-            $(function() {
+      <script>
+        $(function() {
 
-                var $UV = $('#uv');
+            var $UV = $('#uv');
 
-                function resize() {
-                    var windowWidth = window.innerWidth;
-                    var windowHeight = window.innerHeight;
-                    $UV.width(windowWidth);
-                    $UV.height(windowHeight);
-                }
+            function resize() {
+                var windowWidth = window.innerWidth;
+                var windowHeight = window.innerHeight;
+                $UV.width(windowWidth);
+                $UV.height(windowHeight);
+            }
 
-                $(window).on('resize' ,function() {
-                    resize();
-                });
-
+            $(window).on('resize' ,function() {
                 resize();
             });
 
-        </script>
-        <script type="text/javascript" src="uv.js"></script>
+            resize();
+        });
+
+      </script>
+      <script type="text/javascript" src="uv.js"></script>
     </body>
 </html>

--- a/config/uv/uv_config_liberal.json
+++ b/config/uv/uv_config_liberal.json
@@ -1,0 +1,14 @@
+{
+    "options": {
+        "rightPanelEnabled": true
+    },
+    "modules": {
+        "footerPanel": {
+            "options": {
+                "downloadEnabled": true,
+                "fullscreenEnabled": true,
+                "shareEnabled": true
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "preinstall": "rm -rf ./public/uv",
     "postinstall": "yarn run uv-install && yarn run uv-config",
     "uv-install": "shx cp -r ./node_modules/universalviewer/uv ./public/",
-    "uv-config": "shx cp ./config/uv/uv.html ./public/uv/uv.html & shx cp ./config/uv/uv-config.json ./public/uv/"
+    "uv-config": "shx cp ./config/uv/uv.html ./public/uv/uv.html & shx cp ./config/uv/uv_config.json ./public/uv/ & shx cp ./config/uv/uv_config_liberal.json ./public/uv/"
   }
 }

--- a/spec/requests/uv_config_spec.rb
+++ b/spec/requests/uv_config_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "UvConfiguration requests", :clean, type: :request do
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add([
+               work_with_public_visibility,
+               work_with_public_low_view_visibility,
+               work_with_emory_high_visibility,
+               work_with_emory_low_visibility
+             ])
+    solr.commit
+  end
+
+  let(:emory_high_work_id) { '111-321' }
+  let(:public_work_id) { '222-321' }
+  let(:public_low_view_work_id) { '333-321' }
+  let(:emory_low_work_id) { '444-321' }
+
+  let(:work_with_emory_high_visibility) do
+    WORK_WITH_EMORY_HIGH_VISIBILITY
+  end
+
+  let(:work_with_public_visibility) do
+    WORK_WITH_PUBLIC_VISIBILITY
+  end
+
+  let(:work_with_public_low_view_visibility) do
+    WORK_WITH_PUBLIC_LOW_VIEW_VISIBILITY
+  end
+
+  let(:work_with_emory_low_visibility) do
+    WORK_WITH_EMORY_LOW_VISIBILITY
+  end
+
+  describe "GET /uv/config/:id" do
+    it "pulls a Universal Viewer manifest for the resource" do
+      get "/uv/config/#{public_work_id}", params: { format: :json }
+
+      expect(response.status).to eq 200
+      expect(response.body).not_to be_empty
+      expect(response.content_length).to be > 0
+      expect(response.content_type).to eq "application/json"
+
+      response_values = JSON.parse(response.body)
+      expect(response_values).to include "modules"
+      expect(response_values["modules"]["pagingHeaderPanel"]["options"]).to include "pagingToggleEnabled" => true
+      expect(response_values["modules"]["footerPanel"]).to include "options"
+      expect(response_values["modules"]["footerPanel"]["options"]).to include(
+        "shareEnabled" => true,
+        "downloadEnabled" => true,
+        "fullscreenEnabled" => true
+      )
+    end
+
+    it "responds with downloads disabled for a work with 'Public Low View' visibility" do
+      get "/uv/config/#{public_low_view_work_id}", params: { format: :json }
+
+      expect(response.status).to eq 200
+      expect(response.body).not_to be_empty
+      expect(response.content_length).to be > 0
+      expect(response.content_type).to eq "application/json"
+
+      response_values = JSON.parse(response.body)
+      expect(response_values).to include "modules"
+      expect(response_values["modules"]["pagingHeaderPanel"]["options"]).to include "pagingToggleEnabled" => true
+      expect(response_values["modules"]["footerPanel"]).to include "options"
+      expect(response_values["modules"]["footerPanel"]["options"]).to include(
+        "shareEnabled" => false,
+        "downloadEnabled" => false,
+        "fullscreenEnabled" => false
+      )
+    end
+
+    context "when the resource does not exist" do
+      xit "responds with a 404 status code" do
+        get "/uv/config/nonexistent", params: { format: :json }
+
+        expect(response.status).to eq 404
+      end
+    end
+
+    it "responds with the configuration with downloads enabled for a work with 'Public' visibility" do
+      get "/uv/config/#{public_work_id}", params: { format: :json }
+
+      expect(response.status).to eq 200
+      expect(response.body).not_to be_empty
+      expect(response.content_length).to be > 0
+      expect(response.content_type).to eq "application/json"
+
+      response_values = JSON.parse(response.body)
+      expect(response_values).to include "modules"
+      expect(response_values["modules"]["pagingHeaderPanel"]["options"]).to include "pagingToggleEnabled" => true
+      expect(response_values["modules"]).to include "footerPanel"
+      expect(response_values["modules"]["footerPanel"]).to include "options"
+      expect(response_values["modules"]["footerPanel"]["options"]).to include(
+        "shareEnabled" => true,
+        "downloadEnabled" => true,
+        "fullscreenEnabled" => true
+      )
+    end
+
+    it "responds with downloads enabled for a work with 'Emory High Download' visibility" do
+      get "/uv/config/#{emory_high_work_id}", params: { format: :json }
+
+      expect(response.status).to eq 200
+      expect(response.body).not_to be_empty
+      expect(response.content_length).to be > 0
+      expect(response.content_type).to eq "application/json"
+
+      response_values = JSON.parse(response.body)
+      expect(response_values).to include "modules"
+      expect(response_values["modules"]["footerPanel"]).to include "options"
+      expect(response_values["modules"]["footerPanel"]["options"]).to include(
+        "shareEnabled" => true,
+        "downloadEnabled" => true,
+        "fullscreenEnabled" => true
+      )
+    end
+
+    it "responds with downloads enabled for a work with 'Emory Low Download' visibility" do
+      get "/uv/config/#{emory_low_work_id}", params: { format: :json }
+
+      expect(response.status).to eq 200
+      expect(response.body).not_to be_empty
+      expect(response.content_length).to be > 0
+      expect(response.content_type).to eq "application/json"
+
+      response_values = JSON.parse(response.body)
+      expect(response_values).to include "modules"
+      expect(response_values["modules"]["footerPanel"]).to include "options"
+      expect(response_values["modules"]["footerPanel"]["options"]).to include(
+        "shareEnabled" => true,
+        "downloadEnabled" => true,
+        "fullscreenEnabled" => true
+      )
+      expect(response_values["modules"]["downloadDialogue"]).to include("options", "content")
+      expect(response_values["modules"]["downloadDialogue"]["options"]).to include(
+        "currentViewDisabledPercentage" => 0,
+        "confinedImageSize" => 100_000
+      )
+      expect(response_values["modules"]["downloadDialogue"]["content"]).to include("wholeImageHighRes")
+    end
+  end
+end

--- a/spec/routing/uv_config_routes_spec.rb
+++ b/spec/routing/uv_config_routes_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "UV Configuration Routes", type: :routing do
+  it "routes requests for uv configurations with a resource ID" do
+    expect(get("/uv/config/resource-id")).to route_to(
+      format:     :json,
+      controller: "application",
+      action:     "uv_config",
+      id:         "resource-id"
+    )
+  end
+end

--- a/spec/support/visibility_curate_generic_works.rb
+++ b/spec/support/visibility_curate_generic_works.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+WORK_WITH_EMORY_HIGH_VISIBILITY = {
+  id:                            '111-321',
+  has_model_ssim:                ['CurateGenericWork'],
+  title_tesim:                   ['Work with Emory High visibility'],
+  thumbnail_path_ss:             ['/downloads/111-321?file=thumbnail'],
+  hasRelatedImage_ssim:          ['111-456'],
+  edit_access_group_ssim:        ["admin"],
+  read_access_group_ssim:        ["registered"],
+  visibility_ssi:                ['authenticated'],
+  visibility_group_ssi:          "Log In Required",
+  human_readable_visibility_ssi: "Emory High Download"
+
+}.freeze
+
+WORK_WITH_PUBLIC_VISIBILITY = {
+  id:                            '222-321',
+  has_model_ssim:                ['CurateGenericWork'],
+  title_tesim:                   ['Work with Open Access'],
+  thumbnail_path_ss:             ['/downloads/222-321?file=thumbnail'],
+  hasRelatedImage_ssim:          ['222-456'],
+  edit_access_group_ssim:        ["admin"],
+  read_access_group_ssim:        ["public"],
+  visibility_ssi:                ['open'],
+  visibility_group_ssi:          "Public",
+  human_readable_visibility_ssi: "Public"
+}.freeze
+
+WORK_WITH_PUBLIC_LOW_VIEW_VISIBILITY = {
+  id:                            '333-321',
+  has_model_ssim:                ['CurateGenericWork'],
+  title_tesim:                   ['Work with Public Low Resolution'],
+  thumbnail_path_ss:             ['/downloads/333-321?file=thumbnail'],
+  hasRelatedImage_ssim:          ['333-456'],
+  edit_access_group_ssim:        ["admin"],
+  read_access_group_ssim:        ["low_res"],
+  visibility_ssi:                ['low_res'],
+  visibility_group_ssi:          "Public",
+  human_readable_visibility_ssi: "Public Low View"
+}.freeze
+
+WORK_WITH_EMORY_LOW_VISIBILITY = {
+  id:                            '444-321',
+  has_model_ssim:                ['CurateGenericWork'],
+  title_tesim:                   ['Work with Emory Low visibility'],
+  thumbnail_path_ss:             ['/downloads/444-321?file=thumbnail'],
+  hasRelatedImage_ssim:          ['444-456'],
+  edit_access_group_ssim:        ["admin"],
+  read_access_group_ssim:        ["emory_low"],
+  visibility_ssi:                ["emory_low"],
+  visibility_group_ssi:          "Log In Required",
+  human_readable_visibility_ssi: "Emory Low Download"
+}.freeze
+
+WORK_WITH_ROSE_HIGH_VISIBILITY = {
+  id:                            '555-321',
+  has_model_ssim:                ['CurateGenericWork'],
+  title_tesim:                   ['Work with Rose High View visibility'],
+  thumbnail_path_ss:             ['/downloads/555-321?file=thumbnail'],
+  hasRelatedImage_ssim:          ['555-456'],
+  edit_access_group_ssim:        ["admin"],
+  read_access_group_ssim:        ["rose_high"],
+  visibility_ssi:                ['rose_high'],
+  visibility_group_ssi:          "Reading Room Specific",
+  human_readable_visibility_ssi: "Rose High View"
+}.freeze
+
+WORK_WITH_PRIVATE_VISIBILITY = {
+  id:                            '666-321',
+  has_model_ssim:                ['CurateGenericWork'],
+  title_tesim:                   ['Work with Private visibility'],
+  thumbnail_path_ss:             ['/downloads/666-321?file=thumbnail'],
+  hasRelatedImage_ssim:          ['666-456'],
+  edit_access_group_ssim:        ["admin"],
+  visibility_ssi:                ["restricted"],
+  human_readable_visibility_ssi: "Private"
+}.freeze

--- a/spec/values/uv_configuration_spec.rb
+++ b/spec/values/uv_configuration_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe UvConfiguration do
+  subject(:uv_configuration) { described_class.new(foo: "bar") }
+
+  describe ".default_values" do
+    it "generates the default configuration options" do
+      expect(described_class.default_values["modules"]["footerPanel"]).to include "options"
+      expect(described_class.default_values["modules"]["footerPanel"]["options"]).to include(
+        "shareEnabled" => false,
+        "downloadEnabled" => false
+      )
+      expect(described_class.default_values["modules"]["moreInfoRightPanel"]["content"]).to include(
+        "manifestHeader" => nil
+      )
+    end
+  end
+
+  describe ".new" do
+    it "constructs an object with custom properties" do
+      expect(uv_configuration).to include "foo"
+      expect(uv_configuration["foo"]).to eq "bar"
+    end
+  end
+end


### PR DESCRIPTION
- app/assets/javascripts/uv_width.js: resizes the viewer to the container width.
- app/assets/stylesheets/curate.scss: styling that enforces the viewer to exist in desktop mode.
- app/controllers/application_controller.rb: pastes and slightly alters the actions from Lux' setup.
- app/helpers/hyrax/iiif_helper.rb: points the configuration to the uv route.
- app/values/uv_configuration.rb: imports model from Lux for configuration generation. 
- app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb: changes size and helper call.
- config/routes.rb: adds new route for json action.
- config/uv/uv-config.json and config/uv/uv_config_liberal.json: brings over the same code from Lux, even though this seems to only be there for redundancy.
- config/uv/uv.html: mirrors the Lux file.
- package.json: copies Lux' PR.
- spec/*: uses the same spec as Lux with only minor alterations.