### PR TITLE
Adds button to re-characterize file set (#1283).

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,6 +76,7 @@ Metrics/CyclomaticComplexity:
         - app/indexers/curate/file_set_indexer.rb
         - app/indexers/curate_generic_work_indexer.rb
         - app/controllers/iiif_controller.rb
+        - app/jobs/characterize_job.rb
 
 Layout/LineLength:
     Exclude:

--- a/app/controllers/characterization_controller.rb
+++ b/app/controllers/characterization_controller.rb
@@ -5,7 +5,7 @@ class CharacterizationController < ApplicationController
 
   def re_characterize
     file_set = FileSet.find(params[:file_set_id])
-    CharacterizeJob.perform_later(file_set, nil, file_set.file_path.first, user: current_user.uid)
+    ReCharacterizeJob.perform_later(file_set: file_set, user: current_user)
     flash[:notice] = "The Re-characterization request has been submitted and may take several minutes to complete"
     redirect_to hyrax_file_set_path(params[:file_set_id])
   end

--- a/app/controllers/characterization_controller.rb
+++ b/app/controllers/characterization_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CharacterizationController < ApplicationController
+  before_action :authenticate_user!
+
+  def re_characterize
+    file_set = FileSet.find(params[:file_set_id])
+    CharacterizeJob.perform_later(file_set, nil, file_set.file_path.first, user: current_user.uid)
+    flash[:notice] = "The Re-characterization request has been submitted and may take several minutes to complete"
+    redirect_to hyrax_file_set_path(params[:file_set_id])
+  end
+end

--- a/app/controllers/characterization_controller.rb
+++ b/app/controllers/characterization_controller.rb
@@ -5,7 +5,7 @@ class CharacterizationController < ApplicationController
 
   def re_characterize
     file_set = FileSet.find(params[:file_set_id])
-    ReCharacterizeJob.perform_later(file_set: file_set, user: current_user)
+    ReCharacterizeJob.perform_later(file_set: file_set, user: current_user.uid)
     flash[:notice] = "The Re-characterization request has been submitted and may take several minutes to complete"
     redirect_to hyrax_file_set_path(params[:file_set_id])
   end

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -12,7 +12,7 @@ class CharacterizeJob < Hyrax::ApplicationJob
   # @param [FileSet] file_set
   # @param [String] file_id identifier for a Hydra::PCDM::File
   # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
-  def perform(file_set, file_id, filepath = nil)
+  def perform(file_set, file_id, filepath = nil, user: nil)
     event_start = DateTime.current
     relation = file_set.class.characterization_proxy
     file = file_set.characterization_proxy
@@ -21,7 +21,7 @@ class CharacterizeJob < Hyrax::ApplicationJob
     Hydra::Works::CharacterizationService.run(file, filepath)
     event = { 'type' => 'Characterization', 'start' => event_start, 'outcome' => 'Success',
               'details' => "#{relation}: #{file.file_name.first} - Technical metadata extracted from file, format identified, and file validated",
-              'software_version' => 'FITS v1.5.0', 'user' => file_set.depositor }
+              'software_version' => 'FITS v1.5.0', 'user' => user.presence || file_set.depositor }
     create_preservation_event(file_set, event)
     Rails.logger.debug "Ran characterization on #{file.id} (#{file.mime_type})"
     file.alpha_channels = channels(filepath) if file_set.image? && Hyrax.config.iiif_image_server?

--- a/app/jobs/re_characterize_job.rb
+++ b/app/jobs/re_characterize_job.rb
@@ -4,7 +4,7 @@ class ReCharacterizeJob < Hyrax::ApplicationJob
   def perform(file_set:, user: nil)
     repository_file = file_set.public_send(:preservation_master_file)
 
-    ReCharacterizationService.new(repository_file).empty_characterization
+    ReCharacterizationService.empty_out_characterization(repository_file)
     CharacterizeJob.perform_later(file_set, repository_file.id, user)
   end
 end

--- a/app/jobs/re_characterize_job.rb
+++ b/app/jobs/re_characterize_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ReCharacterizeJob < Hyrax::ApplicationJob
+  def perform(file_set:, user: nil)
+    repository_file = file_set.public_send(:preservation_master_file)
+
+    ReCharacterizationService.new(repository_file).empty_characterization
+    CharacterizeJob.perform_later(file_set, repository_file.id, user)
+  end
+end

--- a/app/services/re_characterization_service.rb
+++ b/app/services/re_characterization_service.rb
@@ -10,6 +10,11 @@ class ReCharacterizationService
     @repository_file.save!
   end
 
+  def self.empty_out_characterization(repository_file)
+    service = ReCharacterizationService.new(repository_file)
+    service.empty_characterization
+  end
+
   private
 
     def characterization_terms

--- a/app/services/re_characterization_service.rb
+++ b/app/services/re_characterization_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class ReCharacterizationService
+  def initialize(repository_file)
+    @repository_file = repository_file
+  end
+
+  def empty_characterization
+    characterization_setters.each { |term| @repository_file.send("#{term}=", []) }
+    @repository_file.save!
+  end
+
+  private
+
+    def characterization_terms
+      Hydra::Works::Characterization::FitsDocument.terminology.terms.keys
+    end
+
+    def characterization_setters
+      characterization_terms.select { |term| @repository_file.respond_to?("#{term}=") }
+    end
+end

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -8,7 +8,6 @@
       <div><%= button_to t('.fixity_check'), file_set_fixity_checks_path(file_set_id: @presenter.id), method: :post, class: 'btn btn-primary' %></div><br>
       <div><%= button_to t('.regenerate_derivative'), "/concern/file_sets/#{@presenter.id}/clean_up", class: 'btn btn-primary' %></div><br>
       <div><%= button_to t('.recharacterize'), "/concern/file_sets/#{@presenter.id}/re_characterize", class: 'btn btn-primary' %></div>
-      <%= render 'single_use_links', presenter: @presenter if @presenter.editor? %>
     </div>
     <div itemscope itemtype="<%= @presenter.itemtype %>" class="col-xs-12 col-sm-8">
       <header>

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -5,31 +5,32 @@
       <%= media_display @presenter %>
       <%= render 'show_actions', presenter: @presenter %>
       <br>
-      <div><%= button_to 'Run Fixity check', file_set_fixity_checks_path(file_set_id: @presenter.id), method: :post, class: 'btn btn-primary' %></div>
-      <br>
-      <div><%= button_to 'Regenerate derivative', "/concern/file_sets/#{@presenter.id}/clean_up", class: 'btn btn-primary' %></div>
+      <div><%= button_to t('.fixity_check'), file_set_fixity_checks_path(file_set_id: @presenter.id), method: :post, class: 'btn btn-primary' %></div><br>
+      <div><%= button_to t('.regenerate_derivative'), "/concern/file_sets/#{@presenter.id}/clean_up", class: 'btn btn-primary' %></div><br>
+      <div><%= button_to t('.recharacterize'), "/concern/file_sets/#{@presenter.id}/re_characterize", class: 'btn btn-primary' %></div>
+      <%= render 'single_use_links', presenter: @presenter if @presenter.editor? %>
     </div>
     <div itemscope itemtype="<%= @presenter.itemtype %>" class="col-xs-12 col-sm-8">
       <header>
         <%= render 'file_set_title', presenter: @presenter %>
       </header>
       <%# TODO: render 'show_descriptions' See https://github.com/samvera/hyrax/issues/1481 %>
-      <div id="fileset-id"><strong >FileSet ID:</strong> <%= @presenter.id %></div>
-      <div id="fileset-category"><strong >FileSet Category:</strong> <%= @fileset_use %></div>
-      <div id="fileset-parent"><strong>Is Part of:</strong> <%= link_to "Parent Work", @parent, class: 'btn-link' %></div>
+      <div id="fileset-id"><strong ><%= t('.file_set_id') %>:</strong> <%= @presenter.id %></div>
+      <div id="fileset-category"><strong ><%= t('.file_set_category') %>:</strong> <%= @fileset_use %></div>
+      <div id="fileset-parent"><strong><%= t('.is_part_of') %>:</strong> <%= link_to t('.parent_work'), @parent, class: 'btn-link' %></div>
       <br />
       <table class="table table-striped table-bordered">
         <thead>
-          <th>File name</th>
-          <th>Use</th>
-          <th>Uploaded</th>
+          <th><%= t('.file_name') %></th>
+          <th><%= t('.use') %></th>
+          <th><%= t('.uploaded') %></th>
         </thead>
         <tbody>
-          <%= render partial: 'file_details', locals: { use: "Preservation Master File", file: @pm } unless @pm.nil? %>
-          <%= render partial: 'file_details', locals: { use: "Service File", file: @sf } unless @sf.nil? %>
-          <%= render partial: 'file_details', locals: { use: "Intermediate File", file: @if } unless @if.nil? %>
-          <%= render partial: 'file_details', locals: { use: "Extracted", file: @et } unless @et.nil? %>
-          <%= render partial: 'file_details', locals: { use: "Transcript File", file: @tf } unless @tf.nil? %>
+          <%= render partial: 'file_details', locals: { use: t('.preservation_master_file'), file: @pm } unless @pm.nil? %>
+          <%= render partial: 'file_details', locals: { use: t('.service_file'), file: @sf } unless @sf.nil? %>
+          <%= render partial: 'file_details', locals: { use: t('.intermediate_file'), file: @if } unless @if.nil? %>
+          <%= render partial: 'file_details', locals: { use: t('.extracted'), file: @et } unless @et.nil? %>
+          <%= render partial: 'file_details', locals: { use: t('.transcript_file'), file: @tf } unless @tf.nil? %>
         </tbody>
       </table>
     </div><!-- /columns second -->

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -258,6 +258,23 @@ en:
     file_sets:
       form:
         pcdm_use: "FileSet use"
+      show: 
+        activity: 'Activity'
+        extracted: 'Extracted'
+        file_name: 'File name'
+        file_set_category: 'FileSet Category'
+        file_set_id: 'FileSet ID'
+        fixity_check: 'Run Fixity check'
+        is_part_of: 'Is Part of'
+        intermediate_file: 'Intermediate File'
+        parent_work: 'Parent Work'
+        preservation_master_file: 'Preservation Master File'
+        recharacterize: 'Re-characterize FileSet'
+        regenerate_derivative: 'Regenerate derivative'
+        service_file: 'Service File'
+        transcript_file: 'Transcript File'
+        uploaded: 'Uploaded'
+        use: 'Use'
       show_details:
         file_details: "Preservation Master File Details"
         activity: "Activity"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,5 +67,7 @@ Rails.application.routes.draw do
   get "/uv/config/:id", to: "application#uv_config", as: "uv_config", defaults: { format: :json }
 
   post "/concern/file_sets/:file_set_id/clean_up", to: "derivatives#clean_up"
+  post '/concern/file_sets/:file_set_id/re_characterize', to: 'characterization#re_characterize', as: 'file_set_re_characterization'
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/controllers/characterization_controller_spec.rb
+++ b/spec/controllers/characterization_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CharacterizationController, type: :controller, clean: true do
       end
 
       it 'queues up characterize job' do
-        expect(CharacterizeJob).to receive(:perform_later).with(file_set, nil, nil, user: user.uid)
+        expect(ReCharacterizeJob).to receive(:perform_later).with(file_set: file_set, user: user)
         post :re_characterize, params: { file_set_id: file_set.id }, xhr: true
         expect(response).to be_success
       end

--- a/spec/controllers/characterization_controller_spec.rb
+++ b/spec/controllers/characterization_controller_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CharacterizationController, type: :controller, clean: true do
+  let(:user) { FactoryBot.create(:user) }
+  let(:file_set) { FactoryBot.create(:file_set, user: user) }
+
+  context 'when signed in' do
+    describe 'POST re_characterize' do
+      before do
+        sign_in user
+      end
+
+      it 'queues up characterize job' do
+        expect(CharacterizeJob).to receive(:perform_later).with(file_set, nil, nil, user: user.uid)
+        post :re_characterize, params: { file_set_id: file_set.id }, xhr: true
+        expect(response).to be_success
+      end
+    end
+  end
+
+  context 'when not signed in' do
+    describe 'POST re_characterize' do
+      it 'returns 401' do
+        post :re_characterize, params: { file_set_id: file_set.id }, xhr: true
+        expect(response.code).to eq '401'
+      end
+    end
+  end
+end

--- a/spec/controllers/characterization_controller_spec.rb
+++ b/spec/controllers/characterization_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CharacterizationController, type: :controller, clean: true do
       end
 
       it 'queues up characterize job' do
-        expect(ReCharacterizeJob).to receive(:perform_later).with(file_set: file_set, user: user)
+        expect(ReCharacterizeJob).to receive(:perform_later).with(file_set: file_set, user: user.uid)
         post :re_characterize, params: { file_set_id: file_set.id }, xhr: true
         expect(response).to be_success
       end

--- a/spec/jobs/re_characterize_job_spec.rb
+++ b/spec/jobs/re_characterize_job_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ReCharacterizeJob, :clean do
+  let(:file_set_id) { 'abc12345' }
+  let(:filename)    { Rails.root.join('tmp', 'uploads', 'ab', 'c1', '23', '45', 'abc12345', 'picture.png').to_s }
+  let(:file_set) do
+    FileSet.new(id: file_set_id).tap do |fs|
+      allow(fs).to receive(:preservation_master_file).and_return(file)
+      allow(fs).to receive(:update_index)
+    end
+  end
+
+  let(:file) do
+    Hydra::PCDM::File.new.tap do |f|
+      f.content = 'foo'
+      f.original_name = 'picture.png'
+      f.save!
+      allow(f).to receive(:save!)
+    end
+  end
+
+  before do
+    allow(FileSet).to receive(:find).with(file_set_id).and_return(file_set)
+    allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+    CharacterizeJob.perform_now(file_set, file.id)
+  end
+
+  context '#characterization_setters' do
+    it 'returns the right keys' do
+      expect(described_class.characterization_setters(file)).to eq([])
+    end
+  end
+end

--- a/spec/jobs/re_characterize_job_spec.rb
+++ b/spec/jobs/re_characterize_job_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe ReCharacterizeJob, :clean do
 
   context '#characterization_setters' do
     it 'returns the right keys' do
-      expect(described_class.characterization_setters(file)).to eq([])
+      expect(ReCharacterizationService).to receive(:empty_out_characterization)
+      expect(CharacterizeJob).to receive(:perform_later)
+      described_class.perform_now(file_set: file_set)
     end
   end
 end

--- a/spec/presenters/hyrax/admin_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_presenter_spec.rb
@@ -2,7 +2,7 @@
 # [Hyrax-overwrite-v3.0.0.pre.rc1]
 require 'rails_helper'
 
-RSpec.describe Hyrax::AdminSetPresenter do
+RSpec.describe Hyrax::AdminSetPresenter, :clean do
   let(:admin_set) do
     mock_model(AdminSet,
                id:          '123',

--- a/spec/services/re_characterization_service_spec.rb
+++ b/spec/services/re_characterization_service_spec.rb
@@ -22,7 +22,7 @@ describe ReCharacterizationService, :clean do
     it 'works' do
       expect(values.size).to be > 1
       service.empty_characterization
-      new_values = fields.map { |f| file.send(f)&.first}.compact
+      new_values = fields.map { |f| file.send(f)&.first }.compact
       expect(new_values).to be_empty
     end
   end

--- a/spec/services/re_characterization_service_spec.rb
+++ b/spec/services/re_characterization_service_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'support/file_set_helper'
+
+describe ReCharacterizationService, :clean do
+  let(:filename)     { 'sample-file.pdf' }
+  let(:path_on_disk) { File.join(fixture_path, filename) }
+  let(:file)         { Hydra::PCDM::File.new }
+
+  before do
+    skip 'external tools not installed for CI environment' if ENV['CI']
+    Hydra::Works::CharacterizationService.run(file, path_on_disk)
+    file.content = "junk"
+    file.save
+  end
+
+  describe "#empty_characterization" do
+    let(:service) { described_class.new(file) }
+    let(:fields) { service.send(:characterization_setters) }
+    let(:values) { fields.map { |f| file.send(f)&.first }.compact }
+
+    it 'works' do
+      expect(values.size).to be > 1
+      service.empty_characterization
+      new_values = fields.map { |f| file.send(f)&.first}.compact
+      expect(new_values).to be_empty
+    end
+  end
+end

--- a/spec/system/show_file_spec.rb
+++ b/spec/system/show_file_spec.rb
@@ -171,4 +171,15 @@ RSpec.describe "Showing a file:", integration: true, clean: true, type: :system 
       expect(page).not_to have_link(title: "Tumblr", exact: true)
     end
   end
+
+  context 'Re-characterize FileSet' do
+    it 'has a link to re-characterize the fileset' do
+      visit hyrax_file_set_path(file_set)
+      form = page.find("form[action='/concern/file_sets/#{file_set.id}/re_characterize']")
+
+      within form do
+        page.find("input[value='Re-characterize FileSet']")
+      end
+    end
+  end
 end


### PR DESCRIPTION
- .rubocop.yml: skips `characterize_job` file for rubocop failure when adding new argument.
- app/controllers/characterization_controller.rb: creates new action that starts a re-characterization by pressing a button on the file_set show page. Please note, I understand the preference that the action be associated with the closest relative controller, but attempting to do so produced errors that I couldn't find a quick fix for, so I left this action separate.
- app/jobs/characterize_job.rb: adds `user` argument in case of the Characterization taking place from a controller action.
- app/jobs/re_characterize_job.rb: institutes an individual job for the re-characterization of the preservation_master_file.
- app/services/re_characterization_service.rb: brought processing over to a service class for ease of testing.
- app/views/hyrax/file_sets/show.html.erb: inserts the button mentioned above as well as refactoring the text into localizations.
- config/locales/hyrax.en.yml: adds in the text from the FileSet show page into this locale file.
- config/routes.rb: initiates new route to Characterization action.
- spec/presenters/hyrax/admin_set_presenter_spec.rb: addresses, what seems to be, a flaky error that is cleared up by cleaning out Fedora after every test.
- spec/*: creates new tests for the above actions.