### PR TITLE
Require source_collection_id on works

### DIFF
--- a/app/views/records/edit_fields/_source_collection_id.html.erb
+++ b/app/views/records/edit_fields/_source_collection_id.html.erb
@@ -1,10 +1,19 @@
-<% if current_user.admin? %>
+<% if @curation_concern.class == CurateGenericWork %>
   <%=
     f.input key,
     collection: all_collections_collection,
-    include_blank: true, required: false,
+    include_blank: true, required: true,
     input_html: { class: 'form-control' }
   %>
 <% else %>
-  <p>Available only for admins.</p>
+  <% if current_user.admin? %>
+    <%=
+      f.input key,
+      collection: all_collections_collection,
+      include_blank: true, required: false,
+      input_html: { class: 'form-control' }
+    %>
+  <% else %>
+    <p>Available only for admins.</p>
+  <% end %>
 <% end %>

--- a/spec/system/create_curate_generic_work_spec.rb
+++ b/spec/system/create_curate_generic_work_spec.rb
@@ -85,6 +85,8 @@ RSpec.describe 'Create a CurateGenericWork', integration: true, clean: true, typ
 
     scenario "metadata fields are validated", js: true do
       new_cgw_form.visit_new_page.metadata_fill_in_with
+      click_link('Additional descriptive fields')
+      select collection.title.first, from: 'curate_generic_work_source_collection_id'
       find('body').click
       expect(page).to have_css('li#required-metadata.complete')
     end


### PR DESCRIPTION
- The partial for `source_collection_id` on the new/edit form now checks for whether the form is for a work or a collection. That way, works can require `source_collection_id` without also making it required for collections.