### PR TITLE
Removes the Single-Use Links section from FileSet show page (#1414).

### DIFF
--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -8,7 +8,6 @@
       <div><%= button_to 'Run Fixity check', file_set_fixity_checks_path(file_set_id: @presenter.id), method: :post, class: 'btn btn-primary' %></div>
       <br>
       <div><%= button_to 'Regenerate derivative', "/concern/file_sets/#{@presenter.id}/clean_up", class: 'btn btn-primary' %></div>
-      <%= render 'single_use_links', presenter: @presenter if @presenter.editor? %>
     </div>
     <div itemscope itemtype="<%= @presenter.itemtype %>" class="col-xs-12 col-sm-8">
       <header>

--- a/spec/system/show_file_spec.rb
+++ b/spec/system/show_file_spec.rb
@@ -84,6 +84,12 @@ RSpec.describe "Showing a file:", integration: true, clean: true, type: :system 
       expect(first('#file_download').text).to eq('Download Preservation Master File')
     end
 
+    it 'does not show Single-Use Links section' do
+      expect(page).not_to have_content('Single-Use Links')
+      expect(page).not_to have_css('table.table.table-striped.table-condensed.file_set.single-use-links')
+      expect(page).not_to have_link('Create Single-Use Link')
+    end
+
     context 'within the preservation events block' do
       it 'shows the right header' do
         expect(page).to have_content('Preservation Events')


### PR DESCRIPTION
- app/views/hyrax/file_sets/show.html.erb: deletes `single_use_links` render call.
- spec/system/show_file_spec.rb: tests that Single-Use HTML doesn't appear.