### PR TITLE
Hides Add new work button when user role contains viewer (#1309).

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,10 @@ class User < ApplicationRecord
     email
   end
 
+  def viewer?
+    roles.any? { |r| r.name.include? "viewer" }
+  end
+
   # When a user authenticates via shibboleth, find their User object or make
   # a new one. Populate it with data we get from shibboleth.
   # @param [OmniAuth::AuthHash] auth

--- a/app/views/hyrax/my/works/index.html.erb
+++ b/app/views/hyrax/my/works/index.html.erb
@@ -25,12 +25,14 @@
               class: 'btn btn-primary'
             ) %>
       <% end %>
-      <%= link_to(
-            t(:'helpers.action.work.new'),
-            '#',
-            data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'single' },
-            class: 'btn btn-primary'
-          ) %>
+      <% unless current_user.viewer? %>
+        <%= link_to(
+              t(:'helpers.action.work.new'),
+              '#',
+              data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'single' },
+              class: 'btn btn-primary'
+            ) %>
+      <% end %>
     <% else # simple link to the first work type %>
       <% if Flipflop.batch_upload? && current_user.admin? %>
         <%= link_to(
@@ -39,11 +41,13 @@
             class: 'btn btn-primary'
             ) %>
       <% end %>
-      <%= link_to(
-            t(:'helpers.action.work.new'),
-            new_polymorphic_path([main_app, @create_work_presenter.first_model]),
-            class: 'btn btn-primary'
-          ) %>
+      <% unless current_user.viewer? %>
+        <%= link_to(
+              t(:'helpers.action.work.new'),
+              new_polymorphic_path([main_app, @create_work_presenter.first_model]),
+              class: 'btn btn-primary'
+            ) %>
+      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -131,4 +131,24 @@ RSpec.describe User, :clean do
       # TODO: test that the user does have the elevated privileges.
     end
   end
+
+  context '#viewer?' do
+    it "returns true if any of user's roles contains viewer" do
+      role = Role.find_or_create_by(name: 'health_sciences_viewer')
+      user.roles << role
+
+      expect(user.viewer?).to be_truthy
+    end
+
+    it "returns false is user has no roles" do
+      expect(user.viewer?).to be_falsey
+    end
+
+    it "returns false is user has roles but none containing viewer" do
+      role = Role.find_or_create_by(name: 'admin')
+      user.roles << role
+
+      expect(user.viewer?).to be_falsey
+    end
+  end
 end

--- a/spec/system/viewing_a_work_spec.rb
+++ b/spec/system/viewing_a_work_spec.rb
@@ -155,6 +155,28 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
       find("input[type='checkbox'][id='check_all']").set(true)
       expect(page).not_to have_selector("input[value='delete_all']", visible: false)
     end
+
+    context 'viewer role' do
+      let(:user) do
+        User.create(
+                uid:          'brianbboys1967',
+                ppid:         'P0000001',
+                display_name: 'Brian Wilson'
+              )
+      end
+
+      it 'has no Add new work button' do
+        user.roles = [Role.find_or_create_by(name: 'rose_viewer')]
+        user.save
+        visit "dashboard/works"
+
+        expect(page).not_to have_link "Add new work"
+
+        visit "dashboard/my/works"
+
+        expect(page).not_to have_link "Add new work"
+      end
+    end
   end
 
   describe 'object visibility', :clean do


### PR DESCRIPTION
- app/models/user.rb: creates method that tests whether user has `viewer` role.
- app/views/hyrax/my/works/index.html.erb: makes "Add new work" button useable to only non-"viewer" roles.
- spec/*: tests functionality of user method and its integration.
