### PR TITLE
Use source collection for faceting

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -43,7 +43,7 @@ class CatalogController < ApplicationController
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
     config.add_facet_field 'holding_repository_sim', limit: 5, label: 'Library'
-    config.add_facet_field 'member_of_collections_ssim', limit: 10, label: 'Collection'
+    config.add_facet_field 'source_collection_title_for_works_ssim', limit: 10, label: 'Collection'
     config.add_facet_field 'creator_sim', limit: 10, label: 'Creator'
     config.add_facet_field 'human_readable_content_type_ssim', limit: 10, label: 'Format'
     config.add_facet_field 'content_genres_sim', limit: 10, label: 'Genre'

--- a/app/indexers/curate_generic_work_indexer.rb
+++ b/app/indexers/curate_generic_work_indexer.rb
@@ -33,6 +33,7 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
       solr_doc['child_works_for_lux_tesim'] = child_works_for_lux
       solr_doc['parent_work_for_lux_tesim'] = parent_work_for_lux
       solr_doc['source_collection_title_ssim'] = source_collection
+      solr_doc['source_collection_title_for_works_ssim'] = source_collection
       solr_doc['manifest_cache_key_tesim'] = manifest_cache_key
       # the next two fields are for display and search, not for security
       solr_doc['visibility_group_ssi'] = visibility_group_for_lux

--- a/spec/system/search_results_page_spec.rb
+++ b/spec/system/search_results_page_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'viewing the search results page', type: :system, clean: true do
 
   context 'facet_selects' do
     it 'has the right count of facet_selects' do
-      expect(page).to have_selector('a.facet_select', count: 13)
+      expect(page).to have_selector('a.facet_select', count: 12)
     end
   end
 
@@ -59,6 +59,19 @@ RSpec.describe 'viewing the search results page', type: :system, clean: true do
     it 'shows source collection for work' do
       visit '/catalog?q='
       expect(page).to have_content('Source Collection test')
+    end
+
+    context 'when faceting by source collection' do
+      before { visit '/catalog?f%5Bsource_collection_title_for_works_ssim%5D%5B%5D=Source+Collection+test&locale=en&q=&search_field=all_fields' }
+
+      it 'shows work in search results for source collection' do
+        expect(page).to have_content('Test title')
+        expect(page).to have_content('1 entry found')
+      end
+
+      it 'does not show deposit collections in search results' do
+        expect(page).not_to have_content('Deposit Collection test')
+      end
     end
   end
 


### PR DESCRIPTION
- The collections facet now uses `source_collection_title_for_works_ssim` instead of `member_of_collections_ssim`
- `source_collection_title_for_works_ssim` is created in order for the collections facet to show only works (`source_collection_title_ssim` is also indexed for collections)
- `search_results_spec.rb` is revised to account for the fact that no source collections exist at that point in the system test, reducing the number of applicable facets to 12