### PR TITLE
Show deposit collections on source collection page

### DIFF
--- a/app/helpers/collection_show_helper.rb
+++ b/app/helpers/collection_show_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CollectionShowHelper
-  def source_collection_link(value_hsh, request_url)
+  def collection_link(value_hsh, request_url)
     if request_url.include? "dashboard"
       tag.a value_hsh[:title], href: "/dashboard/collections/#{value_hsh[:id]}"
     else

--- a/app/indexers/curate_collection_indexer.rb
+++ b/app/indexers/curate_collection_indexer.rb
@@ -14,6 +14,7 @@ class CurateCollectionIndexer < Hyrax::CollectionIndexer
       solr_doc['banner_path_ss'] = banner_path
       solr_doc['source_collection_title_ssim'] = source_collection
       solr_doc['deposit_collection_titles_tesim'] = deposit_collection
+      solr_doc['deposit_collection_ids_tesim'] = object.deposit_collection_ids
     end
   end
 

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -229,12 +229,20 @@ module Hyrax
       source_coll_id.present? && source_coll_id[0] != id
     end
 
-    def deposit_collection_object
+    def source_collection_object
       { title: solr_document['source_collection_title_ssim'][0], id: source_coll_id[0] }
     end
 
     def source_coll_id
       solr_document['source_collection_id_tesim']
+    end
+
+    def deposit_collection_ids
+      solr_document['deposit_collection_ids_tesim']
+    end
+
+    def deposit_collections
+      deposit_collection_ids&.map { |id| { id: id, title: Collection.find(id).title.first } }
     end
   end
 end

--- a/app/search_builders/hyrax/collection_member_search_builder.rb
+++ b/app/search_builders/hyrax/collection_member_search_builder.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# [Hyrax-overwrite-v3.0.0.pre.rc1] Modify #member_of_collection to also search against a source collection's deposit collections
+
+module Hyrax
+  # This search builder requires that a accessor named "collection" exists in the scope
+  class CollectionMemberSearchBuilder < ::SearchBuilder
+    include Hyrax::FilterByType
+    attr_reader :collection, :search_includes_models
+
+    class_attribute :collection_membership_field
+    self.collection_membership_field = 'member_of_collection_ids_ssim'
+
+    # Defines which search_params_logic should be used when searching for Collection members
+    self.default_processor_chain += [:member_of_collection]
+
+    # @param [scope] Typically the controller object
+    # @param [Symbol] :works, :collections, (anything else retrieves both)
+    def initialize(scope:,
+                   collection:,
+                   search_includes_models: :works)
+      @collection = collection
+      @search_includes_models = search_includes_models
+      super(scope)
+    end
+
+    # include filters into the query to only include the collection memebers
+    def member_of_collection(solr_parameters)
+      ids = [collection.id]
+      ids.push(*collection.deposit_collection_ids) if collection.deposit_collection_ids
+      formatted_ids = "(#{ids.join(' OR ')})"
+      solr_parameters[:fq] ||= []
+      solr_parameters[:fq] << "#{collection_membership_field}:#{formatted_ids}"
+    end
+
+    private
+
+      def only_works?
+        search_includes_models == :works
+      end
+
+      def only_collections?
+        search_includes_models == :collections
+      end
+  end
+end

--- a/app/views/hyrax/collections/_deposit_collections.html.erb
+++ b/app/views/hyrax/collections/_deposit_collections.html.erb
@@ -1,0 +1,12 @@
+<% if @presenter.deposit_collections %>
+  <div class="col hyc-metadata">
+    <h4><%= t('hyrax.collections.show.deposit_collections') %></h4>
+    <dl>
+      <% @presenter.deposit_collections.each do |collection| %>
+        <div class="metadata-line">
+          <%= collection_link(collection, request_url) %>
+        </div>
+      <% end %>
+    </dl>
+  </div>
+<% end %>

--- a/app/views/hyrax/collections/_source_collection.html.erb
+++ b/app/views/hyrax/collections/_source_collection.html.erb
@@ -3,6 +3,6 @@
     <h4><%= t('hyrax.collections.show.source_collection') %></h4>
   </div>
   <div class="hyc-blacklight hyc-bl-source-link">
-    <%= source_collection_link(presenter.deposit_collection_object, request_url) %>
+    <%= collection_link(presenter.source_collection_object, request_url) %>
   </div>
 <% end %>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -98,6 +98,9 @@
   <!-- Source Collection -->
   <%= render 'source_collection', presenter: @presenter, request_url: request.url %>
 
+  <!-- Deposit Collections -->
+  <%= render 'deposit_collections', presenter: @presenter, request_url: request.url %>
+
   <!-- Subcollections -->
   <% if @presenter.collection_type_is_nestable? && @subcollection_count > 0 %>
       <div class="hyc-blacklight hyc-bl-title">

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -68,6 +68,13 @@
         </div>
       </section>
 
+      <!-- Deposit Collections -->
+      <section class="collections-deposit-collections-wrapper">
+        <div class="row">
+          <%= render 'hyrax/collections/deposit_collections', presenter: @presenter, request_url: request.url %>
+        </div>
+      </section>
+
       <!-- Subcollections -->
       <% if @presenter.collection_type_is_nestable? %>
         <section id="sub-collections-wrapper" class="sub-collections-wrapper">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
     collections:
       show: 
         source_collection: Source Collection
+        deposit_collections: Additional Deposit Collections
     dashboard:
       my:
         heading:

--- a/spec/indexers/collection_indexer_spec.rb
+++ b/spec/indexers/collection_indexer_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe CurateCollectionIndexer do
       end
 
       it 'returns empty array' do
-        expect(solr_document['deposit_collection_ids_tesim']).to be_nil
+        expect(solr_document['deposit_collection_ids_tesim']).to be_empty
       end
     end
 
@@ -72,6 +72,12 @@ RSpec.describe CurateCollectionIndexer do
       it 'returns correct deposit collection title' do
         expect(solr_document['deposit_collection_titles_tesim']).to match_array(
           ["Test title collection123", "Test title collection456"]
+        )
+      end
+
+      it 'returns correct deposit collection ids' do
+        expect(solr_document['deposit_collection_ids_tesim']).to match_array(
+          ['abc123', 'def456']
         )
       end
     end

--- a/spec/presenters/collection_presenter_spec.rb
+++ b/spec/presenters/collection_presenter_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe Hyrax::CollectionPresenter, :clean do
       collection.save!
       deposit_collection.source_collection_id = collection.id
       deposit_collection.save!
+      collection.deposit_collection_ids = [deposit_collection.id]
+      collection.save!
     end
 
     context '#deposit_collection?' do
@@ -73,12 +75,30 @@ RSpec.describe Hyrax::CollectionPresenter, :clean do
       end
     end
 
-    context '#deposit_collection_object' do
+    context '#source_collection_object' do
       it 'provides hash built from 2 solr_doc fields' do
         solr_doc = SolrDocument.new(deposit_collection.to_solr)
         deposit_presenter = described_class.new(solr_doc, ability)
 
-        expect(deposit_presenter.deposit_collection_object).to eq({ id: collection.id, title: "Testing Collection" })
+        expect(deposit_presenter.source_collection_object).to eq({ id: collection.id, title: "Testing Collection" })
+      end
+    end
+
+    context '#deposit_collection_ids' do
+      it 'provides array of deposit collection ids for a source collection' do
+        solr_doc = SolrDocument.new(collection.to_solr)
+        collection_presenter = described_class.new(solr_doc, ability)
+
+        expect(collection_presenter.deposit_collection_ids).to eq([deposit_collection.id])
+      end
+    end
+
+    context 'deposit_collections' do
+      it 'provides array of deposit collection objects for a source collection' do
+        solr_doc = SolrDocument.new(collection.to_solr)
+        collection_presenter = described_class.new(solr_doc, ability)
+
+        expect(collection_presenter.deposit_collections).to eq([{ id: deposit_collection.id, title: deposit_collection.title.first }])
       end
     end
   end

--- a/spec/system/viewing_a_collection_spec.rb
+++ b/spec/system/viewing_a_collection_spec.rb
@@ -101,6 +101,8 @@ RSpec.describe 'Viewing collections', type: :system, clean: true do
       before do
         user_collection.source_collection_id = admin_collection.id
         user_collection.save!
+        admin_collection.deposit_collection_ids = [user_collection.id]
+        admin_collection.save!
         user_collection.reload
       end
 
@@ -121,16 +123,30 @@ RSpec.describe 'Viewing collections', type: :system, clean: true do
       end
 
       describe 'viewing source collection' do
-        it 'does not have the Source Collection element on public page' do
-          visit "/collections/#{admin_collection.id}"
+        context 'on public page' do
+          before { visit "/collections/#{admin_collection.id}" }
 
-          expect(page).not_to have_content "Source Collection"
+          it 'does not have the Source Collection element' do
+            expect(page).not_to have_content "Source Collection"
+          end
+
+          it 'displays deposit collections' do
+            expect(page).to have_content "Additional Deposit Collections"
+            expect(page).to have_link(user_collection.title[0], href: "/collections/#{user_collection.id}")
+          end
         end
 
-        it 'does not have the Source Collection element on dashboard page' do
-          visit "/dashboard/collections/#{admin_collection.id}"
+        context 'on dashboard page' do
+          before { visit "/dashboard/collections/#{admin_collection.id}" }
 
-          expect(page).not_to have_content "Source Collection"
+          it 'does not have the Source Collection element' do
+            expect(page).not_to have_content "Source Collection"
+          end
+
+          it 'displays deposit collections' do
+            expect(page).to have_content "Additional Deposit Collections"
+            expect(page).to have_link(user_collection.title[0], href: "/dashboard/collections/#{user_collection.id}")
+          end
         end
       end
     end


### PR DESCRIPTION
- Display links to all of a source collection's deposit collections on the source collection show page (both dashboard and public versions)
- On the source collection show page, display all the source collection's works as well as its deposit collection's works
- Search against works in the source collection and its deposit collections on the source collection show page
- Generalize `#source_collection_link` to be simply `#collection_link` to accommodate deposit collection links
- Rename `#deposit_collection_object` to `#source_collection_object` to better reflect its purpose and to avoid confusion with new method `#deposit_collections`

**Source collection show page (dashboard):**
<img width="1139" alt="Screen Shot 2020-08-28 at 10 27 18 AM" src="https://user-images.githubusercontent.com/46227821/91579946-5a33ff00-e91a-11ea-9bf2-0392967d5e58.png">

**Source collection show page (public):**
<img width="1165" alt="Screen Shot 2020-08-28 at 10 26 37 AM" src="https://user-images.githubusercontent.com/46227821/91579954-5c965900-e91a-11ea-9ff0-32807670a9bc.png">
