### PR TITLE
creates ui and functionality for background jobs in admin dashboard

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -99,6 +99,7 @@ Metrics/MethodLength:
         - app/indexers/curate_generic_work_indexer.rb
         - spec/fixtures/manifest_output.rb
         - app/controllers/iiif_controller.rb
+        - app/controllers/background_jobs_controller.rb
 
 Metrics/ModuleLength:
     Exclude:

--- a/app/controllers/background_jobs_controller.rb
+++ b/app/controllers/background_jobs_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+class BackgroundJobsController < ApplicationController
+  with_themed_layout 'dashboard'
+  def new; end
+
+  def create
+    if params[:jobs] == 'cleanup'
+      FileSetCleanUpJob.perform_later
+      msg = "File Set Cleanup Job"
+    elsif params[:jobs] == 'preservation'
+      PreservationWorkflowImporterJob.perform_later(params[:preservation_csv].path)
+      msg = "Preservation Workflow Importer Job"
+    else
+      CSV.foreach(params[:reindex_csv].path, headers: true) do |row|
+        r = row.to_h
+        ReindexObjectJob.perform_later(r['id'])
+      end
+      msg = "Reindex Files Job"
+    end
+    flash_message = msg + " has started successfully."
+    redirect_to new_background_job_path, notice: flash_message
+  end
+end

--- a/app/jobs/preservation_workflow_importer_job.rb
+++ b/app/jobs/preservation_workflow_importer_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PreservationWorkflowImporterJob < Hyrax::ApplicationJob
+  def perform(file)
+    PreservationWorkflowImporter.import(file)
+  end
+end

--- a/app/views/background_jobs/new.html.erb
+++ b/app/views/background_jobs/new.html.erb
@@ -1,0 +1,74 @@
+<%= render '/flash_msg' %>
+<%= form_tag background_jobs_path, method: :post, multipart: true, class: "form-horizontal" do %>
+<h3>Background Jobs</h3>
+<table class="table table-striped">
+  <tr>
+    <th>Select Job</th>
+    <th>Select Input File</th>
+   
+  </tr>
+  
+    <tr>
+      <td>
+        <%= radio_button_tag :jobs, 'cleanup', false, id: 'cleanup' %>
+        <%= label :job_cleanup, 'FileSet Cleanup' %>
+        
+        
+      </td>
+      <td>
+        N/A
+      </td>
+      
+    </tr>
+
+    <tr>
+      <td>
+        <%= radio_button_tag :jobs, 'reindex', false, id: 'reindex' %>
+        <%= label :job_cleanup, 'Reindex Selected Files' %>
+        
+        
+      </td>
+      <td>
+        <%= file_field_tag 'reindex_csv', class: 'files', :accept => 'text/csv' %>
+      
+            
+      </td>
+      
+    </tr>
+    <tr>
+      <td>
+        <%= radio_button_tag :jobs, 'preservation', false, id: 'preservation' %>
+        <%= label :job_cleanup, 'Load Preservation Workflow Metadata' %>
+        
+        
+      </td>
+      <td>
+        <%= file_field_tag 'preservation_csv', class: 'files', :accept => 'text/csv' %>
+      </td>
+      
+    </tr>
+
+</table>
+<button class="btn btn-primary" type="submit" value="Submit">Start Job</button>
+<% end %>
+
+
+
+
+<script type="text/javascript">
+$(document).ready(function() {
+    $("input[name='jobs']").on("click",function() {
+      $('.files').each(function(i) {
+         $(this).removeAttr('required');
+      });
+      
+        var val = $(this).val()
+        if(val !== 'cleanup'){
+          $("input[name='" + val + "_csv']").prop('required',true);
+
+        }
+
+
+    }); 
+});
+</script>

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -23,6 +23,10 @@
   <%= menu.nav_link('/csv_imports/new',  data: { turbolinks: false }) do %>
     <span class="fa fa-upload"></span> <span class="sidebar-action-text">Import Content From a CSV</span>
   <% end %>
+
+  <%= menu.nav_link('/background_jobs/new',  data: { turbolinks: false }) do %>
+    <span class="fa fa-tasks"></span> <span class="sidebar-action-text">Background Jobs</span>
+  <% end %>
 <% end %>
 
 <%= render 'hyrax/dashboard/sidebar/menu_partials', menu: menu, section: :tasks %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,5 +66,6 @@ Rails.application.routes.draw do
 
   post "/concern/file_sets/:file_set_id/clean_up", to: "derivatives#clean_up"
 
+  resources :background_jobs, only: [:new, :create]
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,10 +62,10 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :background_jobs, only: [:new, :create]
+
   get "/uv/config/:id", to: "application#uv_config", as: "uv_config", defaults: { format: :json }
 
   post "/concern/file_sets/:file_set_id/clean_up", to: "derivatives#clean_up"
-
-  resources :background_jobs, only: [:new, :create]
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/controllers/background_jobs_controller_spec.rb
+++ b/spec/controllers/background_jobs_controller_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BackgroundJobsController, type: :controller do
+  let(:admin) { FactoryBot.create(:admin) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:csv_file) do
+    fixture_path + '/reindex_files.csv'
+  end
+  let(:csv_file2) do
+    fixture_path + '/preservation_workflows.csv'
+  end
+
+  context "when signed in" do
+    before do
+      sign_in admin
+    end
+
+    describe "#new" do
+      it 'has 200 code for new' do
+        get :new
+        expect(response.status).to eq(200)
+      end
+    end
+
+    describe "#create" do
+      it "successfully starts a file_set cleanup background job" do
+        post :create, params: { jobs: 'cleanup', format: 'json' }
+        response.should redirect_to(new_background_job_path)
+      end
+      it "successfully starts a preservation workflow background job" do
+        post :create, params: { jobs: 'preservation', preservation_csv: fixture_file_upload(csv_file, 'text/csv'), format: 'json' }
+        expect(PreservationWorkflowImporterJob).to have_been_enqueued
+        response.should redirect_to(new_background_job_path)
+      end
+      it "successfully starts a reindex background job" do
+        post :create, params: { jobs: 'reindex', reindex_csv: fixture_file_upload(csv_file2, 'text/csv'), format: 'json' }
+        expect(ReindexObjectJob).to have_been_enqueued
+        response.should redirect_to(new_background_job_path)
+      end
+    end
+  end
+
+  context "when not signed in" do
+    describe "#new" do
+      it 'has 302 found' do
+        get :new
+        response.should redirect_to(new_user_session_path.split('?').first)
+      end
+    end
+  end
+end

--- a/spec/fixtures/reindex_files.csv
+++ b/spec/fixtures/reindex_files.csv
@@ -1,0 +1,3 @@
+id
+723hx3ffjh-cor
+808v9s4n2r-cor

--- a/spec/jobs/preservation_workflow_importer_job_spec.rb
+++ b/spec/jobs/preservation_workflow_importer_job_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe PreservationWorkflowImporterJob, :clean do
+  let(:generic_work) { CurateGenericWork.where(deduplication_key: 'MSS1218_B071_I205').first }
+  let(:csv)          { fixture_path + '/preservation_workflows.csv' }
+
+  before do
+    CurateGenericWork.create(title: ['Example title'], deduplication_key: 'MSS1218_B071_I205')
+  end
+
+  it 'processes preservation workflow preservation metadata' do
+    described_class.perform_now(csv)
+    expect(generic_work.preservation_workflow.count).to eq 4
+  end
+end

--- a/spec/system/admin_dashboard_spec.rb
+++ b/spec/system/admin_dashboard_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe 'Admin dashboard', integration: true, clean: true, type: :system 
       expect(page).to have_link 'Import Content From a CSV'
     end
 
+    scenario 'does have background jobs tab' do
+      expect(page).to have_link 'Background Jobs'
+    end
+
+    scenario 'view background jobs page' do
+      click_on 'Background Jobs'
+      expect(page).to have_content 'Select Job'
+    end
     # TODO: Add more admin tests, for eg: stats page, when work is created
 
     # scenario 'view the statistics page' do


### PR DESCRIPTION
- Curate administrators can load preservation workflow metadata by submitting a CSV in the UI

- The work should happen in a background job

Resolves #1319 