### PR TITLE
Formats the banner path agnostically (#672).

### DIFF
--- a/app/indexers/curate_collection_indexer.rb
+++ b/app/indexers/curate_collection_indexer.rb
@@ -30,12 +30,7 @@ class CurateCollectionIndexer < Hyrax::CollectionIndexer
   end
 
   def path_sanitized(path)
-    if ENV['BRANDING_PATH'].present? && path.include?(ENV['BRANDING_PATH'].to_s)
-      path.gsub ENV['BRANDING_PATH'], '/branding'
-    elsif path.include? Rails.root.join('public', 'branding').to_s
-      path.gsub Rails.root.join('public').to_s, ''
-    else
-      path
-    end
+    return '/branding' + path.split('/branding').last if path&.include? '/branding'
+    path
   end
 end

--- a/spec/indexers/collection_indexer_spec.rb
+++ b/spec/indexers/collection_indexer_spec.rb
@@ -41,19 +41,29 @@ RSpec.describe CurateCollectionIndexer do
       let(:filename) { '/world.png' }
       let(:file)     { fixture_file_upload(filename, 'image/png') }
 
-      it 'indexes the banner path for each collection' do
+      before do
         banner_info = CollectionBrandingInfo.new(
           collection_id: collection.id, filename: filename,
           role: "banner", target_url: ""
         )
         banner_info.save file.local_path
+      end
 
+      it 'indexes the banner path for each collection' do
         expect(solr_document['banner_path_ss']).to eq(
           '/branding/' +
           collection.id.to_s +
           '/banner' +
           filename
         )
+      end
+
+      context 'banner path imported from different environment' do
+        it 'indexes the banner path correctly' do
+          sanitized_path = indexer.path_sanitized('/mnt/prod_efs/uploads/dlp-curate/branding/914nk98sfv-cor/banner/40644j0ztx-cor.jpg')
+
+          expect(sanitized_path).to eq('/branding/914nk98sfv-cor/banner/40644j0ztx-cor.jpg')
+        end
       end
     end
   end


### PR DESCRIPTION
- app/indexers/curate_collection_indexer.rb: formats path without caring what comes before `/branding`.
- spec/indexers/collection_indexer_spec.rb: checks that formatting is working using a path we have in `test` envirnoment.