### PR TITLE
Replaces the depositor of the file with the current_user uid (#1264).

### DIFF
--- a/app/controllers/hyrax/fixity_checks_controller.rb
+++ b/app/controllers/hyrax/fixity_checks_controller.rb
@@ -31,7 +31,7 @@ module Hyrax
         # have to sometimes return a 'in progress' status for some bytestreams,
         # which is a possible future enhancement.
         @fixity_check_service ||=
-          FileSetFixityCheckService.new(::FileSet.find(params[:file_set_id]), async_jobs: false)
+          FileSetFixityCheckService.new(::FileSet.find(params[:file_set_id]), async_jobs: false, initiating_user: current_user.uid)
       end
   end
 end

--- a/app/jobs/fixity_check_job.rb
+++ b/app/jobs/fixity_check_job.rb
@@ -27,9 +27,9 @@ class FixityCheckJob < Hyrax::ApplicationJob
   # @param uri [String] uri - of the specific file/version to fixity check
   # @param file_set_id [FileSet] the id for FileSet parent object of URI being checked.
   # @param file_id [String] File#id, used for logging/reporting.
-  def perform(uri, file_set_id:, file_id:)
+  def perform(uri, file_set_id:, file_id:, initiating_user:)
     uri = uri.to_s # sometimes we get an RDF::URI gah
-    log = run_check(file_set_id, file_id, uri)
+    log = run_check(file_set_id, file_id, uri, initiating_user)
 
     if log.failed? && Hyrax.config.callback.set?(:after_fixity_check_failure)
       file_set = ::FileSet.find(file_set_id)
@@ -43,7 +43,7 @@ class FixityCheckJob < Hyrax::ApplicationJob
 
   private
 
-    def run_check(file_set_id, file_id, uri)
+    def run_check(file_set_id, file_id, uri, initiating_user)
       event_start = DateTime.current
       service = ActiveFedora::FixityService.new(uri)
       begin
@@ -55,7 +55,7 @@ class FixityCheckJob < Hyrax::ApplicationJob
       end
 
       log = ChecksumAuditLog.create_and_prune!(passed: fixity_ok, file_set_id: file_set_id, checked_uri: uri, file_id: file_id, expected_result: expected_result)
-      file_set_preservation_event(log, file_set_id, file_id, event_start)
+      file_set_preservation_event(log, file_set_id, file_id, event_start, initiating_user)
       # Note that the after_fixity_check_failure will be called if the fixity check fail. This
       # logging is for additional information related to the failure. Wondering if we should
       # also include the error message?
@@ -67,11 +67,11 @@ class FixityCheckJob < Hyrax::ApplicationJob
       Hyrax.logger
     end
 
-    def file_set_preservation_event(log, file_set_id, file_id, event_start)
+    def file_set_preservation_event(log, file_set_id, file_id, event_start, initiating_user)
       @logger = Logger.new(STDOUT)
       fixity_file_set = ::FileSet.find(file_set_id)
       fixity_file = Hydra::PCDM::File.find(file_id)
-      event = { 'type' => 'Fixity Check', 'start' => event_start, 'software_version' => 'Fedora v4.7.5', 'user' => fixity_file_set.depositor }
+      event = { 'type' => 'Fixity Check', 'start' => event_start, 'software_version' => 'Fedora v4.7.5', 'user' => initiating_user }
       if log.passed == true
         event['outcome'] = 'Success'
         event['details'] = "Fixity intact for file: #{fixity_file&.original_name}: sha1:#{fixity_file&.checksum&.value}"

--- a/app/services/hyrax/file_set_fixity_check_service.rb
+++ b/app/services/hyrax/file_set_fixity_check_service.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+module Hyrax
+  # [Hyrax-overwrite-v3.0.0.pre.rc1]
+  # This class runs fixity checks on a FileSet, potentially on multiple
+  # files each with multiple versions in the FileSet.
+  #
+  # The FixityCheck itself is performed by FixityCheckJob, which
+  # just uses the fedora service to ask for fixity verification.
+  # The outcome will be some created ChecksumAuditLog (ActiveRecord)
+  # objects, recording the checks and their results.
+  #
+  # By default this runs the checks async using ActiveJob, so
+  # returns no useful info -- the checks are still going on. Use
+  # FixityStatusService if you'd like a human-readable status based on
+  # latest recorded checks, or ChecksumAuditLog.latest_for_fileset_id
+  # if you'd like the the machine-readable checks.
+  #
+  # But if you initialize with `async_jobs: false`, checks will be done
+  # blocking in foreground, and you can get back the ChecksumAuditLog
+  # records created.
+  #
+  # It will only run fixity checks if there are not recent
+  # ChecksumAuditLogs on record. "recent" is defined by
+  # `max_days_between_fixity_checks` arg, which defaults to config'd
+  # `Hyrax.config.max_days_between_fixity_checks`
+  class FileSetFixityCheckService
+    attr_reader :id, :latest_version_only,
+                :async_jobs, :max_days_between_fixity_checks
+
+    # @param file_set [ActiveFedora::Base, String] file_set
+    # @param async_jobs [Boolean] Run actual fixity checks in background. Default true.
+    # @param max_days_between_fixity_checks [int] if an exisitng fixity check is
+    #   recorded within this window, no new one will be created. Default
+    #   `Hyrax.config.max_days_between_fixity_checks`. Set to -1 to force
+    #    check.
+    # @param latest_version_only [Booelan]. Check only latest version instead of all
+    #   versions. Default false.
+    def initialize(file_set,
+                   async_jobs: true,
+                   max_days_between_fixity_checks: Hyrax.config.max_days_between_fixity_checks,
+                   latest_version_only: false,
+                   initiating_user:)
+      @max_days_between_fixity_checks = max_days_between_fixity_checks || 0
+      @async_jobs = async_jobs
+      @latest_version_only = latest_version_only
+      @initiating_user = initiating_user
+      if file_set.is_a?(String)
+        @id = file_set
+      else
+        @id = file_set.id
+        @file_set = file_set
+      end
+    end
+
+    # Fixity checks each version of each file if it hasn't been checked recently
+    # If object async_jobs is false, will returns the set of most recent fixity check
+    # status for each version of the content file(s). As a hash keyed by file_id,
+    # values arrays of possibly multiple version checks.
+    #
+    # If async_jobs is true (default), just returns nil, stuff is still going on.
+    def fixity_check
+      results = file_set.files.collect { |f| fixity_check_file(f) }
+
+      return if async_jobs
+
+      results.flatten.group_by(&:file_id)
+    end
+
+    private
+
+      # Retrieve or generate the fixity check for a file
+      # (all versions are checked for versioned files unless latest_version_only set)
+      # @param [ActiveFedora::File] file to fixity check
+      # @param [Array] log container for messages
+      def fixity_check_file(file)
+        versions = file.has_versions? ? file.versions.all : [file]
+
+        versions = [versions.max_by(&:created)] if file.has_versions? && latest_version_only
+
+        versions.collect { |v| fixity_check_file_version(file.id, v.uri.to_s) }.flatten
+      end
+
+      # Retrieve or generate the fixity check for a specific version of a file
+      # @param [String] file_id used to find the file within its parent object (usually "original_file")
+      # @param [String] version_uri the version to be fixity checked (or the file uri for non-versioned files)
+      def fixity_check_file_version(file_id, version_uri)
+        latest_fixity_check = ChecksumAuditLog.logs_for(file_set.id, checked_uri: version_uri).first
+        return latest_fixity_check unless needs_fixity_check?(latest_fixity_check)
+
+        if async_jobs
+          FixityCheckJob.perform_later(version_uri.to_s, file_set_id: file_set.id, file_id: file_id, initiating_user: @initiating_user)
+        else
+          FixityCheckJob.perform_now(version_uri.to_s, file_set_id: file_set.id, file_id: file_id, initiating_user: @initiating_user)
+        end
+      end
+
+      # Check if time since the last fixity check is greater than the maximum days allowed between fixity checks
+      # @param [ChecksumAuditLog] latest_fixity_check the most recent fixity check
+      def needs_fixity_check?(latest_fixity_check)
+        return true unless latest_fixity_check
+        unless latest_fixity_check.updated_at
+          logger.warn "***FIXITY*** problem with fixity check log! Latest Fixity check is not nil, but updated_at is not set #{latest_fixity_check}"
+          return true
+        end
+        days_since_last_fixity_check(latest_fixity_check) >= max_days_between_fixity_checks
+      end
+
+      # Return the number of days since the latest fixity check
+      # @param [ChecksumAuditLog] latest_fixity_check the most recent fixity check
+      def days_since_last_fixity_check(latest_fixity_check)
+        (DateTime.current - latest_fixity_check.updated_at.to_date).to_i
+      end
+
+      # Loads the FileSet from Fedora if needed
+      def file_set
+        @file_set ||= ::FileSet.find(id)
+      end
+  end
+end

--- a/lib/tasks/fixity_check.rake
+++ b/lib/tasks/fixity_check.rake
@@ -4,7 +4,7 @@ namespace :curate do
     desc "Perform fixity checking on file_sets"
     task fixity_check: :environment do
       FileSet.all.each do |file_set|
-        Hyrax::FileSetFixityCheckService.new(file_set, max_days_between_fixity_checks: 90).fixity_check
+        Hyrax::FileSetFixityCheckService.new(file_set, max_days_between_fixity_checks: 90, initiating_user: "Curate system").fixity_check
       end
     end
   end

--- a/spec/jobs/fixity_check_job_spec.rb
+++ b/spec/jobs/fixity_check_job_spec.rb
@@ -62,13 +62,13 @@ RSpec.describe FixityCheckJob, :clean do
       before do
         Hydra::Works::AddFileToFileSet.call(file_set, file1, :service_file)
         Hydra::Works::AddFileToFileSet.call(file_set, file2, :intermediate_file)
-        described_class.perform_now(uri1, file_set_id: file_set.id, file_id: file_set.preservation_master_file.id)
-        described_class.perform_now(uri2, file_set_id: file_set.id, file_id: file_set.service_file.id)
+        described_class.perform_now(uri1, file_set_id: file_set.id, file_id: file_set.preservation_master_file.id, initiating_user: user.uid)
+        described_class.perform_now(uri2, file_set_id: file_set.id, file_id: file_set.service_file.id, initiating_user: user.uid)
       end
 
       context 'when all fixity_checks pass for a file_set' do
         before do
-          described_class.perform_now(uri3, file_set_id: file_set.id, file_id: file_set.intermediate_file.id)
+          described_class.perform_now(uri3, file_set_id: file_set.id, file_id: file_set.intermediate_file.id, initiating_user: user.uid)
           file_set.reload
         end
 
@@ -83,7 +83,7 @@ RSpec.describe FixityCheckJob, :clean do
         let(:cal) { ChecksumAuditLog.create!(passed: false, file_set_id: file_set.id, file_id: file_set.intermediate_file.id) }
         before do
           allow(ChecksumAuditLog).to receive(:create_and_prune!).and_return(cal)
-          described_class.perform_now(uri3, file_set_id: file_set.id, file_id: file_set.intermediate_file.id)
+          described_class.perform_now(uri3, file_set_id: file_set.id, file_id: file_set.intermediate_file.id, initiating_user: user.uid)
           file_set.reload
         end
 

--- a/spec/jobs/fixity_check_job_spec.rb
+++ b/spec/jobs/fixity_check_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe FixityCheckJob, :clean do
   let(:file_id) { file_set.preservation_master_file.id }
 
   describe "called with perform_now" do
-    let(:log_record) { described_class.perform_now(uri, file_set_id: file_set.id, file_id: file_id) }
+    let(:log_record) { described_class.perform_now(uri, file_set_id: file_set.id, file_id: file_id, initiating_user: user.uid) }
 
     describe 'fixity check the content' do
       let(:uri) { file_set.preservation_master_file.uri }

--- a/spec/services/hyrax/file_set_fixity_check_service_spec.rb
+++ b/spec/services/hyrax/file_set_fixity_check_service_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+# [Hyrax-overwrite-v3.0.0.pre.rc1]
+require 'rails_helper'
+
+RSpec.describe Hyrax::FileSetFixityCheckService do
+  let(:f) do
+    FactoryBot.create(:file_set).tap do |file|
+      Hydra::Works::AddFileToFileSet.call(file, File.open(fixture_path + '/world.png'), :preservation_master_file, versioning: true)
+    end
+  end
+  let(:user)              { FactoryBot.create(:user) }
+  let(:service_by_object) { described_class.new(f, initiating_user: user.uid) }
+  let(:service_by_id)     { described_class.new(f.id, initiating_user: user.uid) }
+
+  describe "async_jobs: false" do
+    let(:service_by_object) { described_class.new(f, async_jobs: false, initiating_user: user.uid) }
+    let(:service_by_id)     { described_class.new(f.id, async_jobs: false, initiating_user: user.uid) }
+
+    describe '#fixity_check' do
+      subject(:check) { service_by_object.fixity_check }
+
+      context 'when a file has two versions' do
+        before do
+          Hyrax::VersioningService.create(f.original_file) # create a second version -- the factory creates the first version when it attaches +content+
+        end
+        specify 'returns two log results' do
+          expect(check.values.flatten.length).to eq(2)
+        end
+
+        context "with latest_version_only" do
+          let(:service_by_object) { described_class.new(f, async_jobs: false, latest_version_only: true, initiating_user: user.uid) }
+
+          specify "returns one log result" do
+            expect(check.values.length).to eq(1)
+          end
+        end
+      end
+
+      context "existing check and disabled max_days_between_fixity_checks" do
+        let(:service_by_object) { described_class.new(f, async_jobs: false, max_days_between_fixity_checks: -1, initiating_user: user.uid) }
+        let(:service_by_id)     { described_class.new(f.id, async_jobs: false, max_days_between_fixity_checks: -1, initiating_user: user.uid) }
+        let!(:existing_record) do
+          ChecksumAuditLog.create!(passed: true, file_set_id: f.id, checked_uri: f.original_file.versions.first.label, file_id: f.original_file.id)
+        end
+
+        it "re-checks" do
+          existing_record
+          expect(check.length).to eq 1
+          expect(check.values.flatten.first.id).not_to eq(existing_record.id)
+          expect(check.values.flatten.first.created_at).to be > existing_record.created_at
+        end
+      end
+    end
+
+    describe '#fixity_check_file' do
+      subject(:check_file) { service_by_object.send(:fixity_check_file, f.original_file) }
+
+      specify 'returns a single result' do
+        expect(check_file.length).to eq(1)
+      end
+      describe 'non-versioned file with latest version only' do
+        subject(:nv_check_file) { service_by_object.send(:fixity_check_file, f.original_file) }
+        let(:service_by_object) { described_class.new(f, async_jobs: false, latest_version_only: true, initiating_user: user.uid) }
+
+        before do
+          allow(f.original_file).to receive(:has_versions?).and_return(false)
+        end
+
+        specify 'returns a single result' do
+          expect(nv_check_file.length).to eq(1)
+        end
+      end
+    end
+
+    describe '#fixity_check_file_version' do
+      subject(:check_file_version) { service_by_object.send(:fixity_check_file_version, f.original_file.id, f.original_file.uri.to_s) }
+
+      specify 'returns a single ChecksumAuditLog for the given file' do
+        expect(check_file_version).to be_kind_of ChecksumAuditLog
+        expect(check_file_version.file_set_id).to eq(f.id)
+        expect(check_file_version.checked_uri).to eq(f.original_file.uri)
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/file_set_fixity_check_service_spec.rb
+++ b/spec/services/hyrax/file_set_fixity_check_service_spec.rb
@@ -2,7 +2,7 @@
 # [Hyrax-overwrite-v3.0.0.pre.rc1]
 require 'rails_helper'
 
-RSpec.describe Hyrax::FileSetFixityCheckService do
+RSpec.describe Hyrax::FileSetFixityCheckService, :clean do
   let(:f) do
     FactoryBot.create(:file_set).tap do |file|
       Hydra::Works::AddFileToFileSet.call(file, File.open(fixture_path + '/world.png'), :preservation_master_file, versioning: true)


### PR DESCRIPTION
- app/controllers/hyrax/fixity_checks_controller.rb: includes the current user's `uid` as `initiating_user` argument.
- app/jobs/fixity_check_job.rb: brings in the new `initiating_user` argument and uses it instead of `fixity_file_set.depositor`.
- app/services/hyrax/file_set_fixity_check_service.rb: overrides the hyrax service to accept the new argument.
- lib/tasks/fixity_check.rake: hardcodes the preferred user value into the rake call associated.
- spec/*: inserts the expectation for the `initiating_user` argument.