### PR TITLE
Attempts to fix fixity check issues caused on the server

### DIFF
--- a/app/services/hyrax/file_set_fixity_check_service.rb
+++ b/app/services/hyrax/file_set_fixity_check_service.rb
@@ -90,6 +90,7 @@ module Hyrax
 
         if async_jobs
           FixityCheckJob.perform_later(version_uri.to_s, file_set_id: file_set.id, file_id: file_id, initiating_user: @initiating_user)
+          sleep(1) # sleep for 1 second after running fixity check job so that file can be correctly fetched from s3 and processed
         else
           FixityCheckJob.perform_now(version_uri.to_s, file_set_id: file_set.id, file_id: file_id, initiating_user: @initiating_user)
         end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -35,7 +35,7 @@ Hyrax.config do |config|
   # config.max_notifications_for_dashboard = 5
 
   # How frequently should a file be fixity checked
-  # config.max_days_between_fixity_checks = 7
+  config.max_days_between_fixity_checks = 1
 
   # Options to control the file uploader
   config.uploader = {

--- a/lib/tasks/fixity_check.rake
+++ b/lib/tasks/fixity_check.rake
@@ -3,7 +3,9 @@ namespace :curate do
   namespace :file_sets do
     desc "Perform fixity checking on file_sets"
     task fixity_check: :environment do
-      FileSet.all.each do |file_set|
+      limit = ENV['limit'].to_i || FileSet.count # limit number of file_sets
+
+      FileSet.all[0..limit].each do |file_set|
         Hyrax::FileSetFixityCheckService.new(file_set, max_days_between_fixity_checks: 90, initiating_user: "Curate system").fixity_check
       end
     end


### PR DESCRIPTION
* We are seeing a large number of fixity check errors which may be caused because of an overwhelming number of file requests sent to s3. We are adding a sleep statement for 1 second in an attempt to let the file be retrieved and processed successfully.
* We are also adding an argument to limit the number of filesets we run fixity check on. This is only for testing purposes.
* Also changing the max days between fixity check via ui to 1. Again, this is only for testing purposes.