### PR TITLE
Ensures that multiple deposit collection titles are indexed properly (#1456).

### DIFF
--- a/app/indexers/curate_collection_indexer.rb
+++ b/app/indexers/curate_collection_indexer.rb
@@ -13,7 +13,7 @@ class CurateCollectionIndexer < Hyrax::CollectionIndexer
       solr_doc['generic_type_sim'] = ["Collection"]
       solr_doc['banner_path_ss'] = banner_path
       solr_doc['source_collection_title_ssim'] = source_collection
-      solr_doc['deposit_collection_titles_tesim'] = deposit_collection&.first
+      solr_doc['deposit_collection_titles_tesim'] = deposit_collection
     end
   end
 
@@ -42,6 +42,6 @@ class CurateCollectionIndexer < Hyrax::CollectionIndexer
   end
 
   def deposit_collection
-    object.deposit_collection_ids.map { |id| Collection.find(id).title } if object.deposit_collection_ids.present?
+    object.deposit_collection_ids.map { |id| Collection.find(id).title.first } if object.deposit_collection_ids.present?
   end
 end

--- a/spec/indexers/collection_indexer_spec.rb
+++ b/spec/indexers/collection_indexer_spec.rb
@@ -56,20 +56,23 @@ RSpec.describe CurateCollectionIndexer do
 
     context 'when deposit_collection_id is present' do
       let(:collection_new) { FactoryBot.create(:collection_lw, id: 'abc123', title: ['Test title collection123']) }
+      let(:collection_new_2) { FactoryBot.create(:collection_lw, id: 'def456', title: ['Test title collection456']) }
       let(:attributes) do
         {
           id:                     '123',
           title:                  ['A title'],
-          deposit_collection_ids: ['abc123']
+          deposit_collection_ids: ['abc123', 'def456']
         }
       end
 
       before do
-        allow(Collection).to receive(:create).and_return(collection_new)
+        allow(Collection).to receive(:create).and_return(collection_new, collection_new_2)
       end
 
       it 'returns correct deposit collection title' do
-        expect(solr_document['deposit_collection_titles_tesim']).to eq(['Test title collection123'])
+        expect(solr_document['deposit_collection_titles_tesim']).to match_array(
+          ["Test title collection123", "Test title collection456"]
+        )
       end
     end
   end


### PR DESCRIPTION
- app/indexers/curate_collection_indexer.rb: corrects the pulling of the title array by choosing the first title.
- spec/indexers/collection_indexer_spec.rb: provides multiple ids so that we can test the processing titles.