### PR TITLE
Corrects member_works_count_isi scope to Works with matching source_collection_id (#693).

### DIFF
--- a/app/indexers/curate_collection_indexer.rb
+++ b/app/indexers/curate_collection_indexer.rb
@@ -9,7 +9,7 @@ class CurateCollectionIndexer < Hyrax::CollectionIndexer
   # For more information, read the SOURCE_DEPOSIT_CHANGES_README.md in dlp-curate's root folder.
   def generate_solr_document
     super.tap do |solr_doc|
-      solr_doc['member_works_count_isi'] = object.child_works.count
+      solr_doc['member_works_count_isi'] = member_works_count
       solr_doc['title_ssort'] = sort_title
       solr_doc['creator_ssort'] = object.creator.first
       solr_doc['generic_type_sim'] = ["Collection"]
@@ -48,5 +48,9 @@ class CurateCollectionIndexer < Hyrax::CollectionIndexer
 
   def deposit_collection
     object.deposit_collection_ids.map { |id| Collection.find(id).title.first } if object.deposit_collection_ids.present?
+  end
+
+  def member_works_count
+    Collection.related_works_solrized(object.id).count
   end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -120,6 +120,15 @@ class Collection < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  def self.related_works_solrized(id)
+    Hyrax::SolrService.query(
+      Hyrax::SolrQueryBuilderService.construct_query(
+        source_collection_id_tesim: id,
+        has_model_ssim:             "CurateGenericWork"
+      ), rows: 1_000_000
+    )
+  end
+
   private
 
     def service

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -16,9 +16,11 @@ RSpec.describe Collection, clean: true do
 
     it "indexes the correct count of child works for populated collections" do
       works = [work1, work2, work3]
-      works.each { |w| collection.ordered_members << w }
-      collection.save!
-      collection.reload
+      works.each do |w|
+        w.source_collection_id = collection.id
+        w.save!
+        w.reload
+      end
       expect(solr_doc['member_works_count_isi']).to eq 3
     end
 


### PR DESCRIPTION
- app/indexers/curate_collection_indexer.rb: swaps out the `member_works_count_isi` value to the number of works with matching `source_collection_id`.
- app/jobs/collection_files_ingested_job.rb: removes the variables for the service and builders, since they are now not repeated. Also points the pulling of works to a newly created class method.
- app/models/collection.rb: creates a new class method that returns an array of Solr objects that are related to a source collection.
- spec/models/collection_spec.rb: changes expectations for the 'member_works_count_isi' count to reflect the matching of `source_collection_id`.