### PR TITLE
Updates yellowback preprocessor with `date_digitized` adjustment (#915).

### DIFF
--- a/app/importers/yellowback_preprocessor.rb
+++ b/app/importers/yellowback_preprocessor.rb
@@ -272,7 +272,8 @@ class YellowbackPreprocessor # rubocop:disable Metrics/ClassLength
     end
 
     def date_digitized(marc_record)
-      extract_datafields(marc_record, '583')
+      dd = extract_datafields(marc_record, '583')
+      extract_date_digitized(dd)
     end
 
     def date_issued(marc_record)
@@ -370,5 +371,11 @@ class YellowbackPreprocessor # rubocop:disable Metrics/ClassLength
     #      "19th Cent."  --> nil
     def clean_marc_date(date_string)
       date_string.scan(/^\[?(\d{4})\D*/).flatten.first
+    end
+
+    def extract_date_digitized(datefields)
+      first_date = datefields&.split('|')&.first
+      return first_date[0..3] if !first_date.nil? && first_date.size >= 4
+      datefields
     end
 end

--- a/spec/fixtures/csv_import/yellowbacks/yellowbacks_marc.xml
+++ b/spec/fixtures/csv_import/yellowbacks/yellowbacks_marc.xml
@@ -317,7 +317,7 @@
       <subfield code="a">The Temple Shakespeare</subfield>
     </datafield>
     <datafield tag="583" ind1="1" ind2=" ">
-      <subfield code="c">2009</subfield>
+      <subfield code="c">20090101</subfield>
     </datafield>
     <datafield tag="590" ind1=" " ind2=" ">
       <subfield code="a">

--- a/spec/importers/books_preprocessor_metadata_spec.rb
+++ b/spec/importers/books_preprocessor_metadata_spec.rb
@@ -131,8 +131,10 @@ RSpec.describe YellowbackPreprocessor do
     expect(import_rows[edge_cases]['date_created']).to eq('XXXX') # Edge Cases
   end
 
-  it 'extracts date_digitized from Alma' do
-    expect(import_rows[shakespeare_start]['date_digitized']).to eq('2009') # Shakespeare's comedy of The merchant of Venice
+  context 'date_digitized from Alma (20090101)' do
+    it 'converts EDTF date into pure year (2009)' do
+      expect(import_rows[shakespeare_start]['date_digitized']).to eq('2009') # Shakespeare's comedy of The merchant of Venice
+    end
   end
 
   it 'extracts date_issued from Alma' do

--- a/spec/importers/curate_mapper_spec.rb
+++ b/spec/importers/curate_mapper_spec.rb
@@ -215,15 +215,18 @@ RSpec.describe CurateMapper do
     end
   end
 
+  # The standard going forward from 8/5/2020 is that date digitized should be a
+  # 4 digit year (per Emily Porter). The Yellowback Preprocessor has been modified
+  # to extract the year value from the supplied csv's EDTF string.
   context "#date_digitized" do
     let(:metadata) do
       {
         "title" => "my title",
-        "date_digitized" => "1985-11-01"
+        "date_digitized" => "1985"
       }
     end
     it "maps the date_digitized field" do
-      expect(mapper.date_digitized).to eq "1985-11-01"
+      expect(mapper.date_digitized).to eq "1985"
     end
   end
 

--- a/spec/models/curate_generic_work_spec.rb
+++ b/spec/models/curate_generic_work_spec.rb
@@ -1229,9 +1229,12 @@ RSpec.describe CurateGenericWork do
     end
   end
 
+  # The standard going forward from 8/5/2020 is that date digitized should be a
+  # 4 digit year (per Emily Porter). The Yellowback Preprocessor has been modified
+  # to extract the year value from the supplied csv's EDTF string.
   describe "#date_digitized" do
     subject { described_class.new }
-    let(:date_digitized) { Date.new(2018, 1, 12) }
+    let(:date_digitized) { '2018' }
 
     context "with new CurateGenericWork work" do
       its(:date_digitized) { is_expected.to be_falsey }


### PR DESCRIPTION
- app/importers/yellowback_preprocessor.rb: adds manipulation logic to import dates correctly.
- spec/fixtures/csv_import/yellowbacks/yellowbacks_marc.xml: alters date so that new preprocessor method can produce an example.
- spec/importers/books_preprocessor_metadata_spec.rb: inserts context concerning how date should be converted to 4-digit year.
- spec/models/curate_generic_work_spec.rb and spec/importers/curate_mapper_spec.rb: makes these tests reflect the expected standard date for `date_digitized` from here on out.