### PR TITLE
Adds guard clause to check if object has any errors before saving

### DIFF
--- a/app/lib/preservation_events.rb
+++ b/app/lib/preservation_events.rb
@@ -13,6 +13,6 @@ module PreservationEvents
                                               initiating_user:  event['user'],
                                               outcome:          event['outcome'],
                                               software_version: event['software_version'] }]
-    object.save!
+    object.save! if object.errors.empty? # save object only if there aren't any errors, eg: validation errors
   end
 end

--- a/spec/system/create_curate_generic_work_spec.rb
+++ b/spec/system/create_curate_generic_work_spec.rb
@@ -243,6 +243,19 @@ RSpec.describe 'Create a CurateGenericWork', integration: true, clean: true, typ
       expect(page).to have_content("Related publications requires a valid URL") # shows up in the red error banner
     end
 
+    scenario "url fields are validated for new work" do
+      new_cgw_form.visit_new_page.metadata_fill_in_with.attach_files.check_visibility
+      find('body').click
+      click_link('Additional descriptive fields')
+      fill_in "curate_generic_work[final_published_versions][]", with: "teststring"
+      fill_in "curate_generic_work[related_publications][]", with: "test2string2"
+
+      click_on('Save')
+
+      expect(page).to have_content("Final published versions requires a valid URL") # shows up in the red error banner
+      expect(page).to have_content("Related publications requires a valid URL") # shows up in the red error banner
+    end
+
     scenario "Create Curate Work" do
       visit '/concern/curate_generic_works/new'
 


### PR DESCRIPTION
* When creating a work, object gets a save call for preservation_events which kicks off url validations. At this point we save the object only if there aren't any errors, else take them back to the create page.