### PR TITLE
Fix files ingested collection job 1252

### DIFF
--- a/app/jobs/collection_files_ingested_job.rb
+++ b/app/jobs/collection_files_ingested_job.rb
@@ -54,6 +54,6 @@ class CollectionFilesIngestedJob < Hyrax::ApplicationJob
     end
 
     def filesets_file_count(filesets)
-      filesets.sum { |fs| fs['sha1_tesim']&.compact&.uniq&.size }
+      filesets.sum { |fs| fs['sha1_tesim']&.compact&.uniq&.size || 0 }
     end
 end

--- a/lib/tasks/collection_files_ingested.rake
+++ b/lib/tasks/collection_files_ingested.rake
@@ -7,7 +7,7 @@ namespace :curate do
       collection_array = ENV['collections']&.split(' ')
 
       CollectionFilesIngestedJob.perform_later(collection_array)
-      puts 'Collection(s) files metrics have been delivered to the public folder.'
+      puts 'Collection(s) files metrics have been delivered to the config/emory folder.'
     end
   end
 end


### PR DESCRIPTION
- app/jobs/collection_files_ingested_job.rb: protects against `sha1_tesim` being nil.
- lib/tasks/collection_files_ingested.rake: points the user to the right folder.