### PR TITLE
Add source_collection_id to work form

### DIFF
--- a/app/forms/hyrax/curate_generic_work_form.rb
+++ b/app/forms/hyrax/curate_generic_work_form.rb
@@ -15,7 +15,7 @@ module Hyrax
                   :rights_statement, :rights_holders, :copyright_date, :re_use_license, :access_restriction_notes, :rights_documentation,
                   :scheduled_rights_review, :scheduled_rights_review_note, :internal_rights_note, :legacy_rights,
                   :data_classifications, :sensitive_material, :sensitive_material_note, :staff_notes, :date_digitized,
-                  :transfer_engineer, :other_identifiers, :emory_ark, :system_of_record_ID, :primary_repository_ID, :deduplication_key]
+                  :transfer_engineer, :other_identifiers, :emory_ark, :system_of_record_ID, :primary_repository_ID, :deduplication_key, :source_collection_id]
 
     self.required_fields = REQUIRED_FIELDS_ON_FORM
 
@@ -39,7 +39,7 @@ module Hyrax
     end
 
     def primary_admin_metadata_fields
-      [:staff_notes, :system_of_record_ID, :other_identifiers, :emory_ark, :date_digitized, :transfer_engineer, :deduplication_key]
+      [:staff_notes, :system_of_record_ID, :other_identifiers, :emory_ark, :date_digitized, :transfer_engineer, :deduplication_key, :source_collection_id]
     end
 
     def preservation_workflow_metadata_fields

--- a/spec/forms/hyrax/curate_generic_work_form_spec.rb
+++ b/spec/forms/hyrax/curate_generic_work_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hyrax::CurateGenericWorkForm do
     it 'includes the expected terms' do
       expect(described_class.terms).to include(:title, :creator, :rights_statement, :conference_name,
                                                :institution, :volume, :sublocation, :subject_names,
-                                               :internal_rights_note, :issue)
+                                               :internal_rights_note, :issue, :source_collection_id)
     end
   end
 


### PR DESCRIPTION

<img width="555" alt="Screen Shot 2020-09-07 at 3 31 30 PM" src="https://user-images.githubusercontent.com/46227821/92413746-7f491e80-f11f-11ea-9490-0c791cedadb4.png">

- Admin users can now specficy a work's source collection on the new/edit work form
- `spec/system/create_curate_generic_work_spec.rb` is updated to make the default user an admin in order for the source collection dropdown to show up