### PR TITLE
Changes sensitive material labels to Yes and No (#1347).

### DIFF
--- a/app/services/hyrax/sensitive_material_service.rb
+++ b/app/services/hyrax/sensitive_material_service.rb
@@ -5,5 +5,12 @@ module Hyrax
     def initialize
       super('sensitive_material')
     end
+
+    def select_active_options
+      active_elements.map do |e|
+        label = e[:id] == true ? "Yes" : "No"
+        [label, e[:id]]
+      end
+    end
   end
 end

--- a/spec/system/create_curate_generic_work_spec.rb
+++ b/spec/system/create_curate_generic_work_spec.rb
@@ -254,6 +254,12 @@ RSpec.describe 'Create a CurateGenericWork', integration: true, clean: true, typ
       expect(page).to have_css('textarea#curate_generic_work_title.required')
       click_link "Files" # switch tab
       expect(page).to have_content "Add files"
+      expect(page).to have_content 'Sensitive/Objectionable Material (sensitive_material)'
+      expect(page).to have_css('select#curate_generic_work_sensitive_material')
+      within('select#curate_generic_work_sensitive_material') do
+        expect(page).to have_css('option[value="true"][text()="Yes"]')
+        expect(page).to have_css('option[value="false"][text()="No"]')
+      end
       # expect(page).to have_content "Add folder"
       # within('span#addfiles') do
       #   attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)


### PR DESCRIPTION
- app/services/hyrax/sensitive_material_service.rb: overrides the QA method so that it delivers Yes and No.
- spec/system/create_curate_generic_work_spec.rb: tests that the labels are correct.