### PR TITLE
Possible fix to the error referenced in Honeybadger for Managed Collections view (#1516).

### DIFF
--- a/app/presenters/hyrax/admin_set_presenter.rb
+++ b/app/presenters/hyrax/admin_set_presenter.rb
@@ -43,16 +43,6 @@ module Hyrax
       []
     end
 
-    # For the Managed Collections tab, determine the label to use for the level of access the user has for this admin set.
-    # Checks from most permissive to most restrictive.
-    # @return String the access label (e.g. Manage, Deposit, View)
-    def managed_access
-      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.manage') if current_ability.can?(:edit, solr_document)
-      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.deposit') if current_ability.can?(:deposit, solr_document)
-      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.view') if current_ability.can?(:read, solr_document)
-      ''
-    end
-
     # Determine if the user can perform batch operations on this admin set.  Currently, the only
     # batch operation allowed is deleting, so this is equivalent to checking if the user can delete
     # the admin set determined by criteria...

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -211,7 +211,10 @@ module Hyrax
     # Checks from most permissive to most restrictive.
     # @return String the access label (e.g. Manage, Deposit, View)
     def managed_access
-      Hyrax::AdminSetPresenter.managed_access
+      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.manage') if current_ability.can?(:edit, solr_document)
+      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.deposit') if current_ability.can?(:deposit, solr_document)
+      return I18n.t('hyrax.dashboard.my.collection_list.managed_access.view') if current_ability.can?(:read, solr_document)
+      ''
     end
 
     # Determine if the user can perform batch operations on this collection.  Currently, the only


### PR DESCRIPTION
Error link: https://app.honeybadger.io/projects/66999/faults/68124506

Summary: Since it makes little sense to define a method in a child Presenter and also call it in the parent Presenter, I have moved the definition to the parent and completely deleted it from the child. Since `Hyrax::AdminSetPresenter` already inherits from `CollectionPresenter`, it will automatically be available in both after the changes.

Changes:
- app/presenters/hyrax/admin_set_presenter.rb: excises the `managed_access` method definition.
- app/presenters/hyrax/collection_presenter.rb: replaces the call to it's child Presenter method with the actual definition.