### PR TITLE
Adds flash notice to derivative regen process so that users know to wait before retrying

### DIFF
--- a/app/controllers/derivatives_controller.rb
+++ b/app/controllers/derivatives_controller.rb
@@ -5,5 +5,7 @@ class DerivativesController < ApplicationController
 
   def clean_up
     FileSetCleanUpJob.perform_later(params[:file_set_id])
+    flash[:notice] = "Your update request has been submitted and may take several minutes to complete"
+    redirect_to hyrax_file_set_path(params[:file_set_id])
   end
 end


### PR DESCRIPTION
Output:
![image](https://user-images.githubusercontent.com/17075287/88086969-2d8c0b00-cb56-11ea-9f8d-eb3ab4f3cc34.png)
