### PR TITLE
Styles the collection view pages and removes size from listed metadata (#1267).

### DIFF
--- a/app/assets/stylesheets/curate.scss
+++ b/app/assets/stylesheets/curate.scss
@@ -54,8 +54,33 @@ dl.file-show-details {
   }
 }
 
+div.hyc-metadata {
+  dl {
+    border-top: none;
+  }
+
+  div {
+    border-bottom: none;
+  }
+
+  div.metadata-line {
+    border-bottom: 1px solid #ddd;
+    display: flow-root; 
+
+    div {
+      dt, dd { width: 100%; }
+      dt { flex-basis: 215px; }
+    }
+  }
+}
+
+div.row.hyc-body { 
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
 // Set bottom padding to 0px for user activity table
-// [Hyrax-overwrite-v3.0.0.pre.beta3]
+// [Hyrax-overwrite-v3.0.0.pre.rc1]
 .activity-display {
   max-height: 100%;
   overflow: scroll;

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -88,7 +88,6 @@ module Hyrax
         :sensitive_material,
         :internal_rights_note,
         :contact_information,
-        :size,
         :staff_notes,
         :system_of_record_ID,
         :emory_ark,

--- a/app/views/hyrax/collections/_show_descriptions.html.erb
+++ b/app/views/hyrax/collections/_show_descriptions.html.erb
@@ -1,17 +1,16 @@
 <% # [Hyrax-overwrite-v3.0.0.pre.rc1] %>
-<!-- Persistent URL block start -->
-<div>
-  <b>Persistent URL</b>
-  <ul class="tabular">
-    <li><a href="<%= @presenter.purl %>" target="_blank"><%= @presenter.purl %></a></li>
-  </ul>
-</div>
-<!-- Persistent URL block end -->
 <dl>
-  <% present_terms(@presenter, @presenter.terms_with_values) do |r, term| %>
-    <div>
-      <dt><%= r.label(term) %></dt>
-      <dd><%= r.value(term) %></dd>
-    </div>
-  <% end %>
+  <!-- Persistent URL block start -->
+  <div class='metadata-line'>
+    <div class='col-xs-12 col-sm-4'><dt >Persistent URL</dt></div>
+    <div class='col-xs-12 col-sm-8'><dd><a href="<%= @presenter.purl %>" target="_blank"><%= @presenter.purl %></a></dd></div>
+  </div>
+  <!-- Persistent URL block end -->
+    <% present_terms(@presenter, @presenter.terms_with_values) do |r, term| %>
+      <div class='metadata-line'>
+        <div class='col-xs-12 col-sm-4'><dt><%= r.label(term) %></dt></div>
+        <div class='col-xs-12 col-sm-8'><dd><%= r.value(term) %></dd></div>
+      </div>
+    <% end %>
+  </div>
 </dl>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -1,0 +1,126 @@
+<% # [Hyrax-overwrite-v3.0.0.pre.rc1] Changes column sizing L# 57 and 72 %>
+<% provide :page_title, construct_page_title(@presenter.title) %>
+<div class="hyc-container" itemscope itemtype="http://schema.org/CollectionPage">
+  <div class="row hyc-header">
+    <div class="col-md-12">
+
+      <% unless @presenter.banner_file.blank? %>
+          <header class="hyc-banner" style="background-image:url(<%= @presenter.banner_file %>)">
+      <% else %>
+          <header class="hyc-generic">
+      <% end %>
+
+      <div class="hyc-title">
+        <h1><%= @presenter.title.first %></h1>
+        <%= @presenter.collection_type_badge %>
+        <%= @presenter.permission_badge %>
+      </div>
+
+      <% unless @presenter.logo_record.blank? %>
+          <div class="hyc-logos">
+            <% @presenter.logo_record.each_with_index  do |lr, i| %>
+
+                <% if lr[:linkurl].blank? %>
+                    <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" />
+                <% else %>
+                    <a href="<%= lr[:linkurl] %>">
+                      <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" />
+                    </a>
+                <% end %>
+
+            <% end %>
+          </div>
+      <% end %>
+
+      <% unless @presenter.total_viewable_items.blank? %>
+          <div class="hyc-bugs">
+            <div class="hyc-item-count">
+              <b><%= @presenter.total_viewable_items %></b>
+              <%= 'Item'.pluralize(@presenter.total_viewable_items) %></div>
+
+            <% unless @presenter.creator.blank? %>
+                <div class="hyc-created-by">Created by: <%= @presenter.creator.first %></div>
+            <% end %>
+
+            <% unless @presenter.modified_date.blank? %>
+                <div class="hyc-last-updated">Last Updated: <%= @presenter.modified_date %></div>
+            <% end %>
+          </div>
+      <% end %>
+
+      </header>
+
+    </div>
+  </div>
+
+  <div class="row hyc-body">
+    <div class="col hyc-description">
+      <%= render 'collection_description', presenter: @presenter %>
+
+      <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
+          <div class="hyc-blacklight hyc-bl-title">
+            <h2>
+              <%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)
+            </h2>
+          </div>
+          <div class="hyc-blacklight hyc-bl-results">
+            <%= render 'show_parent_collections', presenter: @presenter %>
+          </div>
+      <% end %>
+
+    </div>
+    <div class="col hyc-metadata">
+      <% unless has_collection_search_parameters? %>
+          <h2><%= t('hyrax.dashboard.collections.show.metadata_header') %></h2>
+          <%= render 'show_descriptions' %>
+      <% end %>
+    </div>
+  </div>
+
+  <!-- Search results label -->
+  <% if @members_count > 0 || @presenter.subcollection_count > 0 %>
+    <div class="hyc-blacklight hyc-bl-title">
+      <h2>
+        <% if has_collection_search_parameters? %>
+            <%= t('hyrax.dashboard.collections.show.search_results') %>
+        <% end %>
+      </h2>
+    </div>
+  <% end %>
+
+  <!-- Search bar -->
+  <div class="hyc-blacklight hyc-bl-search hyc-body row">
+    <div class="col-sm-8">
+      <%= render 'search_form', presenter: @presenter, url: hyrax.collection_path(@presenter.id) %>
+    </div>
+  </div>
+
+  <!-- Subcollections -->
+  <% if @presenter.collection_type_is_nestable? && @subcollection_count > 0 %>
+      <div class="hyc-blacklight hyc-bl-title">
+        <h4><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h4>
+      </div>
+      <div class="hyc-blacklight hyc-bl-results">
+        <%= render 'subcollection_list', collection: @subcollection_docs %>
+      </div>
+  <% end %>
+
+  <!-- Works -->
+  <% if @members_count > 0 %>
+      <div class="hyc-blacklight hyc-bl-title">
+        <h4><%= t('.works_in_collection') %> (<%= @members_count %>)</h4>
+      </div>
+
+      <div class="hyc-blacklight hyc-bl-sort">
+        <%= render 'sort_and_per_page', collection: @presenter %>
+      </div>
+
+      <div class="hyc-blacklight hyc-bl-results">
+        <%= render_document_index @member_docs %>
+      </div>
+
+      <div class="hyc-blacklight hyc-bl-pager">
+        <%= render 'paginate' %>
+      </div>
+  <% end # if @members_count > 0 %>
+</div>

--- a/app/views/hyrax/dashboard/collections/_show_descriptions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_descriptions.html.erb
@@ -1,0 +1,8 @@
+<% # [Hyrax-overwrite-v3.0.0.pre.rc1] Completely excises the dl structure %>
+<h2 class="sr-only"><%= t('.descriptions') %></h2>
+<div>
+  <% present_terms(@presenter, @presenter.terms_with_values) do |r, term| %>
+    <p><strong><%= r.label(term) %></strong><br>
+    <%= r.value(term) %></p>
+  <% end %>
+</div>


### PR DESCRIPTION
- app/assets/stylesheets/curate.scss: adjusts the styling of the elements addressed in the ticket.
- app/presenters/hyrax/collection_presenter.rb: removes the display value of size, per request by @eporter23 made on 7/31/20 via DM on slack.
- app/views/hyrax/collections/_show_descriptions.html.erb: strips `dl` structure in favor of a straight bootstrap column approach.
- app/views/hyrax/collections/show.html.erb: brings in the page as override to excise exact column sizing.
- app/views/hyrax/dashboard/collections/_show_descriptions.html.erb: once again removes dl structure fo that label-top/value-bottom is maintained.