### PR TITLE
Adds regen derivative button to fileset page

### DIFF
--- a/app/controllers/derivatives_controller.rb
+++ b/app/controllers/derivatives_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DerivativesController < ApplicationController
+  before_action :authenticate_user!
+
+  def clean_up
+    FileSetCleanUpJob.perform_later(params[:file_set_id])
+  end
+end

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -6,6 +6,8 @@
       <%= render 'show_actions', presenter: @presenter %>
       <br>
       <div><%= button_to 'Run Fixity check', file_set_fixity_checks_path(file_set_id: @presenter.id), method: :post, class: 'btn btn-primary' %></div>
+      <br>
+      <div><%= button_to 'Regenerate derivative', "/concern/file_sets/#{@presenter.id}/clean_up", class: 'btn btn-primary' %></div>
       <%= render 'single_use_links', presenter: @presenter if @presenter.editor? %>
     </div>
     <div itemscope itemtype="<%= @presenter.itemtype %>" class="col-xs-12 col-sm-8">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,5 +64,7 @@ Rails.application.routes.draw do
 
   get "/uv/config/:id", to: "application#uv_config", as: "uv_config", defaults: { format: :json }
 
+  post "/concern/file_sets/:file_set_id/clean_up", to: "derivatives#clean_up"
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/controllers/derivates_controller_spec.rb
+++ b/spec/controllers/derivates_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DerivativesController, type: :controller, clean: true do
+  let(:user) { FactoryBot.create(:user) }
+  let(:file_set) { FactoryBot.create(:file_set, user: user) }
+
+  context "when signed in" do
+    describe "POST clean_up" do
+      before do
+        sign_in user
+      end
+
+      it "queues up fileset cleanup job" do
+        expect(FileSetCleanUpJob).to receive(:perform_later).with(file_set.id)
+        post :clean_up, params: { file_set_id: file_set }, xhr: true
+        expect(response).to be_success
+      end
+    end
+  end
+
+  context "when not signed in" do
+    describe "POST clean_up" do
+      it "returns 401" do
+        post :clean_up, params: { file_set_id: file_set }, xhr: true
+        expect(response.code).to eq '401'
+      end
+    end
+  end
+end


### PR DESCRIPTION
* We are adding a regen derivative button to fileset show page for on demand running of fileset cleanup on that particular fs.
* **app/controllers/derivatives_controller.rb**: Adds controller and its action for the on demand call to regen derivatives
* **app/jobs/file_set_clean_up_job.rb**: Modifies job to accept a single file_set_id argument instead of running on all file_sets, while keeping the option to run on all file_sets via rake task.
* **app/views/hyrax/file_sets/show.html.erb**: Adds button
* **config/routes.rb**: Adds route
* **spec/controllers/derivates_controller_spec.rb**: Controller spec

Connected to: #1284 