### PR TITLE
Fixes the passing of username into Characterize Job (#1283).

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -12,7 +12,7 @@ class CharacterizeJob < Hyrax::ApplicationJob
   # @param [FileSet] file_set
   # @param [String] file_id identifier for a Hydra::PCDM::File
   # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
-  def perform(file_set, file_id, filepath = nil, user: nil)
+  def perform(file_set, file_id, filepath = nil, user = nil)
     event_start = DateTime.current
     relation = file_set.class.characterization_proxy
     file = file_set.characterization_proxy

--- a/app/jobs/re_characterize_job.rb
+++ b/app/jobs/re_characterize_job.rb
@@ -5,6 +5,6 @@ class ReCharacterizeJob < Hyrax::ApplicationJob
     repository_file = file_set.public_send(:preservation_master_file)
 
     ReCharacterizationService.empty_out_characterization(repository_file)
-    CharacterizeJob.perform_later(file_set, repository_file.id, user)
+    CharacterizeJob.perform_later(file_set, repository_file.id, "", user)
   end
 end

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe CharacterizeJob, :clean do
       allow(fs).to receive(:update_index)
     end
   end
+  let(:user) { 'bob' }
 
   let(:file) do
     Hydra::PCDM::File.new.tap do |f|
@@ -58,12 +59,13 @@ RSpec.describe CharacterizeJob, :clean do
 
   context "when performed" do
     before do
-      described_class.perform_now(file_set, file.id)
+      described_class.perform_now(file_set, file.id, "", user)
     end
     it "adds a new preservation event for fileset characterization" do
       expect(file_set.preservation_event.first.event_type).to eq ['Characterization']
       expect(file_set.preservation_event.first.outcome).to eq ['Success']
       expect(file_set.preservation_event.first.event_details).to eq ['preservation_master_file: picture.png - Technical metadata extracted from file, format identified, and file validated']
+      expect(file_set.preservation_event.first.initiating_user).to eq [user]
     end
   end
 end

--- a/spec/jobs/re_characterize_job_spec.rb
+++ b/spec/jobs/re_characterize_job_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ReCharacterizeJob, :clean do
       allow(fs).to receive(:update_index)
     end
   end
+  let(:user) { 'bob' }
 
   let(:file) do
     Hydra::PCDM::File.new.tap do |f|
@@ -26,11 +27,13 @@ RSpec.describe ReCharacterizeJob, :clean do
     CharacterizeJob.perform_now(file_set, file.id)
   end
 
-  context '#characterization_setters' do
-    it 'returns the right keys' do
-      expect(ReCharacterizationService).to receive(:empty_out_characterization)
-      expect(CharacterizeJob).to receive(:perform_later)
-      described_class.perform_now(file_set: file_set)
+  context 'processing' do
+    it 'calls the right services and jobs' do
+      repository_file = file_set.public_send(:preservation_master_file)
+
+      expect(ReCharacterizationService).to receive(:empty_out_characterization).with(repository_file)
+      expect(CharacterizeJob).to receive(:perform_later).with(file_set, repository_file.id, "", user)
+      described_class.perform_now(file_set: file_set, user: user)
     end
   end
 end


### PR DESCRIPTION
- app/jobs/characterize_job.rb: makes the user variable a positional argument.
- app/jobs/re_characterize_job.rb: lines up the argument values in the CharacterizeJob call.
- spec/*: tests the expected outcome for the user assignment.