### PR TITLE
Remove delete buttons for non-admin users

### DIFF
--- a/app/views/hyrax/my/collections/_batch_actions.html.erb
+++ b/app/views/hyrax/my/collections/_batch_actions.html.erb
@@ -1,0 +1,8 @@
+<% # [Hyrax-overwrite-v3.0.0.pre.rc1] Only display delete button for admins L#4 %>
+<div class="batch-info">
+  <div class="batch-toggle">
+    <% if current_user.admin? %>
+      <button id="delete-collections-button" class="btn btn-danger delete-collections-button"><%= t("hyrax.dashboard.my.action.delete_collections") %></button>
+    <% end %>
+  </div>
+</div>

--- a/app/views/hyrax/my/works/_bactch_actions.html.erb
+++ b/app/views/hyrax/my/works/_bactch_actions.html.erb
@@ -1,0 +1,17 @@
+<% # [Hyrax-overwrite-v3.0.0.pre.rc1] Only display delete, edit, add to collection buttons for admins L#6 %>
+<div class="batch-info">
+  <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>
+
+  <div class="batch-toggle">
+    <% if current_user.admin? %>
+      <% session[:batch_edit_state] = "on" %>
+      <div class="button_to-inline">
+        <%= button_to t('hyrax.dashboard.my.action.edit_selected'), hyrax.edit_batch_edits_path, method: :get, class: "btn btn-update btn-primary hidden submits-batches", data: { behavior: 'batch-edit' }, id: 'batch-edit' %>
+      </div>
+      <%= batch_delete %>
+      <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
+          class: 'btn btn-primary submits-batches submits-batches-add',
+          data: { toggle: "modal", target: "#collection-list-container" } %>
+    <% end %>
+  </div>
+</div>

--- a/spec/system/viewing_a_collection_spec.rb
+++ b/spec/system/viewing_a_collection_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe 'Viewing collections', type: :system, clean: true do
       visit "/dashboard/collections/#{user_collection.id}"
       expect(page).to have_selector(:css, 'a[title="Delete this collection"]')
     end
+
+    it 'has delete selected button' do
+      visit "dashboard/collections"
+      find("input[type='checkbox'][id='check_all']").set(true)
+      expect(page).to have_selector("button[id='delete-collections-button']")
+    end
   end
 
   context 'when logged in as a non-admin user' do
@@ -58,6 +64,12 @@ RSpec.describe 'Viewing collections', type: :system, clean: true do
       visit "/dashboard/collections/#{user_collection.id}"
       expect(page).to have_selector(:css, 'a[title="Edit this collection"]')
       expect(page).not_to have_selector(:css, 'a[title="Delete this collection"]')
+    end
+
+    it 'does not have delete selected button' do
+      visit "dashboard/collections"
+      find("input[type='checkbox'][id='check_all']").set(true)
+      expect(page).not_to have_selector("button[id='delete-collections-button']")
     end
   end
 end

--- a/spec/system/viewing_a_work_spec.rb
+++ b/spec/system/viewing_a_work_spec.rb
@@ -117,6 +117,12 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
       visit "/dashboard/works"
       expect(page).to have_link(href: /batch/)
     end
+
+    it 'has delete selected and add to collections buttons' do
+      visit "dashboard/works"
+      find("input[type='checkbox'][id='check_all']").set(true)
+      expect(page).to have_selector("input[value='delete_all']", visible: false)
+    end
   end
 
   context 'when logged in as a non-admin user' do
@@ -142,6 +148,12 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
     it 'does not have a batch upload link on the works dashboard' do
       visit "/dashboard/works"
       expect(page).not_to have_link(href: /batch/)
+    end
+
+    it 'does not have delete selected and add to collections buttons' do
+      visit "dashboard/works"
+      find("input[type='checkbox'][id='check_all']").set(true)
+      expect(page).not_to have_selector("input[value='delete_all']")
     end
   end
 


### PR DESCRIPTION
* We are removing delete, edit, and add to collections buttons for non-admin users. We are also removing delete collections button for the same.