### PR TITLE
Remove feature button from work show page

### DIFF
--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,4 +1,5 @@
-<% # [Hyrax-overwrite-v3.0.0.pre.rc1] Only display delete button if user is an admin L#44 %>
+<% # [Hyrax-overwrite-v3.0.0.pre.rc1] Only display delete button if user is an admin L#36 %>
+<% # Do not display feature button L#10 (removed default code) %>
 <div class="row show-actions button-row-top-two-column">
   <div class="col-sm-6">
     <% if presenter.show_deposit_for?(collections: @user_collections) && current_user.admin? %>
@@ -6,15 +7,6 @@
       <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
                     class: 'btn btn-default submits-batches submits-batches-add',
                     data: { toggle: "modal", target: "#collection-list-container" } %>
-    <% end %>
-    <% if presenter.work_featurable? %>
-      <%= link_to t('.feature'), hyrax.featured_work_path(presenter, format: :json),
-          data: { behavior: 'feature' },
-          class: presenter.display_feature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>
-
-      <%= link_to t('.unfeature'), hyrax.featured_work_path(presenter, format: :json),
-          data: { behavior: 'unfeature' },
-          class: presenter.display_unfeature_link? ? 'btn btn-default' : 'btn btn-default collapse' %>
     <% end %>
     <% if Hyrax.config.analytics? %>
       <% # turbolinks needs to be turned off or the page will use the cache and the %>

--- a/spec/system/viewing_a_work_spec.rb
+++ b/spec/system/viewing_a_work_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
 
       expect(social_media.size).to eq(0)
     end
+
+    it 'does not show feature button' do
+      expect(page).not_to have_link('Feature')
+    end
   end
 
   context 'page metadata labels' do


### PR DESCRIPTION
Because the feature button breaks other functionality, we are removing it from work show pages for all users.

**Before:**
<img width="353" alt="Screen Shot 2020-10-02 at 3 33 17 PM" src="https://user-images.githubusercontent.com/46227821/94963950-e1026b80-04c6-11eb-8abb-ebb1bf320e8a.png">

**After:**
<img width="353" alt="Screen Shot 2020-10-02 at 3 33 32 PM" src="https://user-images.githubusercontent.com/46227821/94963962-e495f280-04c6-11eb-9d0c-a4c7b95508a2.png">
