### PR TITLE
Changes the fields show on the search result list (#1346).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -68,26 +68,11 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
     config.add_index_field solr_name("title", :stored_searchable), label: "Title", itemprop: 'name', if: false
-    config.add_index_field solr_name("description", :stored_searchable), itemprop: 'description', helper_method: :iconify_auto_link
-    config.add_index_field solr_name("keyword", :stored_searchable), itemprop: 'keywords', link_to_search: solr_name("keyword", :facetable)
-    config.add_index_field solr_name("subject", :stored_searchable), itemprop: 'about', link_to_search: solr_name("subject", :facetable)
-    config.add_index_field solr_name("creator", :stored_searchable), itemprop: 'creator', link_to_search: solr_name("creator", :facetable)
-    config.add_index_field solr_name("contributors", :stored_searchable), itemprop: 'contributors', link_to_search: solr_name("contributors", :facetable)
-    config.add_index_field solr_name("proxy_depositor", :symbol), label: "Depositor", helper_method: :link_to_profile
-    config.add_index_field solr_name("depositor"), label: "Owner", helper_method: :link_to_profile
-    config.add_index_field solr_name("publisher", :stored_searchable), itemprop: 'publisher', link_to_search: solr_name("publisher", :facetable)
-    config.add_index_field solr_name("based_near_label", :stored_searchable), itemprop: 'contentLocation', link_to_search: solr_name("based_near_label", :facetable)
-    config.add_index_field solr_name("language", :stored_searchable), itemprop: 'inLanguage', link_to_search: solr_name("language", :facetable)
-    config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), itemprop: 'datePublished', helper_method: :human_readable_date
-    config.add_index_field solr_name("date_modified", :stored_sortable, type: :date), itemprop: 'dateModified', helper_method: :human_readable_date
-    config.add_index_field solr_name("date_created", :stored_searchable), itemprop: 'dateCreated'
-    config.add_index_field solr_name("rights_statement", :stored_searchable), helper_method: :rights_statement_links
-    config.add_index_field solr_name("license", :stored_searchable), helper_method: :license_links
-    config.add_index_field solr_name("resource_type", :stored_searchable), label: "Resource Type", link_to_search: solr_name("resource_type", :facetable)
-    config.add_index_field solr_name("file_format", :stored_searchable), link_to_search: solr_name("file_format", :facetable)
-    config.add_index_field solr_name("identifier", :stored_searchable), helper_method: :index_field_link, field_name: 'identifier'
-    config.add_index_field solr_name("embargo_release_date", :stored_sortable, type: :date), label: "Embargo release date", helper_method: :human_readable_date
-    config.add_index_field solr_name("lease_expiration_date", :stored_sortable, type: :date), label: "Lease expiration date", helper_method: :human_readable_date
+    config.add_index_field solr_name("holding_repository", :stored_searchable), label: "Library", itemprop: 'holding_repository'
+    config.add_index_field 'member_of_collections_ssim', label: "Collection", itemprop: 'member_of_collections'
+    config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), label: 'Date Uploaded', itemprop: 'datePublished', helper_method: :human_readable_date
+    config.add_index_field solr_name("date_modified", :stored_sortable, type: :date), label: 'Date Modified', itemprop: 'dateModified', helper_method: :human_readable_date
+    config.add_index_field 'human_readable_visibility_ssi', label: 'Visibility', itemprop: 'human_readable_visibility'
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/spec/system/search_results_page_spec.rb
+++ b/spec/system/search_results_page_spec.rb
@@ -40,4 +40,12 @@ RSpec.describe 'viewing the search results page', type: :system, clean: true do
       expect(page).to have_selector('a.facet_select', count: 13)
     end
   end
+
+  context 'result list item' do
+    it 'should have the right metadata labels' do
+      expect(page).to have_css('.metadata .dl-horizontal dt', text: 'Library:')
+      expect(page).to have_css('.metadata .dl-horizontal dt', text: 'Collection:')
+      expect(page).to have_css('.metadata .dl-horizontal dt', text: 'Visibility:')
+    end
+  end
 end

--- a/spec/system/search_results_page_spec.rb
+++ b/spec/system/search_results_page_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'viewing the search results page', type: :system, clean: true do
   end
 
   context 'result list item' do
-    it 'should have the right metadata labels' do
+    it 'has the right metadata labels' do
       expect(page).to have_css('.metadata .dl-horizontal dt', text: 'Library:')
       expect(page).to have_css('.metadata .dl-horizontal dt', text: 'Collection:')
       expect(page).to have_css('.metadata .dl-horizontal dt', text: 'Visibility:')


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: removes unwanted fields, adds requested ones, and tailors all of their labels.
- spec/system/search_results_page_spec.rb: tests all fields that are populating.