### PR TITLE
Facet works by source collection

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -43,7 +43,7 @@ class CatalogController < ApplicationController
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
     config.add_facet_field 'holding_repository_sim', limit: 5, label: 'Library'
-    config.add_facet_field 'source_collection_title_for_works_ssim', limit: 10, label: 'Collection'
+    config.add_facet_field 'source_collection_title_ssim', limit: 10, label: 'Collection'
     config.add_facet_field 'creator_sim', limit: 10, label: 'Creator'
     config.add_facet_field 'human_readable_content_type_ssim', limit: 10, label: 'Format'
     config.add_facet_field 'content_genres_sim', limit: 10, label: 'Genre'

--- a/app/indexers/curate_collection_indexer.rb
+++ b/app/indexers/curate_collection_indexer.rb
@@ -12,7 +12,7 @@ class CurateCollectionIndexer < Hyrax::CollectionIndexer
       solr_doc['creator_ssort'] = object.creator.first
       solr_doc['generic_type_sim'] = ["Collection"]
       solr_doc['banner_path_ss'] = banner_path
-      solr_doc['source_collection_title_ssim'] = source_collection
+      solr_doc['source_collection_title_for_collections_ssim'] = source_collection
       solr_doc['deposit_collection_titles_tesim'] = deposit_collection
       solr_doc['deposit_collection_ids_tesim'] = object.deposit_collection_ids
     end

--- a/app/indexers/curate_generic_work_indexer.rb
+++ b/app/indexers/curate_generic_work_indexer.rb
@@ -33,7 +33,6 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
       solr_doc['child_works_for_lux_tesim'] = child_works_for_lux
       solr_doc['parent_work_for_lux_tesim'] = parent_work_for_lux
       solr_doc['source_collection_title_ssim'] = source_collection
-      solr_doc['source_collection_title_for_works_ssim'] = source_collection
       solr_doc['manifest_cache_key_tesim'] = manifest_cache_key
       # the next two fields are for display and search, not for security
       solr_doc['visibility_group_ssi'] = visibility_group_for_lux

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -230,7 +230,7 @@ module Hyrax
     end
 
     def source_collection_object
-      { title: solr_document['source_collection_title_ssim'][0], id: source_coll_id[0] }
+      { title: solr_document['source_collection_title_for_collections_ssim'][0], id: source_coll_id[0] }
     end
 
     def source_coll_id

--- a/spec/indexers/collection_indexer_spec.rb
+++ b/spec/indexers/collection_indexer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CurateCollectionIndexer do
       end
 
       it 'returns correct source collection title' do
-        expect(solr_document['source_collection_title_ssim']).to eq(['Test title collection123'])
+        expect(solr_document['source_collection_title_for_collections_ssim']).to eq(['Test title collection123'])
       end
     end
   end

--- a/spec/system/search_results_page_spec.rb
+++ b/spec/system/search_results_page_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'viewing the search results page', type: :system, clean: true do
     end
 
     context 'when faceting by source collection' do
-      before { visit '/catalog?f%5Bsource_collection_title_for_works_ssim%5D%5B%5D=Source+Collection+test&locale=en&q=&search_field=all_fields' }
+      before { visit '/catalog?f%5Bsource_collection_title_ssim%5D%5B%5D=Source+Collection+test&locale=en&q=&search_field=all_fields' }
 
       it 'shows work in search results for source collection' do
         expect(page).to have_content('Test title')


### PR DESCRIPTION
- This PR accomplishes the same behavior as #1497, but instead of indexing a new field on works, we are indexing a new field on collections. This way, only collections will have to be re-indexed in order for faceting by source collection to function properly.
- See #1497 for the specs. Every change from that PR is reversed in this one except for the specs.