### PR TITLE
Adds deduplication_key and id to the search results snippet (#1444).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -75,6 +75,8 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), label: 'Date Uploaded', itemprop: 'datePublished', helper_method: :human_readable_date
     config.add_index_field solr_name("date_modified", :stored_sortable, type: :date), label: 'Date Modified', itemprop: 'dateModified', helper_method: :human_readable_date
     config.add_index_field 'human_readable_visibility_ssi', label: 'Visibility', itemprop: 'human_readable_visibility'
+    config.add_index_field 'deduplication_key_tesim', label: 'Deduplication Key', itemprop: 'deduplication_key'
+    config.add_index_field 'id', label: 'ID', itemprop: 'id'
 
     # solr fields to be displayed in the show (single result) view
     # The ordering of the field names is the order of the display

--- a/spec/system/search_results_page_spec.rb
+++ b/spec/system/search_results_page_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe 'viewing the search results page', type: :system, clean: true do
       expect(page).to have_css('.metadata .dl-horizontal dt', text: 'Library:')
       expect(page).to have_css('.metadata .dl-horizontal dt', text: 'Collection:')
       expect(page).to have_css('.metadata .dl-horizontal dt', text: 'Visibility:')
+      expect(page).to have_css('.metadata .dl-horizontal dt', text: 'Deduplication Key:')
+      expect(page).to have_css('.metadata .dl-horizontal dt', text: 'ID:')
     end
   end
 


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: inserts two new fields to display in search result snippet.
- spec/system/search_results_page_spec.rb: tests for existence of label.