### PR TITLE
Adds additional limit param to fixity check job queue

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,8 +2,11 @@
 :queues:
   - [ingest, 4]
   - [batch, 2]
-  - [default, 1]
   - [fixity_check_job, 2]
+  - [default, 1]
+
+:limits:
+  fixity_check_job: 1
 
 :process_limits:
   fixity_check_job: 1


### PR DESCRIPTION
* Putting queues in order of their weightage and adding additional limit configuration in an attempt to make fixity_check_job to use the fixity_check_job queue.