### PR TITLE
Changes Rights Status to a link with QA terms as text (#1191).

### DIFF
--- a/app/presenters/hyrax/curate_generic_work_presenter.rb
+++ b/app/presenters/hyrax/curate_generic_work_presenter.rb
@@ -34,7 +34,7 @@ module Hyrax
     def manifest_metadata
       [
         { "label" => "Provided by", "value" => holding_repository },
-        { "label" => "Rights Status", "value" => rights_statement },
+        { "label" => "Rights Status", "value" => "<a href=\"#{rights_statement_authority[:id]}\">#{rights_statement_authority[:term]}</a>" },
         { "label" => "Identifier", "value" => id },
         { "label" => "Persistent URL", "value" => "<a href=\"#{purl}\">#{purl}</a>" }
       ]
@@ -71,6 +71,10 @@ module Hyrax
           wf_copy[key.split('_').map(&:capitalize).join(' ').remove('Workflow ')] = wf_copy.delete(key) # alter keys as per display requirements
         end
         wf_copy
+      end
+
+      def rights_statement_authority
+        Qa::Authorities::Local.subauthority_for('rights_statements').find(rights_statement.first)
       end
   end
 end

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe IiifController, type: :controller, clean: true, iiif: true do
         "date_modified_dtsi" => "2019-11-11T18:20:32Z",
         "depositor_tesim" => 'example_user',
         "holding_repository_tesim" => ["test holding repo"],
-        "rights_statement_tesim" => ["example.com"] }
+        "rights_statement_tesim" => ["http://rightsstatements.org/vocab/InC/1.0/"] }
     end
     let(:params) do
       {
@@ -288,7 +288,7 @@ RSpec.describe IiifController, type: :controller, clean: true, iiif: true do
       expect(response_values["metadata"][0]["label"]).to eq "Provided by"
       expect(response_values["metadata"][0]["value"]).to eq ["test holding repo"]
       expect(response_values["metadata"][1]["label"]).to eq "Rights Status"
-      expect(response_values["metadata"][1]["value"]).to eq ["example.com"]
+      expect(response_values["metadata"][1]["value"]).to eq "<a href=\"http://rightsstatements.org/vocab/InC/1.0/\">In Copyright</a>"
       expect(response_values["metadata"][2]["label"]).to eq "Identifier"
       expect(response_values["metadata"][2]["value"]).to eq work.id
       expect(response_values["metadata"][3]["label"]).to eq "Persistent URL"

--- a/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
+++ b/spec/presenters/hyrax/curate_generic_work_presenter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
       "date_created_tesim" => ['an unformatted date'],
       "depositor_tesim" => user_key,
       "holding_repository_tesim" => ["test holding repo"],
-      "rights_statement_tesim" => ["empl.com"],
+      "rights_statement_tesim" => ["http://rightsstatements.org/vocab/InC/1.0/"],
       "preservation_workflow_terms_tesim" => [
         "{\"workflow_type\":\"Ingest\",\"workflow_notes\":\"Migrated to Cor repository from Extensis Portfolio\",
         \"workflow_rights_basis\":\"Administrative Signo\",\"workflow_rights_basis_note\":\"Ingest note\",
@@ -68,7 +68,8 @@ RSpec.describe Hyrax::CurateGenericWorkPresenter do
       subject { presenter.manifest_metadata }
 
       it {
-        is_expected.to eq [{ "label" => "Provided by", "value" => ["test holding repo"] }, { "label" => "Rights Status", "value" => ["empl.com"] },
+        is_expected.to eq [{ "label" => "Provided by", "value" => ["test holding repo"] },
+                           { "label" => "Rights Status", "value" => "<a href=\"http://rightsstatements.org/vocab/InC/1.0/\">In Copyright</a>" },
                            { "label" => "Identifier", "value" => "888888" },
                            { "label" => "Persistent URL", "value" => "<a href=\"https://example.com/purl/888888\">https://example.com/purl/888888</a>" }]
       }

--- a/spec/services/manifest_builder_service_spec.rb
+++ b/spec/services/manifest_builder_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ManifestBuilderService, :clean do
       "date_modified_dtsi" => "2019-11-11T18:20:32Z",
       "depositor_tesim" => user.uid,
       "holding_repository_tesim" => ["test holding repo"],
-      "rights_statement_tesim" => ["example.com"],
+      "rights_statement_tesim" => "http://rightsstatements.org/vocab/InC/1.0/",
       "hasFormat_ssim" => ["608hdr7srt-cor"] }
   end
   let(:file_set)  { FactoryBot.create(:file_set, read_groups: ['public']) }
@@ -90,7 +90,7 @@ RSpec.describe ManifestBuilderService, :clean do
         expect(response_values["metadata"][0]["label"]).to eq "Provided by"
         expect(response_values["metadata"][0]["value"]).to eq ["test holding repo"]
         expect(response_values["metadata"][1]["label"]).to eq "Rights Status"
-        expect(response_values["metadata"][1]["value"]).to eq ["example.com"]
+        expect(response_values["metadata"][1]["value"]).to eq "<a href=\"http://rightsstatements.org/vocab/InC/1.0/\">In Copyright</a>"
         expect(response_values["metadata"][2]["label"]).to eq "Identifier"
         expect(response_values["metadata"][2]["value"]).to eq work.id
         expect(response_values).to include "sequences"


### PR DESCRIPTION
- app/presenters/hyrax/curate_generic_work_presenter.rb: swaps out just displaying value with formatting a link similar to "Persistent URL".
- spec/*: changes expectations for the link processing.