### PR TITLE
Adds manifest regen button

### DIFF
--- a/app/controllers/manifest_regeneration_controller.rb
+++ b/app/controllers/manifest_regeneration_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class ManifestRegenerationController < ApplicationController
+  before_action :authenticate_user!
+  include IiifManifestCache
+
+  def regen_manifest
+    solr_doc = SolrDocument.find(params[:work_id])
+    key = solr_doc[:manifest_cache_key_tesim]&.first.to_s + '_' + params[:work_id]
+    file_path = File.join(iiif_manifest_cache, key)
+    File.delete(file_path) if File.exist?(file_path)
+    ManifestBuilderService.build_manifest(presenter: presenter(solr_doc), curation_concern: CurateGenericWork.find(params[:work_id]))
+    redirect_to hyrax_curate_generic_work_path(params[:work_id])
+  end
+
+  private
+
+    # @param [SolrDocument] document
+    def presenter(document)
+      ability = ManifestAbility.new
+      Hyrax::CurateGenericWorkPresenter.new(document, ability)
+    end
+end

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -43,6 +43,7 @@
       <% end %>
       <% if current_user.admin? %>
         <%= link_to t('.delete'), [main_app, presenter], class: 'btn btn-danger', data: { confirm: t('.confirm_delete', work_type: presenter.human_readable_type) }, method: :delete %>
+        <div><%= button_to t('.regen_manifest'), "/concern/curate_generic_works/#{@presenter.id}/regen_manifest", class: 'btn btn-primary' %></div>
       <% end %>
     <% end %>
   </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -236,6 +236,8 @@ en:
         no_failures: "No Event failures noted."
         with_failures: "One or more recent events failed for this object"
         preservation_events_work_level: "Preservation Events - Work-level"
+      show_actions:
+        regen_manifest: "Regenerate Manifest"
     account_name: My Institution Account Id
     directory:
       suffix: "@example.org"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Rails.application.routes.draw do
 
   post "/concern/file_sets/:file_set_id/clean_up", to: "derivatives#clean_up"
   post '/concern/file_sets/:file_set_id/re_characterize', to: 'characterization#re_characterize', as: 'file_set_re_characterization'
+  post "/concern/curate_generic_works/:work_id/regen_manifest", to: "manifest_regeneration#regen_manifest", as: 'regen_manifest'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/controllers/manifest_regeneration_controller_spec.rb
+++ b/spec/controllers/manifest_regeneration_controller_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ManifestRegenerationController, type: :controller, clean: true do
+  let(:user) { FactoryBot.create(:user) }
+  let(:work) { FactoryBot.create(:public_generic_work, user: user) }
+  let(:ability) { instance_double(Ability) }
+  let(:presenter) { Hyrax::CurateGenericWorkPresenter.new(solr_document, ability) }
+  let(:solr_document) { SolrDocument.new(attributes) }
+  let(:attributes) do
+    { "id" => work.id,
+      "title_tesim" => [work.title.first],
+      "human_readable_type_tesim" => ["Curate Generic Work"],
+      "has_model_ssim" => ["CurateGenericWork"],
+      "date_created_tesim" => ['an unformatted date'],
+      "date_modified_dtsi" => "2019-11-11T18:20:32Z",
+      "depositor_tesim" => 'example_user',
+      "manifest_cache_key_tesim" => "abc123" }
+  end
+
+  context "when signed in" do
+    describe "POST clean_up" do
+      before do
+        sign_in user
+        allow(SolrDocument).to receive(:find).and_return(solr_document)
+        allow(Hyrax::CurateGenericWorkPresenter).to receive(:new).and_return(presenter)
+      end
+
+      it "queues up fileset cleanup job" do
+        expect(ManifestBuilderService).to receive(:build_manifest).with(presenter: presenter, curation_concern: work)
+        post :regen_manifest, params: { work_id: work }, xhr: true
+        expect(File.exist?("./tmp/abc123_#{work.id}")).to be_falsey
+        expect(response).to be_success
+      end
+    end
+  end
+
+  context "when not signed in" do
+    describe "POST clean_up" do
+      it "returns 401" do
+        post :regen_manifest, params: { work_id: work }, xhr: true
+        expect(response.code).to eq '401'
+      end
+    end
+  end
+end


### PR DESCRIPTION
* We are adding a manifest regen button for admins to manually regen manifests
on demand.

* **app/controllers/manifest_regeneration_controller.rb**: Adds logic to delete existing manifest for a work if it exists and then call the manifest builder service to create a new manifest.
* **app/views/hyrax/base/_show_actions.html.erb**: Adds button
* **config/routes.rb**: Adds route
* **spec/controllers/manifest_regeneration_controller_spec.rb**: Adds tests

Output:
![image](https://user-images.githubusercontent.com/17075287/92778114-df81cf80-f36e-11ea-8593-133bdb41d635.png)
