### PR TITLE
Expands Admin abbreviation in labels for clarity (#1478).

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -254,7 +254,7 @@ en:
         additional_descriptive_fields: "Additional descriptive fields"
         rights_metadata_heading: "Rights Metadata"
         additional_rights_fields: "Additional rights fields"
-        admin_metadata_heading: "Admin Metadata"
+        admin_metadata_heading: "Administrative Metadata"
         additional_admin_fields: "Additional admin fields"
         preservation_workflow_metadata_heading: "Preservation Workflow Metadata"
     file_sets:

--- a/spec/system/create_curate_generic_work_spec.rb
+++ b/spec/system/create_curate_generic_work_spec.rb
@@ -292,6 +292,8 @@ RSpec.describe 'Create a CurateGenericWork', integration: true, clean: true, typ
         expect(page).to have_css('option[value="true"][text()="Yes"]')
         expect(page).to have_css('option[value="false"][text()="No"]')
       end
+      expect(page).to have_content "Administrative Metadata"
+      expect(page).not_to have_content "Admin Metadata"
       # expect(page).to have_content "Add folder"
       # within('span#addfiles') do
       #   attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)


### PR DESCRIPTION
- config/locales/hyrax.en.yml: changes verbiage.
- spec/system/create_curate_generic_work_spec.rb: tests the existence of the correct verbiage.