### PR TITLE
Suppresses Add to collection button on Works page when user non-admin (#1504).

### DIFF
--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,7 +1,7 @@
 <% # [Hyrax-overwrite-v3.0.0.pre.rc1] Only display delete button if user is an admin L#44 %>
 <div class="row show-actions button-row-top-two-column">
   <div class="col-sm-6">
-    <% if presenter.show_deposit_for?(collections: @user_collections) %>
+    <% if presenter.show_deposit_for?(collections: @user_collections) && current_user.admin? %>
       <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
       <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
                     class: 'btn btn-default submits-batches submits-batches-add',

--- a/spec/system/viewing_a_work_spec.rb
+++ b/spec/system/viewing_a_work_spec.rb
@@ -136,6 +136,7 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
       visit "dashboard/works"
       find("input[type='checkbox'][id='check_all']").set(true)
       expect(page).to have_selector("input[value='delete_all']", visible: false)
+      expect(page).to have_css('button', text: 'Add to collection')
     end
   end
 
@@ -168,6 +169,7 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
       visit "dashboard/works"
       find("input[type='checkbox'][id='check_all']").set(true)
       expect(page).not_to have_selector("input[value='delete_all']", visible: false)
+      expect(page).not_to have_css('button', text: 'Add to collection')
     end
 
     context 'viewer role' do


### PR DESCRIPTION
- app/views/hyrax/base/_show_actions.html.erb: adds admin requirement for Add to collection button.
- spec/system/viewing_a_work_spec.rb: tests for existence of button when user admin/non.