### PR TITLE
Changes total_viewable_items to not care about viewability (#1405).

### DIFF
--- a/app/presenters/hyrax/admin_set_presenter.rb
+++ b/app/presenters/hyrax/admin_set_presenter.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# [Hyrax-overwrite-v3.0.0.pre.rc1]
+# Changes behavior of total_viewable_items to match total_items
+
+module Hyrax
+  class AdminSetPresenter < CollectionPresenter
+    ##
+    # @return [Boolean] true if there are items
+    def any_items?
+      total_items.positive?
+    end
+
+    def total_items
+      Hyrax::SolrService.count("{!field f=isPartOf_ssim}#{id}")
+    end
+
+    def total_viewable_items
+      total_items
+    end
+
+    # AdminSet cannot be deleted if default set or non-empty
+    def disable_delete?
+      AdminSet.default_set?(id) || any_items?
+    end
+
+    # Message to display if deletion is disabled
+    def disabled_message
+      return I18n.t('hyrax.admin.admin_sets.delete.error_default_set') if AdminSet.default_set?(id)
+
+      I18n.t('hyrax.admin.admin_sets.delete.error_not_empty') if any_items?
+    end
+
+    def collection_type
+      @collection_type ||= Hyrax::CollectionType.find_or_create_admin_set_type
+    end
+
+    def show_path
+      Hyrax::Engine.routes.url_helpers.admin_admin_set_path(id, locale: I18n.locale)
+    end
+
+    def available_parent_collections(*)
+      []
+    end
+
+    # For the Managed Collections tab, determine the label to use for the level of access the user has for this admin set.
+    # Checks from most permissive to most restrictive.
+    # @return String the access label (e.g. Manage, Deposit, View)
+    def managed_access
+      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.manage') if current_ability.can?(:edit, solr_document)
+      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.deposit') if current_ability.can?(:deposit, solr_document)
+      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.view') if current_ability.can?(:read, solr_document)
+      ''
+    end
+
+    # Determine if the user can perform batch operations on this admin set.  Currently, the only
+    # batch operation allowed is deleting, so this is equivalent to checking if the user can delete
+    # the admin set determined by criteria...
+    # * user must be able to edit the admin set to be able to delete it
+    # * the admin set itself must be able to be deleted (i.e., there cannot be any works in the admin set)
+    # @return Boolean true if the user can perform batch actions; otherwise, false
+    def allow_batch?
+      return false unless current_ability.can?(:edit, solr_document)
+      !disable_delete?
+    end
+  end
+end

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -211,10 +211,7 @@ module Hyrax
     # Checks from most permissive to most restrictive.
     # @return String the access label (e.g. Manage, Deposit, View)
     def managed_access
-      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.manage') if current_ability.can?(:edit, solr_document)
-      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.deposit') if current_ability.can?(:deposit, solr_document)
-      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.view') if current_ability.can?(:read, solr_document)
-      ''
+      Hyrax::AdminSetPresenter.managed_access
     end
 
     # Determine if the user can perform batch operations on this collection.  Currently, the only

--- a/spec/factories/admin_sets.rb
+++ b/spec/factories/admin_sets.rb
@@ -1,0 +1,25 @@
+FactoryBot.define do
+  factory :admin_set do
+    sequence(:title) { |n| ["Title #{n}"] }
+
+    # Given the relationship between permission template and admin set, when
+    # an admin set is created via a factory, I believe it is appropriate to go ahead and
+    # create the corresponding permission template
+    #
+    # This way, we can go ahead
+    after(:create) do |admin_set, evaluator|
+      if evaluator.with_permission_template
+        attributes = { source_id: admin_set.id }
+        attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
+        # There is a unique constraint on permission_templates.source_id; I don't want to
+        # create a permission template if one already exists for this admin_set
+        create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: admin_set.id)
+      end
+    end
+
+    transient do
+      # false, true, or Hash with keys for permission_template
+      with_permission_template { false }
+    end
+  end
+end

--- a/spec/factories/admin_sets.rb
+++ b/spec/factories/admin_sets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :admin_set do
     sequence(:title) { |n| ["Title #{n}"] }

--- a/spec/presenters/hyrax/admin_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_presenter_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+# [Hyrax-overwrite-v3.0.0.pre.rc1]
+require 'rails_helper'
+
+RSpec.describe Hyrax::AdminSetPresenter do
+  let(:admin_set) do
+    mock_model(AdminSet,
+               id: '123',
+               description: ['An example admin set.'],
+               title: ['Example Admin Set Title'])
+  end
+
+  let(:work) { FactoryBot.build(:work, title: ['Example Work Title']) }
+  let(:solr_document) { SolrDocument.new(admin_set.to_solr) }
+  let(:ability) { double }
+  let(:presenter) { described_class.new(solr_document, ability) }
+
+  describe "total_items" do
+    subject { presenter.total_items }
+
+    let(:admin_set) { FactoryBot.build(:admin_set) }
+
+    context "empty admin set" do
+      it { is_expected.to eq 0 }
+    end
+
+    context "admin set with work" do
+      let(:admin_set) { FactoryBot.create(:admin_set, members: [work]) }
+
+      it { is_expected.to eq 1 }
+    end
+  end
+
+  describe "disable_delete?" do
+    subject { presenter.disable_delete? }
+
+    context "empty admin set" do
+      let(:admin_set) { FactoryBot.create(:admin_set) }
+
+      it { is_expected.to be false }
+    end
+
+    context "non-empty admin set" do
+      let(:admin_set) { FactoryBot.create(:admin_set, members: [work]) }
+
+      it { is_expected.to be true }
+    end
+
+    context "default admin set" do
+      let(:admin_set) do
+        FactoryBot.build(:admin_set, id: AdminSet::DEFAULT_ID)
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#collection_type' do
+    let(:admin_set) do
+      FactoryBot.build(:admin_set, id: AdminSet::DEFAULT_ID)
+    end
+
+    subject { presenter.collection_type }
+
+    it { is_expected.to eq(FactoryBot.create(:admin_set_collection_type)) }
+  end
+
+  describe '#show_path' do
+    let(:admin_set) do
+      FactoryBot.build(:admin_set, id: 'sb397824g')
+    end
+
+    subject { presenter.show_path }
+
+    it { is_expected.to eq "/admin/admin_sets/#{admin_set.id}?locale=en" }
+  end
+
+  describe '#managed_access' do
+    let(:admin_set) { FactoryBot.create(:admin_set, members: [work]) }
+
+    context 'when manager' do
+      before do
+        allow(ability).to receive(:can?).with(:edit, solr_document).and_return(true)
+      end
+      it 'returns Manage label' do
+        expect(presenter.managed_access).to eq 'Manage'
+      end
+    end
+
+    context 'when depositor' do
+      before do
+        allow(ability).to receive(:can?).with(:edit, solr_document).and_return(false)
+        allow(ability).to receive(:can?).with(:deposit, solr_document).and_return(true)
+      end
+      it 'returns Deposit label' do
+        expect(presenter.managed_access).to eq 'Deposit'
+      end
+    end
+
+    context 'when viewer' do
+      before do
+        allow(ability).to receive(:can?).with(:edit, solr_document).and_return(false)
+        allow(ability).to receive(:can?).with(:deposit, solr_document).and_return(false)
+        allow(ability).to receive(:can?).with(:read, solr_document).and_return(true)
+      end
+      it 'returns View label' do
+        expect(presenter.managed_access).to eq 'View'
+      end
+    end
+  end
+
+  describe '#allow_batch?' do
+    let(:admin_set) { FactoryBot.create(:admin_set, members: [work]) }
+
+    context 'when user cannot edit' do
+      before do
+        allow(ability).to receive(:can?).with(:edit, solr_document).and_return(false)
+      end
+
+      it 'returns false' do
+        expect(presenter.allow_batch?).to be false
+      end
+    end
+
+    context 'when user can edit' do
+      before do
+        allow(ability).to receive(:can?).with(:edit, solr_document).and_return(true)
+      end
+
+      context 'and there are works in the admin set' do
+        it 'returns false' do
+          expect(presenter.allow_batch?).to be false
+        end
+      end
+
+      context 'and there are no works in the admin set' do
+        before do
+          allow(presenter).to receive(:total_items).and_return(0)
+        end
+
+        it 'returns true' do
+          expect(presenter.allow_batch?).to be true
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/hyrax/admin_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_presenter_spec.rb
@@ -5,9 +5,9 @@ require 'rails_helper'
 RSpec.describe Hyrax::AdminSetPresenter do
   let(:admin_set) do
     mock_model(AdminSet,
-               id: '123',
+               id:          '123',
                description: ['An example admin set.'],
-               title: ['Example Admin Set Title'])
+               title:       ['Example Admin Set Title'])
   end
 
   let(:work) { FactoryBot.build(:work, title: ['Example Work Title']) }
@@ -56,21 +56,19 @@ RSpec.describe Hyrax::AdminSetPresenter do
   end
 
   describe '#collection_type' do
+    subject { presenter.collection_type }
     let(:admin_set) do
       FactoryBot.build(:admin_set, id: AdminSet::DEFAULT_ID)
     end
-
-    subject { presenter.collection_type }
 
     it { is_expected.to eq(FactoryBot.create(:admin_set_collection_type)) }
   end
 
   describe '#show_path' do
+    subject { presenter.show_path }
     let(:admin_set) do
       FactoryBot.build(:admin_set, id: 'sb397824g')
     end
-
-    subject { presenter.show_path }
 
     it { is_expected.to eq "/admin/admin_sets/#{admin_set.id}?locale=en" }
   end


### PR DESCRIPTION
app/presenters/hyrax/admin_set_presenter.rb: brings in Hyrax code for override. Changes the `total_viewable_items` scope to `total_items`. Would have imported the `spec` file as well, but the file didn't test this method.