### PR TITLE
Displays Source alongside Deposit Collection in Is Part Of on Dashboard Works (#1479).

### DIFF
--- a/app/helpers/hyrax/collections_override_helper.rb
+++ b/app/helpers/hyrax/collections_override_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module CollectionsOverrideHelper
+    include Hyrax::CollectionsHelper
+
+    # rubocop:disable Rails/ContentTag
+    def render_collection_links(solr_doc)
+      collection_list = Hyrax::CollectionMemberService.run(solr_doc, controller.current_ability)
+      source_collection = collection_list.present? ? [::SolrDocument.find(collection_list.first['source_collection_id_tesim'])] : []
+      collection_list |= source_collection
+      return if collection_list.empty?
+      links = collection_list.map { |collection| link_to collection.title_or_label, hyrax.collection_path(collection.id) }
+      collection_links = []
+      links.each_with_index do |link, n|
+        collection_links << link
+        collection_links << ', ' unless links[n + 1].nil?
+      end
+      content_tag :span, safe_join([t('hyrax.collection.is_part_of'), ': '] + collection_links)
+    end
+    # rubocop:enable Rails/ContentTag
+  end
+end

--- a/app/helpers/hyrax/collections_override_helper.rb
+++ b/app/helpers/hyrax/collections_override_helper.rb
@@ -7,9 +7,9 @@ module Hyrax
     # rubocop:disable Rails/ContentTag
     def render_collection_links(solr_doc)
       collection_list = Hyrax::CollectionMemberService.run(solr_doc, controller.current_ability)
-      source_collection = collection_list.present? ? [::SolrDocument.find(collection_list.first['source_collection_id_tesim'])] : []
-      collection_list |= source_collection
       return if collection_list.empty?
+      source_collection = collection_list.first['source_collection_id_tesim'].present? ? [::SolrDocument.find(collection_list.first['source_collection_id_tesim'])] : []
+      collection_list |= source_collection
       links = collection_list.map { |collection| link_to collection.title_or_label, hyrax.collection_path(collection.id) }
       collection_links = []
       links.each_with_index do |link, n|

--- a/spec/helpers/hyrax/collections_override_helper_spec.rb
+++ b/spec/helpers/hyrax/collections_override_helper_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Hyrax::CollectionsHelper do
+  let(:user) { FactoryBot.create(:user, groups: ['admin']) }
+  let(:ability) { Ability.new(user) }
+
+  describe '#render_collection_links' do
+    before do
+      allow(controller).to receive(:current_ability).and_return(ability)
+    end
+
+    context 'when a GenericWork does not belongs to any collections', :clean_repo do
+      let!(:work_doc) { SolrDocument.new(id: '123', title_tesim: ['My GenericWork']) }
+
+      it 'renders nothing' do
+        expect(helper.render_collection_links(work_doc)).to be_nil
+      end
+    end
+
+    context 'when a GenericWork belongs to collections' do
+      let(:coll_ids) { ['111', '222'] }
+      let(:coll_titles) { ['Collection 111', 'Collection 222'] }
+      let(:coll1_attrs) { { id: coll_ids[0], title_tesim: [coll_titles[0]] } }
+      let(:coll2_attrs) { { id: coll_ids[1], title_tesim: [coll_titles[1]] } }
+      let!(:work_doc) { SolrDocument.new(id: '123', title_tesim: ['My GenericWork'], member_of_collection_ids_ssim: coll_ids) }
+
+      before do
+        Hyrax::SolrService.add(coll1_attrs)
+        Hyrax::SolrService.add(coll2_attrs)
+        Hyrax::SolrService.commit
+      end
+
+      it 'renders a list of links to the collections' do
+        expect(helper.render_collection_links(work_doc)).to match(/Is part of/i)
+        expect(helper.render_collection_links(work_doc)).to match("href=\"/collections/#{coll_ids[0]}\"")
+        expect(helper.render_collection_links(work_doc)).to match("href=\"/collections/#{coll_ids[1]}\"")
+        expect(helper.render_collection_links(work_doc)).to match(coll_titles[0])
+        expect(helper.render_collection_links(work_doc)).to match(coll_titles[1])
+      end
+    end
+
+    context 'when a GenericWork belongs to deposit and source collections' do
+      let(:coll_ids) { ['111', '222'] }
+      let(:coll_titles) { ['Collection 111', 'Collection 222'] }
+      let(:coll1_attrs) { { id: coll_ids[0], title_tesim: [coll_titles[0]], source_collection_id_tesim: coll_ids[1] } }
+      let(:coll2_attrs) { { id: coll_ids[1], title_tesim: [coll_titles[1]] } }
+      let!(:work_doc) { SolrDocument.new(id: '123', title_tesim: ['My GenericWork'], member_of_collection_ids_ssim: [coll_ids[0]], source_collection_id_tesim: coll_ids[1]) }
+
+      before do
+        Hyrax::SolrService.add(coll1_attrs)
+        Hyrax::SolrService.add(coll2_attrs)
+        Hyrax::SolrService.commit
+      end
+
+      it 'renders a list of links to the collections' do
+        expect(helper.render_collection_links(work_doc)).to match(/Is part of/i)
+        expect(helper.render_collection_links(work_doc)).to match("href=\"/collections/#{coll_ids[0]}\"")
+        expect(helper.render_collection_links(work_doc)).to match("href=\"/collections/#{coll_ids[1]}\"")
+        expect(helper.render_collection_links(work_doc)).to match(coll_titles[0])
+        expect(helper.render_collection_links(work_doc)).to match(coll_titles[1])
+      end
+    end
+  end
+end


### PR DESCRIPTION
`app/helpers/hyrax/collections_override_helper.rb`:
> This overrides only one helper method in `Hyrax::CollectionsHelper`, namely `render_collection_links(solr_doc)`. Lines 10 and 11 are the only changes where we are pulling source collections attached to the work, and integrating them into the `collections_list` array that the "Is Part Of:" is fed from.

Note: I couldn't get rspec to load the "Dashboard > All Works" page after associating the work with the deposit collection (e.g. `work.member_of_collections << deposit_collection`). Because of this, I have left with out of the system rspec tests. 