### PR TITLE
Adds source collection dropdown facet

### DIFF
--- a/config/initializers/works_controller.rb
+++ b/config/initializers/works_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# [Hyrax-overwrite-v3.0.0.pre.rc1] Adds source collection search facet to works page
+Hyrax::My::WorksController.class_eval do
+  # Define collection specific filter facets.
+  def self.configure_facets
+    configure_blacklight do |config|
+      config.add_facet_field "source_collection_title_ssim", limit: 5, label: 'Source Collection'
+    end
+  end
+  configure_facets
+end

--- a/spec/system/viewing_a_work_spec.rb
+++ b/spec/system/viewing_a_work_spec.rb
@@ -391,4 +391,32 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
       end
     end
   end
+
+  describe 'viewing works using source collection facet' do
+    context 'when source collection is present' do
+      let(:work) { FactoryBot.create(:public_generic_work, title: ['SC test work']) }
+      let(:work2) { FactoryBot.create(:public_generic_work, title: ['SC test work2']) }
+      let(:collection) { FactoryBot.create(:collection_lw, title: ['Collection test']) }
+      before do
+        work.source_collection_id = collection.id
+        work.save!
+      end
+
+      it 'shows source collection in its dropdown facet' do
+        visit("/dashboard/works")
+        expect(page).to have_content(collection.title.first)
+        click_link(collection.title.first)
+        expect(page).to have_content('SC test work') # make sure work with source collection shows up in search result
+        expect(page).not_to have_content('SC test work 2') # make sure work without source collection does not show up in search result
+      end
+    end
+
+    context 'when source collection is absent' do
+      it 'does not show source collection details' do
+        visit("/dashboard/works")
+
+        expect(page).not_to have_content('Source Collection') # make sure dropdown is not present
+      end
+    end
+  end
 end


### PR DESCRIPTION
Connected to: #1406 
* We are adding a new dropdown facet to the works dashboard index page. This dropdown will be used to search by source collections.

* **config/initializers/works_controller.rb**: Opens up `works_controller` and appends to the `configure_facets` method.
* **spec**: Tests to make sure dropdown is present and absent in different scenarios.

Output:
![image](https://user-images.githubusercontent.com/17075287/91224394-0d6ce000-e6f0-11ea-8369-207a8a3577cb.png)
