### PR TITLE
Partializes the Source Collection links in Collection show pages (#1390).

### DIFF
--- a/app/helpers/collection_show_helper.rb
+++ b/app/helpers/collection_show_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CollectionShowHelper
+  def source_collection_link(value_hsh, request_url)
+    if request_url.include? "dashboard"
+      tag.a value_hsh[:title], href: "/dashboard/collections/#{value_hsh[:id]}"
+    else
+      tag.a value_hsh[:title], href: "/collections/#{value_hsh[:id]}"
+    end
+  end
+end

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -229,8 +229,8 @@ module Hyrax
       source_coll_id.present? && source_coll_id[0] != id
     end
 
-    def deposit_collection_link
-      tag.a solr_document['source_collection_title_ssim'][0], href: "/collections/#{source_coll_id[0]}"
+    def deposit_collection_object
+      { title: solr_document['source_collection_title_ssim'][0], id: source_coll_id[0] }
     end
 
     def source_coll_id

--- a/app/views/hyrax/collections/_source_collection.html.erb
+++ b/app/views/hyrax/collections/_source_collection.html.erb
@@ -1,0 +1,8 @@
+<% if presenter.deposit_collection? %>
+  <div class="hyc-blacklight hyc-bl-title">
+    <h4><%= t('hyrax.collections.show.source_collection') %></h4>
+  </div>
+  <div class="hyc-blacklight hyc-bl-source-link">
+    <%= source_collection_link(presenter.deposit_collection_object, request_url) %>
+  </div>
+<% end %>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -96,15 +96,7 @@
   </div>
 
   <!-- Source Collection -->
-  <% if @presenter.deposit_collection? %>
-    <div class="hyc-blacklight hyc-bl-title">
-      <h4><%= t('.source_collection') %></h4>
-    </div>
-    <div class="hyc-blacklight hyc-bl-source-link">
-      <%= @presenter.deposit_collection_link %>
-    </div>
-  <% end %>
-
+  <%= render 'source_collection', presenter: @presenter, request_url: request.url %>
 
   <!-- Subcollections -->
   <% if @presenter.collection_type_is_nestable? && @subcollection_count > 0 %>

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -1,0 +1,112 @@
+<% # [Hyrax-overwrite-v3.0.0.pre.rc1] Inserts source collection link L#64 %>
+<% provide :page_title, construct_page_title(@presenter.title) %>
+
+<% provide :page_header do %>
+  <h1><span class="fa fa-file" aria-hidden="true"></span> <%= t('.header') %></h1>
+<% end %>
+
+<div class="collections-wrapper">
+  <section class="panel panel-default collections-panel-wrapper admin-show-page">
+    <div class="panel-heading">
+      <%= render 'collection_title', presenter: @presenter %>
+    </div>
+
+    <div class="panel-body">
+      <section>
+        <div itemscope itemtype="http://schema.org/CollectionPage" class="row collection">
+          <div class="col-sm-3 text-center">
+              <%= render 'hyrax/collections/media_display', presenter: @presenter %>
+              <%= link_to t('.public_view_label'), collection_path(id: @presenter.id) %>
+          </div>
+          <div class="col-sm-9 collection-description-wrapper">
+            <!-- Parent Collection(s) -->
+            <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
+                <h4><%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)</h4>
+                <section id="parent-collections-wrapper" class="parent-collections-wrapper">
+                  <%= render 'hyrax/dashboard/collections/show_parent_collections', presenter: @presenter %>
+                </section>
+            <% end %>
+
+            <!-- Collection Description(s) -->
+            <section>
+              <%= render 'hyrax/collections/collection_description', presenter: @presenter %>
+            </section>
+
+            <% unless has_collection_search_parameters? %>
+              <%= render 'show_descriptions' %>
+            <% end %>
+          </div>
+        </div>
+      </section>
+
+      <!-- Search results label -->
+
+      <% if @members_count > 0 || @presenter.subcollection_count > 0 %>
+          <div class="hyc-blacklight hyc-bl-title">
+            <h2>
+              <% if has_collection_search_parameters? %>
+                  <%= t('hyrax.dashboard.collections.show.search_results') %>
+              <% end %>
+            </h2>
+          </div>
+      <% end %>
+
+      <!-- Search bar -->
+      <section class="collections-search-wrapper">
+        <div class="row">
+          <div class="col-sm-8">
+            <%# TODO: leaving this as it was causes rerouting to the public show page. needs work %>
+            <%= render 'hyrax/collections/search_form', presenter: @presenter, url: hyrax.dashboard_collection_path(@presenter.id) %>
+          </div>
+        </div>
+      </section>
+
+      <!-- Source Collection -->
+      <section class="collections-source-collection-wrapper">
+        <div class="row">
+          <%= render 'hyrax/collections/source_collection', presenter: @presenter, request_url: request.url %>
+        </div>
+      </section>
+
+      <!-- Subcollections -->
+      <% if @presenter.collection_type_is_nestable? %>
+        <section id="sub-collections-wrapper" class="sub-collections-wrapper">
+          <h4><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h4>
+          <div class="row">
+            <div class="col-md-7">
+              <%= render 'subcollection_list', id: @presenter.id, collection: @subcollection_docs %>
+            </div>
+            <% unless has_collection_search_parameters? %>
+              <div class="col-md-5">
+                <%= render 'show_subcollection_actions', presenter: @presenter %>
+              </div>
+            <% end %>
+          </div>
+        </section>
+      <% end %>
+
+      <!-- Works -->
+      <section class="works-wrapper">
+        <h4><%= t('.item_count') %> (<%= @members_count %>)</h4>
+        <% unless has_collection_search_parameters? %>
+          <%= render 'show_add_items_actions', presenter: @presenter %>
+        <% end %>
+
+        <%= render 'sort_and_per_page', collection: @presenter %>
+        <%= render_document_index @member_docs %>
+        <%= render 'hyrax/collections/paginate' %>
+      </section>
+
+    </div><!-- /panel-body -->
+  </section><!-- /collections-panel-wrapper -->
+</div><!-- /collections-wrapper -->
+
+<% if @presenter.collection_type_is_nestable? && !has_collection_search_parameters? %>
+  <%= render 'hyrax/my/collections/modal_add_to_collection', source: 'show' %>
+  <%= render 'hyrax/my/collections/modal_add_subcollection', id: @presenter.id, source: 'show' %>
+  <%= render 'hyrax/dashboard/collections/modal_parent_collection_remove_deny', source: 'show' %>
+<% end %>
+
+<% unless has_collection_search_parameters? %>
+  <%= render '/shared/select_work_type_modal', create_work_presenter: @presenter.create_work_presenter if @presenter.draw_select_work_modal? %>
+<% end %>

--- a/spec/presenters/collection_presenter_spec.rb
+++ b/spec/presenters/collection_presenter_spec.rb
@@ -73,12 +73,12 @@ RSpec.describe Hyrax::CollectionPresenter, :clean do
       end
     end
 
-    context '#deposit_collection_link' do
-      it 'provides link built from 2 solr_doc fields' do
+    context '#deposit_collection_object' do
+      it 'provides hash built from 2 solr_doc fields' do
         solr_doc = SolrDocument.new(deposit_collection.to_solr)
         deposit_presenter = described_class.new(solr_doc, ability)
 
-        expect(deposit_presenter.deposit_collection_link).to eq "<a href=\"/collections/#{collection.id}\">Testing Collection</a>"
+        expect(deposit_presenter.deposit_collection_object).to eq({ id: collection.id, title: "Testing Collection" })
       end
     end
   end

--- a/spec/system/viewing_a_collection_spec.rb
+++ b/spec/system/viewing_a_collection_spec.rb
@@ -105,17 +105,30 @@ RSpec.describe 'Viewing collections', type: :system, clean: true do
       end
 
       describe 'viewing deposit collection' do
-        it 'does have the Source Collection element' do
+        it 'does have the Source Collection element on public page' do
           visit "/collections/#{user_collection.id}"
 
           expect(page).to have_content "Source Collection"
           expect(page).to have_link(admin_collection.title[0], href: "/collections/#{admin_collection.id}")
         end
+
+        it 'does have the Source Collection element on dashboard page' do
+          visit "/dashboard/collections/#{user_collection.id}"
+
+          expect(page).to have_content "Source Collection"
+          expect(page).to have_link(admin_collection.title[0], href: "/dashboard/collections/#{admin_collection.id}")
+        end
       end
 
       describe 'viewing source collection' do
-        it 'does not have the Source Collection element' do
+        it 'does not have the Source Collection element on public page' do
           visit "/collections/#{admin_collection.id}"
+
+          expect(page).not_to have_content "Source Collection"
+        end
+
+        it 'does not have the Source Collection element on dashboard page' do
+          visit "/dashboard/collections/#{admin_collection.id}"
 
           expect(page).not_to have_content "Source Collection"
         end


### PR DESCRIPTION
- app/helpers/collection_show_helper.rb: reverts to a helper to create the link since additional logic to form appropriate destination was needed.
- app/presenters/hyrax/collection_presenter.rb: alters method so that it delivers a value hash, not a link.
- app/views/hyrax/collections/_source_collection.html.erb: instigates partial since this will show on two separate pages.
- app/views/hyrax/collections/show.html.erb: renders partial instead of html code.
- app/views/hyrax/dashboard/collections/show.html.erb: overrides the Hyrax show page so that source collection link can be included.
- spec/*: switches out expectations to accommodate more views and different method.