### PR TITLE
Remove inapplicable warning for public works

### DIFF
--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -14,9 +14,6 @@
             <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) %>
             <br />
             <%= t('hyrax.visibility.open.note_html', type: f.object.human_readable_type) %>
-            <div class="collapse" id="collapsePublic">
-              <%= t('hyrax.visibility.open.warning_html', label: visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)) %>
-            </div>
           </label>
         </li>
 

--- a/spec/system/create_curate_generic_work_spec.rb
+++ b/spec/system/create_curate_generic_work_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe 'Create a CurateGenericWork', integration: true, clean: true, typ
       # its element
       find('body').click
       choose('curate_generic_work_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      expect(page).not_to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
       check('agreement')
 
       # click_on('Save')


### PR DESCRIPTION
- When a user selects the public visibility option in the new work form, they are no longer presented with a warning

<img width="313" alt="Screen Shot 2020-08-04 at 12 37 23 PM" src="https://user-images.githubusercontent.com/46227821/89321258-b45ddf00-d650-11ea-824e-20d9831f9fec.png">
