### PR TITLE
Suppresses the SubCollection related buttons/links for non-admins (#1336).

### DIFF
--- a/app/views/hyrax/dashboard/collections/_show_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_actions.html.erb
@@ -7,12 +7,13 @@
                 class: 'btn btn-primary' %>
 <% end %>
 
-<% if presenter.collection_type_is_nestable? && presenter.user_can_nest_collection? %>
+<% if presenter.collection_type_is_nestable? && presenter.user_can_nest_collection? && current_user.admin? %>
 <!-- The user should have deposit access to the parent and read access to the child (the collection we are already showing, so no test is necessary). -->
     <%= button_tag '',
                   class: 'btn btn-primary add-to-collection',
                   title: t("hyrax.collection.actions.nested_subcollection.desc"),
                   type: 'button',
+                  id: 'add-to-collection-button',
                   data: { nestable: presenter.collection_type_is_nestable?,
                           hasaccess: true } do %>
                   <%= t('hyrax.collection.actions.nested_subcollection.button_label') %>

--- a/app/views/hyrax/dashboard/collections/_show_subcollection_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_subcollection_actions.html.erb
@@ -1,0 +1,27 @@
+<!-- [Hyrax-overwrite-v3.0.0.pre.rc1] Only deliver whole partial in current user's admin -->
+<% if presenter.collection_type_is_nestable? && presenter.user_can_nest_collection? && current_user.admin? %>
+  <!-- The user should have deposit access to the parent (the collection we are showing) and read access to the child -->
+  <div class="text-right">
+    <div>
+      <div class="sr-only"><% t('hyrax.collection.actions.nest_collections.desc') %></div>
+      <%= button_tag t('hyrax.collection.actions.nest_collections.button_label'),
+            class: 'btn btn-primary add-subcollection',
+            id: 'add-subcollection-button',
+            title: t('hyrax.collection.actions.nest_collections.desc'),
+            data: { nestable: true,
+                    hasaccess: true,
+                    presenter_id: presenter.id } %>
+    </div>
+    <div>
+      <!-- The user should must have the ability to create a new collection of parent's type -->
+      <% if presenter.user_can_create_new_nest_collection? %>
+        <div class="sr-only"><% t('hyrax.collection.actions.add_new_nested_collection.desc') %></div>
+        <%= link_to t('hyrax.collection.actions.add_new_nested_collection.label'),
+          hyrax.dashboard_create_subcollection_under_path(parent_id: presenter.id),
+          title: t('hyrax.collection.actions.add_new_nested_collection.desc'),
+          id: 'create-new-collection-sub-link',
+          class: 'btn btn-link side-arrows' %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/spec/system/viewing_a_collection_spec.rb
+++ b/spec/system/viewing_a_collection_spec.rb
@@ -71,5 +71,20 @@ RSpec.describe 'Viewing collections', type: :system, clean: true do
       find("input[type='checkbox'][id='check_all']").set(true)
       expect(page).not_to have_selector("button[id='delete-collections-button']")
     end
+
+    it 'does not have add to collection button on a collection show page' do
+      visit "dashboard/collections/#{user_collection.id}"
+      expect(page).not_to have_selector("button[id='add-to-collection-button']")
+    end
+
+    it 'does not have add a subcollection button on a collection show page' do
+      visit "dashboard/collections/#{user_collection.id}"
+      expect(page).not_to have_selector("button[id='add-subcollection-button']")
+    end
+
+    it 'does not have create new collection as subcollection link on a collection show page' do
+      visit "dashboard/collections/#{user_collection.id}"
+      expect(page).not_to have_selector("a[id='create-new-collection-sub-link']")
+    end
   end
 end


### PR DESCRIPTION
- app/views/hyrax/dashboard/collections/_show_actions.html.erb: adds admin requirement to button code.
- app/views/hyrax/dashboard/collections/_show_subcollection_actions.html.erb: brings in hyrax file to add admin restraint. 
- spec/system/viewing_a_collection_spec.rb: expands testing to check for these elements' ids.