### PR TITLE
Diverts collections options to already created custom helper (#1522).

### DIFF
--- a/app/views/zizia/csv_imports/_collection_selection.html.erb
+++ b/app/views/zizia/csv_imports/_collection_selection.html.erb
@@ -1,1 +1,3 @@
+<!-- [Zizia-overwrite-v5.3.0] ActiveFedora Solr query was producing a list without all Collections, so
+        an overwrite is needed to provide them all, which all_collections_collection does -->
 <%= form.select :fedora_collection_id, options_for_select(all_collections_collection), {}, class: "form-control", id: "fedora_collection_id"  %>

--- a/app/views/zizia/csv_imports/_collection_selection.html.erb
+++ b/app/views/zizia/csv_imports/_collection_selection.html.erb
@@ -1,0 +1,1 @@
+<%= form.select :fedora_collection_id, options_for_select(all_collections_collection), {}, class: "form-control", id: "fedora_collection_id"  %>


### PR DESCRIPTION
app/views/zizia/csv_imports/_collection_selection.html.erb: utilizes already created helper to ensure that all Collections show in select options.