### PR TITLE
Adds relationship metadata fields to Collection model

### DIFF
--- a/app/indexers/curate_collection_indexer.rb
+++ b/app/indexers/curate_collection_indexer.rb
@@ -12,6 +12,8 @@ class CurateCollectionIndexer < Hyrax::CollectionIndexer
       solr_doc['creator_ssort'] = object.creator.first
       solr_doc['generic_type_sim'] = ["Collection"]
       solr_doc['banner_path_ss'] = banner_path
+      solr_doc['source_collection_title_ssim'] = source_collection
+      solr_doc['deposit_collection_title_ssim'] = deposit_collection
     end
   end
 
@@ -32,5 +34,15 @@ class CurateCollectionIndexer < Hyrax::CollectionIndexer
   def path_sanitized(path)
     return '/branding' + path.split('/branding').last if path&.include? '/branding'
     path
+  end
+
+  def source_collection
+    collection = Collection.find(object.source_collection_id) if object.source_collection_id
+    return collection.title unless collection.nil?
+  end
+
+  def deposit_collection
+    collection = Collection.find(object.deposit_collection_id) if object.deposit_collection_id
+    return collection.title unless collection.nil?
   end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -38,6 +38,10 @@ class Collection < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
+  property :deposit_collection_id, predicate: "http://metadata.emory.edu/vocab/cor-terms#depositCollectionID", multiple: false do |index|
+    index.as :stored_searchable
+  end
+
   property :emory_ark, predicate: 'http://id.loc.gov/vocabulary/identifiers/local#ark' do |index|
     index.as :stored_searchable
   end
@@ -81,6 +85,10 @@ class Collection < ActiveFedora::Base
   property :rights_documentation, predicate: 'http://metadata.emory.edu/vocab/cor-terms#rightsDocumentationURI', multiple: false
 
   property :sensitive_material, predicate: 'http://metadata.emory.edu/vocab/cor-terms#sensitiveMaterial', multiple: false do |index|
+    index.as :stored_searchable
+  end
+
+  property :source_collection_id, predicate: "http://metadata.emory.edu/vocab/cor-terms#sourceCollectionID", multiple: false do |index|
     index.as :stored_searchable
   end
 

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -6,4 +6,4 @@ download_dir: /var/tmp
 collection:
     persist: false
     dir: solr/config
-    name: hydra-test
+    name: hydratest2

--- a/spec/indexers/collection_indexer_spec.rb
+++ b/spec/indexers/collection_indexer_spec.rb
@@ -6,6 +6,74 @@ RSpec.describe CurateCollectionIndexer do
   let(:collection) { Collection.new(attributes) }
   let(:indexer) { described_class.new(collection) }
 
+  describe 'save source_collection on collection' do
+    context 'when source_collection_id is empty' do
+      let(:attributes) do
+        {
+          id:    '123',
+          title: ['A title']
+        }
+      end
+
+      it 'returns empty array' do
+        expect(solr_document['source_collection_id_tesim']).to eq(nil)
+      end
+    end
+
+    context 'when source_collection_id is present' do
+      let(:collection_new) { FactoryBot.create(:collection_lw, id: 'abc123', title: ['Test title collection123']) }
+      let(:attributes) do
+        {
+          id:                   '123',
+          title:                ['A title'],
+          source_collection_id: 'abc123'
+        }
+      end
+
+      before do
+        allow(Collection).to receive(:create).and_return(collection_new)
+      end
+
+      it 'returns correct source collection title' do
+        expect(solr_document['source_collection_title_ssim']).to eq(['Test title collection123'])
+      end
+    end
+  end
+
+  describe 'save deposit_collection' do
+    context 'when source_collection_id is empty' do
+      let(:attributes) do
+        {
+          id:    '123',
+          title: ['A title']
+        }
+      end
+
+      it 'returns empty array' do
+        expect(solr_document['deposit_collection_id_tesim']).to eq(nil)
+      end
+    end
+
+    context 'when deposit_collection_id is present' do
+      let(:collection_new) { FactoryBot.create(:collection_lw, id: 'abc123', title: ['Test title collection123']) }
+      let(:attributes) do
+        {
+          id:                    '123',
+          title:                 ['A title'],
+          deposit_collection_id: 'abc123'
+        }
+      end
+
+      before do
+        allow(Collection).to receive(:create).and_return(collection_new)
+      end
+
+      it 'returns correct deposit collection title' do
+        expect(solr_document['deposit_collection_title_ssim']).to eq(['Test title collection123'])
+      end
+    end
+  end
+
   describe 'sort fields' do
     let(:attributes) do
       {

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -442,6 +442,24 @@ RSpec.describe Collection, clean: true do
     end
   end
 
+  describe "#source_collection_id" do
+    subject { described_class.new }
+    let(:source_collection_id) { '123abc' }
+
+    context "with new Collection" do
+      its(:source_collection_id) { is_expected.to be_falsey }
+    end
+
+    context "with a Collection that has a source_collection_id" do
+      subject do
+        described_class.create.tap do |collection|
+          collection.source_collection_id = source_collection_id
+        end
+      end
+      its(:source_collection_id) { is_expected.to eq source_collection_id }
+    end
+  end
+
   describe "#members_objects", clean_repo: true do
     let(:collection) { FactoryBot.create(:collection_lw) }
 


### PR DESCRIPTION
In order to relate a source collection to its deposit collections (see wireframe showing a Source Collection showing a link to its Deposit Collection) we anticipate needing one or two metadata fields at the Collection level:

These would follow the same pattern as established for work-level equivalents for SOLR and Fedora.

source_collection_id
http://metadata.emory.edu/vocab/cor-terms#sourceCollectionID

deposit_collection_id
http://metadata.emory.edu/vocab/cor-terms#depositCollectionID