### PR TITLE
Changes label and count focus for Items on Collection index (#1405).

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -139,3 +139,7 @@ RSpec/AnyInstance:
     Exclude:
         - 'spec/models/job_io_wrapper_spec.rb'
         - spec/views/manifest/manifest.json.jbuilder_spec.rb
+
+RSpec/LetSetup:
+    Exclude:
+        - spec/presenters/collection_presenter_spec.rb

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -127,7 +127,7 @@ module Hyrax
     end
 
     def total_viewable_items
-      ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id}").accessible_by(current_ability).count
+      ActiveFedora::Base.where("member_of_collection_ids_ssim:#{id}").size
     end
 
     def total_viewable_works

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,8 +40,10 @@ en:
     dashboard:
       my:
         heading:
-          collection_type: Collection Type
-          type: Type
-          visibility: Visibility
           collection:
             visibility: Visibility of Collection
+          collection_type: Collection Type
+          items: Deposited Items
+          type: Type
+          visibility: Visibility
+          

--- a/spec/presenters/collection_presenter_spec.rb
+++ b/spec/presenters/collection_presenter_spec.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+# [Hyrax-overwrite-v3.0.0.pre.rc1] Brings in just the tests affected by the change
+# in behavior of the #total_viewable_items method.
 require 'rails_helper'
 
 RSpec.describe Hyrax::CollectionPresenter, :clean do

--- a/spec/presenters/collection_presenter_spec.rb
+++ b/spec/presenters/collection_presenter_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Hyrax::CollectionPresenter, :clean do
+  let(:user) { FactoryBot.create(:user) }
+  let(:collection) { FactoryBot.build(:public_collection_lw, user: user, with_permission_template: true) }
+  let(:ability) { instance_double(Ability) }
+  let(:presenter) { described_class.new(solr_doc, ability) }
+  let(:solr_doc) { SolrDocument.new(collection.to_solr) }
+
+  describe "#total_viewable_items", :clean_repo do
+    subject { presenter.total_viewable_items }
+
+    before do
+      allow(ability).to receive(:user_groups).and_return(['public'])
+      allow(ability).to receive(:current_user).and_return(user)
+    end
+
+    context "empty collection" do
+      it { is_expected.to eq 0 }
+    end
+
+    context "collection with private work" do
+      let!(:work) { FactoryBot.create(:private_work, member_of_collections: [collection]) }
+
+      it { is_expected.to eq 1 }
+    end
+
+    context "collection with public work" do
+      let!(:work) { FactoryBot.create(:public_work, member_of_collections: [collection]) }
+
+      it { is_expected.to eq 1 }
+    end
+
+    context "collection with public collection" do
+      let!(:subcollection) { FactoryBot.create(:public_collection_lw, member_of_collections: [collection]) }
+
+      it { is_expected.to eq 1 }
+    end
+
+    context "collection with public work and sub-collection" do
+      let!(:work) { FactoryBot.create(:public_work, member_of_collections: [collection]) }
+      let!(:subcollection) { FactoryBot.create(:public_collection_lw, member_of_collections: [collection]) }
+
+      it { is_expected.to eq 2 }
+    end
+
+    context "null members" do
+      let(:presenter) { described_class.new(SolrDocument.new(id: '123'), ability) }
+
+      it { is_expected.to eq 0 }
+    end
+  end
+end

--- a/spec/system/show_collection_spec.rb
+++ b/spec/system/show_collection_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'viewing a collection', :clean, type: :system, js: true do
     multi_fields.each do |fieldname|
       expect(page).to have_content collection.send(fieldname).first
     end
-    expect(page).to have_content '0 Items'
+    expect(page).to have_content '1 Item'
     expect(page).not_to have_content 'Works (1)'
     expect(page).not_to have_content 'Test title'
   end

--- a/spec/system/viewing_a_collection_spec.rb
+++ b/spec/system/viewing_a_collection_spec.rb
@@ -86,5 +86,15 @@ RSpec.describe 'Viewing collections', type: :system, clean: true do
       visit "dashboard/collections/#{user_collection.id}"
       expect(page).not_to have_selector("a[id='create-new-collection-sub-link']")
     end
+
+    context 'Items table heading' do
+      it 'shows "Deposited Items", not "Items"' do
+        visit "dashboard/collections"
+        ths = find_all('table#collections-list-table thead tr th').map(&:text)
+
+        expect(ths.include? "Deposited Items").to be_truthy
+        expect(ths.include? "Items").to be_falsey
+      end
+    end
   end
 end

--- a/spec/system/viewing_a_collection_spec.rb
+++ b/spec/system/viewing_a_collection_spec.rb
@@ -92,8 +92,8 @@ RSpec.describe 'Viewing collections', type: :system, clean: true do
         visit "dashboard/collections"
         ths = find_all('table#collections-list-table thead tr th').map(&:text)
 
-        expect(ths.include? "Deposited Items").to be_truthy
-        expect(ths.include? "Items").to be_falsey
+        expect(ths.include?('Deposited Items')).to be_truthy
+        expect(ths.include?('Items')).to be_falsey
       end
     end
   end


### PR DESCRIPTION
- app/presenters/hyrax/collection_presenter.rb: removes visibility constriction.
- config/locales/en.yml: changes header text.
- spec/presenters/collection_presenter_spec.rb: pulls in the spec from the Hyrax gem and focuses purely on changed method.
- spec/system/viewing_a_collection_spec.rb: adds expectations for the altered header.