### PR TITLE
Adds source collection details to work show page

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -157,4 +157,8 @@ class SolrDocument
   def human_readable_visibility
     self['human_readable_visibility_ssi']
   end
+
+  def source_collection_title
+    self['source_collection_title_ssim']
+  end
 end

--- a/app/presenters/hyrax/curate_generic_work_presenter.rb
+++ b/app/presenters/hyrax/curate_generic_work_presenter.rb
@@ -7,7 +7,7 @@ module Hyrax
     CurateGenericWorkAttributes.instance.attributes.each do |key|
       delegate key.to_sym, to: :solr_document
     end
-    delegate :failed_preservation_events, to: :solr_document
+    delegate :failed_preservation_events, :source_collection_title, to: :solr_document
 
     include CuratePurl
 

--- a/app/views/hyrax/base/_relationships_parent_rows.html.erb
+++ b/app/views/hyrax/base/_relationships_parent_rows.html.erb
@@ -13,3 +13,14 @@
     <%= render 'relationships_parent_row', type: type, items: items, presenter: presenter %>
   <% end %>
 <% end %>
+
+<% if presenter.source_collection_id %>
+  <% unless presenter.member_of_collection_ids.first == presenter.source_collection_id.first %>
+    <dt>Source Collection:</dt>
+    <dd>
+      <ul class="tabular">
+        <li><%= link_to presenter.source_collection_title.first, collection_path(presenter.source_collection_id.first) %></li>
+      </ul>
+    </dd>
+  <% end %>
+<% end %>

--- a/spec/system/viewing_a_work_spec.rb
+++ b/spec/system/viewing_a_work_spec.rb
@@ -352,4 +352,29 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
       end
     end
   end
+
+  describe 'object relations' do
+    context 'when source collection is present' do
+      let(:work) { FactoryBot.create(:public_generic_work) }
+      let(:collection) { FactoryBot.create(:collection_lw, title: ['Collection test']) }
+      before do
+        work.source_collection_id = collection.id
+        work.save!
+      end
+
+      it 'shows source collection under relations section' do
+        visit(work_url)
+
+        expect(page).to have_link('Collection test')
+      end
+    end
+
+    context 'when source collection is absent' do
+      it 'does not show source collection details' do
+        visit(work_url)
+
+        expect(page).not_to have_link('Collection test')
+      end
+    end
+  end
 end


### PR DESCRIPTION
**app/models/solr_document.rb**: Adds raw solr field to `source_collection_title` method
**app/presenters/hyrax/curate_generic_work_presenter.rb**: adds delegation for `source_collection_title`
**app/views/hyrax/base/_relationships_parent_rows.html.erb**: Show source collection if it exists and if it is different from deposit collection
**spec/system/viewing_a_work_spec.rb**: spec to test display when source collection is present and absent


Output:
![image](https://user-images.githubusercontent.com/17075287/90561584-eaca4c80-e16e-11ea-962f-b9e889368dda.png)
