### PR TITLE
Changes FileSet Attachment Event to reflect initiating user (#1249).

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -151,3 +151,7 @@ RSpec/AnyInstance:
 RSpec/LetSetup:
     Exclude:
         - spec/presenters/collection_presenter_spec.rb
+
+RSpec/LeadingSubject:
+    Exclude:
+        - spec/actors/hyrax/actors/create_with_files_actor_spec.rb

--- a/app/actors/hyrax/actors/create_with_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_actor.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+# [Hyrax-overwrite-v3.0.0.pre.rc1] Overwritten so that the associated change event
+#   reflects the initiating user, not the depositor.
+
+module Hyrax
+  module Actors
+    # Creates a work and attaches files to the work
+    class CreateWithFilesActor < Hyrax::Actors::AbstractActor
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if create was successful
+      def create(env)
+        uploaded_file_ids = filter_file_ids(env.attributes.delete(:uploaded_files))
+        files             = uploaded_files(uploaded_file_ids)
+        # get a current copy of attributes, to protect against future mutations
+        attributes        = env.attributes.clone
+        user = env&.user
+
+        validate_files(files, env) &&
+          next_actor.create(env) &&
+          attach_files(files, env.curation_concern, attributes, user)
+      end
+
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if update was successful
+      def update(env)
+        uploaded_file_ids = filter_file_ids(env.attributes.delete(:uploaded_files))
+        files             = uploaded_files(uploaded_file_ids)
+        # get a current copy of attributes, to protect against future mutations
+        attributes        = env.attributes.clone
+        user = env&.user
+
+        validate_files(files, env) &&
+          next_actor.update(env) &&
+          attach_files(files, env.curation_concern, attributes, user)
+      end
+
+      private
+
+        def filter_file_ids(input)
+          Array.wrap(input).select(&:present?)
+        end
+
+        # ensure that the files we are given are owned by the depositor of the work
+        def validate_files(files, env)
+          expected_user_id = env.user.id
+          files.each do |file|
+            if file.user_id != expected_user_id
+              Rails.logger.error "User #{env.user.user_key} attempted to ingest uploaded_file #{file.id}, but it belongs to a different user"
+              return false
+            end
+          end
+          true
+        end
+
+        # @return [TrueClass]
+        def attach_files(files, curation_concern, attributes, user = nil)
+          return true if files.blank?
+          AttachFilesToWorkJob.perform_later(curation_concern, files, user, attributes.to_h.symbolize_keys)
+          true
+        end
+
+        # Fetch uploaded_files from the database
+        def uploaded_files(uploaded_file_ids)
+          return [] if uploaded_file_ids.empty?
+          UploadedFile.find(uploaded_file_ids)
+        end
+    end
+  end
+end

--- a/app/actors/hyrax/actors/create_with_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_actor.rb
@@ -13,6 +13,8 @@ module Hyrax
         files             = uploaded_files(uploaded_file_ids)
         # get a current copy of attributes, to protect against future mutations
         attributes        = env.attributes.clone
+        # Initiating user variable created and then passed along in the the
+        # attach_files method call below.
         user = env&.user
 
         validate_files(files, env) &&
@@ -27,6 +29,8 @@ module Hyrax
         files             = uploaded_files(uploaded_file_ids)
         # get a current copy of attributes, to protect against future mutations
         attributes        = env.attributes.clone
+        # Initiating user variable created and then passed along in the the
+        # attach_files method call below.
         user = env&.user
 
         validate_files(files, env) &&

--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -7,10 +7,12 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
 
   # @param [ActiveFedora::Base] work - the work object
   # @param [Array<Hyrax::UploadedFile>] uploaded_files - an array of files to attach
-  def perform(work, uploaded_files, **work_attributes)
+  # @param [User] initiating_user - single user pulled from the env container so
+  #   that the change event can reflect the initiating user
+  def perform(work, uploaded_files, initiating_user, **work_attributes)
     validate_files!(uploaded_files)
     depositor = proxy_or_depositor(work)
-    user = User.find_by_user_key(depositor)
+    user = initiating_user.presence || User.find_by_user_key(depositor)
     work, work_permissions = create_permissions work, depositor
     metadata = visibility_attributes(work_attributes)
     uploaded_files.each do |uploaded_file|

--- a/spec/actors/hyrax/actors/create_with_files_actor_spec.rb
+++ b/spec/actors/hyrax/actors/create_with_files_actor_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+# [Hyrax-overwrite-v3.0.0.pre.rc1] Changes expectations to include initiating user argument
+require 'rails_helper'
+
+RSpec.describe Hyrax::Actors::CreateWithFilesActor, :clean do
+  let(:user) { FactoryBot.create(:user) }
+  let(:ability) { ::Ability.new(user) }
+  let(:work) { FactoryBot.create(:generic_work, user: user) }
+  let(:env) { Hyrax::Actors::Environment.new(work, ability, attributes) }
+  let(:terminator) { Hyrax::Actors::Terminator.new }
+  let(:uploaded_file1) { FactoryBot.create(:uploaded_file, user: user) }
+  let(:uploaded_file2) { FactoryBot.create(:uploaded_file, user: user) }
+  let(:uploaded_file_ids) { [uploaded_file1.id, uploaded_file2.id] }
+  let(:attributes) { { uploaded_files: uploaded_file_ids } }
+
+  subject(:middleware) do
+    stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+      middleware.use described_class
+    end
+    stack.build(terminator)
+  end
+
+  [:create, :update].each do |mode|
+    context "on #{mode}" do
+      before do
+        allow(terminator).to receive(mode).and_return(true)
+      end
+      context "when uploaded_file_ids include nil" do
+        let(:uploaded_file_ids) { [nil, uploaded_file1.id, nil] }
+
+        it "will discard those nil values when attempting to find the associated UploadedFile" do
+          expect(AttachFilesToWorkJob).to receive(:perform_later)
+          expect(Hyrax::UploadedFile).to receive(:find).with([uploaded_file1.id]).and_return([uploaded_file1])
+          middleware.public_send(mode, env)
+        end
+      end
+
+      context "when uploaded_file_ids belong to me" do
+        it "attaches files" do
+          expect(AttachFilesToWorkJob).to receive(:perform_later).with(CurateGenericWork, [uploaded_file1, uploaded_file2], user, {})
+          expect(middleware.public_send(mode, env)).to be true
+        end
+      end
+
+      context "when uploaded_file_ids don't belong to me" do
+        let(:uploaded_file2) { FactoryBot.create(:uploaded_file) }
+
+        it "doesn't attach files" do
+          expect(AttachFilesToWorkJob).not_to receive(:perform_later)
+          expect(middleware.public_send(mode, env)).to be false
+        end
+      end
+
+      context "when no uploaded_file" do
+        let(:attributes) { {} }
+
+        it "doesn't invoke job" do
+          expect(AttachFilesToWorkJob).not_to receive(:perform_later)
+          expect(middleware.public_send(mode, env)).to be true
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -26,12 +26,13 @@ RSpec.describe AttachFilesToWorkJob, :clean, perform_enqueued: [AttachFilesToWor
                      fileset_use:              'supplementary')
   end
   let(:generic_work) { FactoryBot.create(:public_generic_work) }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user)         { FactoryBot.create(:user) }
+  let(:user2)        { FactoryBot.create(:user) }
 
   shared_examples 'a file attacher', perform_enqueued: [described_class, IngestJob] do
     it 'attaches files, copies visibility and permissions and updates the uploaded files' do
       expect(CharacterizeJob).to receive(:perform_later).once
-      described_class.perform_now(generic_work, [uploaded_file1])
+      described_class.perform_now(generic_work, [uploaded_file1], user)
       generic_work.reload
       expect(generic_work.file_sets.first.title).to eq ['Example title']
       expect(generic_work.file_sets.first.pcdm_use).to eq 'primary'
@@ -47,12 +48,21 @@ RSpec.describe AttachFilesToWorkJob, :clean, perform_enqueued: [AttachFilesToWor
   context "sets fileset name" do
     it_behaves_like 'a file attacher' do
       it 'sets fileset name as preservation_master_file name when fileset name is not present' do
-        described_class.perform_now(generic_work, [uploaded_file2])
+        described_class.perform_now(generic_work, [uploaded_file2], user)
 
         expect(generic_work.file_sets.first.title).to eq ['0003_preservation_master.tif']
         expect(generic_work.file_sets.first.pcdm_use).to eq 'supplementary'
         expect(generic_work.file_sets.first.files.size).to eq 3
       end
+    end
+  end
+
+  # Added to check that the associated event actually gets the initiating user instead of
+  #   the depositor on file.
+  context "calls FileSetAttachedEventJob", perform_enqueued: [described_class, IngestJob, FileSetAttachedEventJob] do
+    it 'calls FileSetAttachedEventJob with the initiating user when passed along' do
+      expect(FileSetAttachedEventJob).to receive(:perform_later).with(an_instance_of(FileSet), user2).once
+      described_class.perform_now(generic_work, [uploaded_file1], user2)
     end
   end
 
@@ -71,7 +81,7 @@ RSpec.describe AttachFilesToWorkJob, :clean, perform_enqueued: [AttachFilesToWor
         let(:uploaded_file1) { FactoryBot.build(:uploaded_file, file: pmf, file_set_uri: 'http://example.com/file_set') }
 
         it 'skips files that already have a FileSet' do
-          expect { described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2]) }
+          expect { described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2], user) }
             .to change { generic_work.file_sets.count }.to eq 1
         end
       end
@@ -111,7 +121,7 @@ RSpec.describe AttachFilesToWorkJob, :clean, perform_enqueued: [AttachFilesToWor
       upload = File.open(virus_file_path) do |virus_file|
         Hyrax::UploadedFile.create(user: user, preservation_master_file: virus_file)
       end
-      described_class.perform_now(generic_work, [upload])
+      described_class.perform_now(generic_work, [upload], user)
     end
     it 'does not upload file' do
       expect(generic_work.file_sets.first.files.size).to eq 0


### PR DESCRIPTION
- .rubocop.yml: allows Hyrax-imported spec to pass rubocop linting.
- app/actors/hyrax/actors/create_with_files_actor.rb: passes initiating user to the AttachFilesToWorkJob.
- app/jobs/attach_files_to_work_job.rb: takes in and makes the initiating user the priority for the user associated for the File Attached change event.
- spec/*: changes expectations for arguments passed through as well as makes sure that the `FileSetAttachedEventJob` gets the right user.