### PR TITLE
Points the Message Digest Calculation event point to initiating user when processing Recharacterization (#1283).

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -18,7 +18,7 @@ class CharacterizeJob < Hyrax::ApplicationJob
     file = file_set.characterization_proxy
     raise "#{relation} was not found for FileSet #{file_set.id}" unless file_set.characterization_proxy?
     filepath = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id) unless filepath && File.exist?(filepath)
-    Hydra::Works::CharacterizationService.run(file, filepath)
+    Hydra::Works::CharacterizationService.run(file, filepath, {}, user)
     event = { 'type' => 'Characterization', 'start' => event_start, 'outcome' => 'Success',
               'details' => "#{relation}: #{file.file_name.first} - Technical metadata extracted from file, format identified, and file validated",
               'software_version' => 'FITS v1.5.0', 'user' => user.presence || file_set.depositor }

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#frozen_string_literal: true
 # [Hyrax-overwrite-v3.0.0.pre.rc1]
 require 'rails_helper'
 
@@ -24,7 +24,7 @@ RSpec.describe CharacterizeJob, :clean do
 
   before do
     allow(FileSet).to receive(:find).with(file_set_id).and_return(file_set)
-    allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+    allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename, {}, user)
     # commenting out because we are doing this in file_actor and not characterize_job
     # allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
   end
@@ -34,19 +34,19 @@ RSpec.describe CharacterizeJob, :clean do
 
     it 'skips Hyrax::WorkingDirectory' do
       expect(Hyrax::WorkingDirectory).not_to receive(:find_or_retrieve)
-      expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
-      described_class.perform_now(file_set, file.id, filename)
+      expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename, {}, user)
+      described_class.perform_now(file_set, file.id, filename, user)
     end
   end
 
   context 'when the characterization proxy content is present' do
     it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
-      expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+      expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename, {}, user)
       expect(file).to receive(:save!)
       expect(file_set).to receive(:update_index)
       # commenting out because we are doing this in file_actor and not characterize_job
       # expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
-      described_class.perform_now(file_set, file.id)
+      described_class.perform_now(file_set, file.id, "", user)
     end
   end
 

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -1,4 +1,4 @@
-#frozen_string_literal: true
+# frozen_string_literal: true
 # [Hyrax-overwrite-v3.0.0.pre.rc1]
 require 'rails_helper'
 

--- a/spec/jobs/re_characterize_job_spec.rb
+++ b/spec/jobs/re_characterize_job_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ReCharacterizeJob, :clean do
 
   before do
     allow(FileSet).to receive(:find).with(file_set_id).and_return(file_set)
-    allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+    allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename, {}, nil)
     CharacterizeJob.perform_now(file_set, file.id)
   end
 


### PR DESCRIPTION
- app/jobs/characterize_job.rb: passes the user to the the service if present.
- config/initializers/characterization_service.rb: overrides the `run` and `initialization` methods so they accept a user argument. Also establishes a `@user` instance variable that can be used in the event creation.
- spec/jobs/characterize_job_spec.rb and spec/jobs/re_characterize_job_spec.rb: changes `rspec` expectation for new argument.
- spec/services/characterization_service_spec.rb: checks that initiating user's `uid` is assigned correctly. 