### PR TITLE
Removes two unnecessary links from the homepage (#1511).

### DIFF
--- a/app/views/hyrax/homepage/index.html.erb
+++ b/app/views/hyrax/homepage/index.html.erb
@@ -1,0 +1,9 @@
+<!-- [Hyrax-overwrite-v3.0.0.pre.rc1] Removes the Share Your Work and Terms of Use links -->
+
+<% provide :page_title, application_name %>
+
+<div class="row home-content">
+  <%= render 'home_content' %>
+</div>
+
+<%= render '/shared/select_work_type_modal', create_work_presenter: @presenter.create_work_presenter if @presenter.draw_select_work_modal? %>

--- a/spec/system/viewing_homepage_spec.rb
+++ b/spec/system/viewing_homepage_spec.rb
@@ -3,15 +3,22 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.describe 'viewing the homepage', type: :system do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:admin) }
+
+  before do
+    login_as user
+    visit root_path
+  end
 
   context 'when contact link clicked' do
     it 'goes to the libwizard link' do
-      login_as user
-      visit root_path
-
       expect(find_link('Contact')[:href]).to eq 'https://emory.libwizard.com/f/dlp-feedback'
       expect(find_link('Contact')[:target]).to eq '_blank'
     end
+  end
+
+  it "doesn't show Terms of Use or Share Your Work links" do
+    expect(page).not_to have_link('Share Your Work')
+    expect(page).not_to have_link('Terms of Use')
   end
 end


### PR DESCRIPTION
- app/views/hyrax/homepage/index.html.erb: removes logic that delivers both links.
- spec/system/viewing_homepage_spec.rb: adds test to check for removal of links.