### PR TITLE
Improving manifest key generation in work indexer

### DIFF
--- a/app/indexers/curate_generic_work_indexer.rb
+++ b/app/indexers/curate_generic_work_indexer.rb
@@ -172,7 +172,10 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
   end
 
   def manifest_cache_key
-    Digest::MD5.hexdigest(object.title.first.to_s + object.file_sets.count.to_s + object.holding_repository.to_s + object.rights_statement.first.to_s + object.visibility.to_s +
-                          object.rendering_ids.to_s)
+    rendering_ids = object.rendering_ids.sort.to_s # sorting so it always returns the same order when generating hash key
+    holding_repository = object.holding_repository.class == 'Array' ? object.holding_repository.first : object.holding_repository # checking if holding repo is returned
+    # from solr. If yes, this might be an array and we will need to get the first value; if it is from fedora, this will be a string always.
+    Digest::MD5.hexdigest(object.title.first.to_s + object.file_sets.count.to_s + holding_repository.to_s + object.rights_statement.first.to_s + object.visibility.to_s +
+                          rendering_ids)
   end
 end

--- a/spec/indexers/curate_generic_work_indexer_spec.rb
+++ b/spec/indexers/curate_generic_work_indexer_spec.rb
@@ -259,6 +259,8 @@ RSpec.describe CurateGenericWorkIndexer do
       end
 
       it 'returns manifest_cache_key' do
+        expect(solr_document['holding_repository_tesim']).to eq(['Library']) # solr returns an array for holding_repo. This problem is solved at
+        # L#177 in CurateGenericWorkIndexer
         expect(Digest::MD5).to receive(:hexdigest).with('Test title0Libraryrestricted[]') # zero because number of file_sets attached to the work is zero
         indexer.generate_solr_document
       end
@@ -284,12 +286,12 @@ RSpec.describe CurateGenericWorkIndexer do
         {
           id:            '123',
           title:         ['Test title'],
-          rendering_ids: ['abc123']
+          rendering_ids: ["7719kd51jq-cor", "4881jwstww-cor"] # making sure we sort these before passed to hash generation
         }
       end
 
       it 'returns manifest_cache_key' do
-        expect(Digest::MD5).to receive(:hexdigest).with("Test title0restricted[\"abc123\"]") # zero because number of file_sets attached to the work is zero
+        expect(Digest::MD5).to receive(:hexdigest).with("Test title0restricted[\"4881jwstww-cor\", \"7719kd51jq-cor\"]") # zero because number of file_sets attached to the work is zero
         indexer.generate_solr_document
       end
     end


### PR DESCRIPTION
* There are instances when the order of the rendering_ids in its array gets messed up and we end up with different hash keys whenever a work is reindexed. To be able to have consistency, we are making sure we first sort the array and then pass it for hash generation. We are also checking to make sure holding repo is always single valued (in case the solr field value is used which is an array).