### PR TITLE
Moves the attributes hash to the end of the argument chain in attach_files (#1249).

### DIFF
--- a/app/actors/hyrax/actors/create_with_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_actor.rb
@@ -19,7 +19,7 @@ module Hyrax
 
         validate_files(files, env) &&
           next_actor.create(env) &&
-          attach_files(files, env.curation_concern, attributes, user)
+          attach_files(files, env.curation_concern, user, attributes)
       end
 
       # @param [Hyrax::Actors::Environment] env
@@ -35,7 +35,7 @@ module Hyrax
 
         validate_files(files, env) &&
           next_actor.update(env) &&
-          attach_files(files, env.curation_concern, attributes, user)
+          attach_files(files, env.curation_concern, user, attributes)
       end
 
       private
@@ -57,7 +57,7 @@ module Hyrax
         end
 
         # @return [TrueClass]
-        def attach_files(files, curation_concern, attributes, user = nil)
+        def attach_files(files, curation_concern, user, attributes)
           return true if files.blank?
           AttachFilesToWorkJob.perform_later(curation_concern, files, user, attributes.to_h.symbolize_keys)
           true


### PR DESCRIPTION
app/actors/hyrax/actors/create_with_files_actor.rb: adjusts the order of the arguments since a hash argument should be last.