### PR TITLE
Remove batch upload button

### DIFF
--- a/app/views/hyrax/base/_form.html.erb
+++ b/app/views/hyrax/base/_form.html.erb
@@ -1,3 +1,4 @@
+<% # [Hyrax-overwrite-v3.0.0.pre.rc1] Remove batch upload link L#17-18 %>
 <%= simple_form_for [main_app, @form],
                     html: {
                       data: { behavior: 'work-form',
@@ -13,11 +14,6 @@
       <%= render 'form_collections_error', f: f %>
       <%= render 'form_visibility_error', f: f %>
     </div>
-  <% end %>
-  <% if Flipflop.batch_upload? && f.object.new_record? %>
-    <% provide :metadata_tab do %>
-      <p class="switch-upload-type"><%= t('.batch_upload_hint') %> <%= link_to t('.batch_link'), hyrax.new_batch_upload_path %></p>
-    <% end %>
   <% end %>
   <%= render 'hyrax/base/guts4form', f: f %>
 <% end %>

--- a/app/views/hyrax/my/works/index.html.erb
+++ b/app/views/hyrax/my/works/index.html.erb
@@ -1,0 +1,77 @@
+<% # [Hyrax-overwrite-v3.0.0.pre.rc1] Only display batch upload link for admins L#20 and L#35 %>
+<% provide :page_title, t("hyrax.admin.sidebar.works") %>
+
+<% provide :head do %>
+  <%= rss_feed_link_tag route_set: hyrax %>
+  <%= atom_feed_link_tag route_set: hyrax %>
+<% end %>
+
+<script>
+//<![CDATA[
+
+  <%= render partial: 'scripts', formats: [:js] %>
+
+//]]>
+</script>
+<% provide :page_header do %>
+  <h1><span class="fa fa-file" aria-hidden="true"></span> <%= t("hyrax.admin.sidebar.works") %></h1>
+  <div class="pull-right">
+    <% if @create_work_presenter.many? %>
+      <% if Flipflop.batch_upload? && current_user.admin? %>
+        <%= link_to(
+              t(:'helpers.action.batch.new'),
+              '#',
+              data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'batch' },
+              class: 'btn btn-primary'
+            ) %>
+      <% end %>
+      <%= link_to(
+            t(:'helpers.action.work.new'),
+            '#',
+            data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'single' },
+            class: 'btn btn-primary'
+          ) %>
+    <% else # simple link to the first work type %>
+      <% if Flipflop.batch_upload? && current_user.admin? %>
+        <%= link_to(
+            t(:'helpers.action.batch.new'),
+            hyrax.new_batch_upload_path(payload_concern: @create_work_presenter.first_model),
+            class: 'btn btn-primary'
+            ) %>
+      <% end %>
+      <%= link_to(
+            t(:'helpers.action.work.new'),
+            new_polymorphic_path([main_app, @create_work_presenter.first_model]),
+            class: 'btn btn-primary'
+          ) %>
+    <% end %>
+  </div>
+<% end %>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default <%= 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>">
+      <%= render 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>
+      <div class="panel-heading">
+        <% if current_page?(hyrax.my_works_path(locale: nil)) %>
+          <span class="count-display"><%= I18n.t('hyrax.my.count.works.you_own', total_count: @response.total_count).html_safe %></span>
+        <% elsif current_page?(hyrax.dashboard_works_path(locale: nil)) && !current_ability.admin? %>
+          <span class="count-display"><%= I18n.t('hyrax.my.count.works.you_manage', total_count: @response.total_count).html_safe %></span>
+        <% else %>
+          <span class="count-display"><%= I18n.t('hyrax.my.count.works.in_repo', total_count: @response.total_count).html_safe %></span>     
+        <% end %>
+      </div> 
+      <div class="panel-body">
+        <%= render 'search_header' %>
+        <h2 class="sr-only"><%= t('hyrax.my.count.works.works_listing') %></h2>
+        <%= render 'document_list' %>
+
+        <%= render 'results_pagination' %>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+<%= render '/shared/select_work_type_modal', create_work_presenter: @create_work_presenter if @create_work_presenter.many? %>

--- a/spec/system/create_curate_generic_work_spec.rb
+++ b/spec/system/create_curate_generic_work_spec.rb
@@ -224,6 +224,12 @@ RSpec.describe 'Create a CurateGenericWork', integration: true, clean: true, typ
       expect(page).to have_content 'abc12345-dedup_key'
     end
 
+    scenario "user cannot navigate to batch upload" do
+      visit '/concern/curate_generic_works/new'
+      expect(page).not_to have_css('.switch-upload-type')
+      expect(page).not_to have_link(href: /batch/)
+    end
+
     scenario "Create Curate Work" do
       visit '/concern/curate_generic_works/new'
 

--- a/spec/system/viewing_a_work_spec.rb
+++ b/spec/system/viewing_a_work_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.describe 'viewing the importer guide', type: :system, clean: true, js: true do
+RSpec.describe 'viewing the importer guide', type: :system, clean: true do
   let(:admin_user) { FactoryBot.create(:admin) }
   let(:work) { FactoryBot.build(:work_with_full_metadata, user: admin_user) }
   let(:user) { FactoryBot.create(:user) }

--- a/spec/system/viewing_a_work_spec.rb
+++ b/spec/system/viewing_a_work_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.describe 'viewing the importer guide', type: :system, clean: true do
+RSpec.describe 'viewing the importer guide', type: :system, clean: true, js: true do
   let(:admin_user) { FactoryBot.create(:admin) }
   let(:work) { FactoryBot.build(:work_with_full_metadata, user: admin_user) }
   let(:user) { FactoryBot.create(:user) }
@@ -112,6 +112,11 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
       visit "/dashboard/my/works"
       expect(page).to have_selector(:css, 'a[data-method="delete"]')
     end
+
+    it 'has a batch upload link on the works dashboard' do
+      visit "/dashboard/works"
+      expect(page).to have_link(href: /batch/)
+    end
   end
 
   context 'when logged in as a non-admin user' do
@@ -132,6 +137,11 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
     it 'does not have a delete action on the my works dashboard' do
       visit "/dashboard/my/works"
       expect(page).not_to have_selector(:css, 'a[data-method="delete"]')
+    end
+
+    it 'does not have a batch upload link on the works dashboard' do
+      visit "/dashboard/works"
+      expect(page).not_to have_link(href: /batch/)
     end
   end
 


### PR DESCRIPTION
- Only admin users should see a batch upload link on the works dashboard. No users should see a batch upload link in the new work form.