### PR TITLE
Adds logging for imagemagick errors when creating thumbs

### DIFF
--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+# [Hyrax-overwrite-v3.0.0.pre.rc1] - Adds logger info and warning for bad/missing tmp files L#13-L#20
+
+class CreateDerivativesJob < Hyrax::ApplicationJob
+  queue_as Hyrax.config.ingest_queue_name
+
+  # @param [FileSet] file_set
+  # @param [String] file_id identifier for a Hydra::PCDM::File
+  # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
+  def perform(file_set, file_id, filepath = nil)
+    return if file_set.video? && !Hyrax.config.enable_ffmpeg
+    filename = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id, filepath)
+    @logger = Logger.new(STDOUT)
+    @logger.info "CreateDerivativesJob for #{filename} started at #{DateTime.current}"
+
+    begin
+      file_set.create_derivatives(filename)
+    rescue
+      @logger.warn "Error occurred in CreateDerivativesJob for #{filename}"
+    end
+
+    # Reload from Fedora and reindex for thumbnail and extracted text
+    file_set.reload
+    file_set.update_index
+    file_set.parent.update_index if parent_needs_reindex?(file_set)
+  end
+
+  # If this file_set is the thumbnail for the parent work,
+  # then the parent also needs to be reindexed.
+  def parent_needs_reindex?(file_set)
+    return false unless file_set.parent
+    file_set.parent.thumbnail_id == file_set.id
+  end
+end


### PR DESCRIPTION
* Sometimes when create derivatives for a fileset, there might be a mini magick error which leads to failure of the job. Currently, we are not logging any file details when this failure happens. This
commit helps mitigate that problem.

* **app/jobs/create_derivatives_job.rb**: Adds more logging options for info and failure
* **spec/jobs/create_derivatives_job_spec.rb**: Adds spec to confirm warnings are logged when minimagick errors occur.