### PR TITLE
Adds logic to display source col on search results page

### DIFF
--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -1,0 +1,41 @@
+<% # [Hyrax-overwrite-v3.0.0.pre.rc1] Add logic to display source collection for a work if present %>
+<div class="col-md-6">
+  <div class="metadata">
+    <dl class="dl-horizontal">
+    <% doc_presenter = index_presenter(document) %>
+    <% index_fields(document).each do |field_name, field| -%>
+      <% if should_render_index_field? document, field %>
+        <% # display field name %>
+        <dt><%= render_index_field_label document, field: field_name %></dt>
+        <% if field_name == 'member_of_collections_ssim' %>
+        <% # only do this for collection field %>
+          <% if document.source_collection_id %>
+          <% # check if work has source collection %>
+            <% unless document.member_of_collection_ids.first == document.source_collection_id.first %>
+            <% # only display source collection if it is different from deposit collection %>
+              <dd><%= document.source_collection_title.first %></dd>
+              <% # `next` will make sure dd on L#23 does not get executed if source collection is already displayed %>
+              <%next%>
+            <% end %>
+          <% end %>
+        <% end %>
+        <% # display field value %>
+        <dd><%= doc_presenter.field_value field %></dd>
+      <% end %>
+    <% end %>
+    </dl>
+  </div>
+</div>
+<% if document.collection? %>
+<% collection_presenter = Hyrax::CollectionPresenter.new(document, current_ability) %>
+<div class="col-md-4">
+  <div class="collection-counts-wrapper">
+    <div class="collection-counts-item">
+      <span><%= collection_presenter.total_viewable_collections %></span>Collections
+    </div>
+    <div class="collection-counts-item">
+      <span><%= collection_presenter.total_viewable_works %></span>Works
+    </div>
+  </div>
+</div>
+<% end %>

--- a/spec/system/search_results_page_spec.rb
+++ b/spec/system/search_results_page_spec.rb
@@ -4,8 +4,9 @@ include Warden::Test::Helpers
 
 RSpec.describe 'viewing the search results page', type: :system, clean: true do
   let(:admin_user) { FactoryBot.create(:admin) }
+  let(:source_collection) { FactoryBot.create(:collection_lw, title: ['Source Collection test']) }
   let(:work) { FactoryBot.build(:work_with_full_metadata, user: admin_user) }
-  let(:admin_collection) { FactoryBot.build(:public_collection_lw, user: admin_user, with_permission_template: true) }
+  let(:admin_collection) { FactoryBot.build(:public_collection_lw, user: admin_user, with_permission_template: true, title: ['Deposit Collection test']) }
   before do
     login_as admin_user
     work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
@@ -46,6 +47,24 @@ RSpec.describe 'viewing the search results page', type: :system, clean: true do
       expect(page).to have_css('.metadata .dl-horizontal dt', text: 'Library:')
       expect(page).to have_css('.metadata .dl-horizontal dt', text: 'Collection:')
       expect(page).to have_css('.metadata .dl-horizontal dt', text: 'Visibility:')
+    end
+  end
+
+  context 'source collection is present' do
+    before do
+      work.source_collection_id = source_collection.id
+      work.save!
+    end
+
+    it 'shows source collection for work' do
+      visit '/catalog?q='
+      expect(page).to have_content('Source Collection test')
+    end
+  end
+
+  context 'source collection is absent' do
+    it 'shows deposit collection for work' do
+      expect(page).to have_content('Deposit Collection test')
     end
   end
 end


### PR DESCRIPTION
Connected to: #1490 

* We are adding logic to display the source col for a work on the search results page if source collection is present. If source and deposit cols are same, do nothing.