### PR TITLE
Adds errors message to banner on url validation failure

### DIFF
--- a/app/models/curate_generic_work.rb
+++ b/app/models/curate_generic_work.rb
@@ -10,10 +10,10 @@ class CurateGenericWork < ActiveFedora::Base
   end
 
   validates :title, presence: { message: 'Your work must have a title.' }
-  validates :final_published_versions, url: true, if: -> { final_published_versions.present? }
-  validates :related_publications, url: true, if: -> { related_publications.present? }
-  validates :related_datasets, url: true, if: -> { related_datasets.present? }
-  validates :rights_documentation, url: true, if: -> { rights_documentation.present? }
+  validates :final_published_versions, url: { message: 'requires a valid URL' }, if: -> { final_published_versions.present? }
+  validates :related_publications, url: { message: 'requires a valid URL' }, if: -> { related_publications.present? }
+  validates :related_datasets, url: { message: 'requires a valid URL' }, if: -> { related_datasets.present? }
+  validates :rights_documentation, url: { message: 'requires a valid URL' }, if: -> { rights_documentation.present? }
   before_save :index_preservation_workflow_terms
 
   property :abstract, predicate: "http://purl.org/dc/elements/1.1/description", multiple: false do |index|

--- a/app/views/hyrax/base/_form.html.erb
+++ b/app/views/hyrax/base/_form.html.erb
@@ -13,6 +13,7 @@
       <%= render 'form_ordered_members_error', f: f %>
       <%= render 'form_collections_error', f: f %>
       <%= render 'form_visibility_error', f: f %>
+      <%= render 'form_url_validation_error', f: f %>
     </div>
   <% end %>
   <%= render 'hyrax/base/guts4form', f: f %>

--- a/app/views/hyrax/curate_generic_works/_form_url_validation_error.html.erb
+++ b/app/views/hyrax/curate_generic_works/_form_url_validation_error.html.erb
@@ -1,0 +1,4 @@
+<%= f.full_error(:final_published_versions) %>
+<%= f.full_error(:related_publications) %>
+<%= f.full_error(:related_datasets) %>
+<%= f.full_error(:rights_documentation) %>

--- a/spec/system/create_curate_generic_work_spec.rb
+++ b/spec/system/create_curate_generic_work_spec.rb
@@ -230,6 +230,19 @@ RSpec.describe 'Create a CurateGenericWork', integration: true, clean: true, typ
       expect(page).not_to have_link(href: /batch/)
     end
 
+    scenario "url fields are validated" do
+      visit("/concern/curate_generic_works/#{cgw.id}/edit")
+      find('body').click
+      click_link('Additional descriptive fields')
+      fill_in "curate_generic_work[final_published_versions][]", with: "teststring"
+      fill_in "curate_generic_work[related_publications][]", with: "test2string2"
+
+      click_on('Save')
+
+      expect(page).to have_content("Final published versions requires a valid URL") # shows up in the red error banner
+      expect(page).to have_content("Related publications requires a valid URL") # shows up in the red error banner
+    end
+
     scenario "Create Curate Work" do
       visit '/concern/curate_generic_works/new'
 


### PR DESCRIPTION
* We are adding more specific errors messages to the red error banner provided by simpleform when url validation failures occur.

OUTPUT:
![image](https://user-images.githubusercontent.com/17075287/88101880-aeee9800-cb6c-11ea-91c3-b8466ed68f30.png)

![image](https://user-images.githubusercontent.com/17075287/88101747-7484fb00-cb6c-11ea-9dbe-a814dffa4800.png)
