### PR TITLE
Improves limiting fixity check for filesets

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -23,8 +23,8 @@
 
 case @hostname
 when 'curate-test'
-  # run rake task every 7th day - this is only for testing purposes
-  every '0 0 * * */7' do
+  # run rake task every wednesday - this is only for testing purposes
+  every '0 0 * * 3' do
     rake "curate:file_sets:fixity_check"
   end
 end

--- a/lib/tasks/fixity_check.rake
+++ b/lib/tasks/fixity_check.rake
@@ -3,7 +3,7 @@ namespace :curate do
   namespace :file_sets do
     desc "Perform fixity checking on file_sets"
     task fixity_check: :environment do
-      limit = ENV['limit'].to_i || FileSet.count # limit number of file_sets
+      limit = ENV['limit'].present? ? ENV['limit'].to_i : FileSet.count # limit number of file_sets
       response = Blacklight.default_index.connection.get 'select', params: { q: "has_model_ssim:FileSet", rows: limit, fl: "id" }
       file_set_ids = response["response"]["docs"].pluck("id")
 


### PR DESCRIPTION
* We need to check for presence of limit arg when running fixity check rake task, else it assigns zero if it doesn't see a value. So making a change to first check for presence, if not presence go with fileset total count.
* Also changing when cron runs rake task to wednesday on curate-test for testing purposes.