### PR TITLE
Skips failing QA test

### DIFF
--- a/spec/system/create_curate_generic_work_spec.rb
+++ b/spec/system/create_curate_generic_work_spec.rb
@@ -84,7 +84,8 @@ RSpec.describe 'Create a CurateGenericWork', integration: true, clean: true, typ
       expect(page).to have_css('li#required-metadata.complete')
     end
 
-    scenario "custom terms show up as dynamic option for external vocab fields", js: true do
+    # TODO: Upgrade QA to 5.5.0+ to re-enable this test
+    scenario "custom terms show up as dynamic option for external vocab fields", js: true, skip: true do
       new_cgw_form.visit_new_page
 
       click_link('Additional descriptive fields')


### PR DESCRIPTION
The LoC authorities in QA appear to not return the proper json at the moment, so we'll skip this test until we can get that fixed.