### PR TITLE
Corrects the visibility badges for works on Dashboard (#1545).

### DIFF
--- a/app/helpers/hyrax/ability_override_helper.rb
+++ b/app/helpers/hyrax/ability_override_helper.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module AbilityOverrideHelper
+    include Hyrax::AbilityHelper
+
+    # [Hyrax-overwrite-v3.0.0.pre.rc1] The following method needs to read the bare
+    # document's visibility_ssi when rendering the visibility badge.
+    def render_visibility_link(document)
+      # Admin Sets do not have a visibility property.
+      return if document.respond_to?(:admin_set?) && document.admin_set?
+
+      # Anchor must match with a tab in
+      # https://github.com/samvera/hyrax/blob/master/app/views/hyrax/base/_guts4form.html.erb#L2
+      path = if document.collection?
+               hyrax.edit_dashboard_collection_path(document, anchor: 'share')
+             else
+               edit_polymorphic_path([main_app, document], anchor: 'share')
+             end
+      link_to(
+        visibility_badge(document['visibility_ssi']),
+        path,
+        id:    "permission_#{document.id}",
+        class: 'visibility-link'
+      )
+    end
+  end
+end

--- a/spec/system/filtering_on_dashboard_works_spec.rb
+++ b/spec/system/filtering_on_dashboard_works_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Filtering on the Dashboard Works page', type: :system, clean: true do
+  let(:admin) { FactoryBot.create(:admin) }
+  let(:work) { FactoryBot.build(:work_with_full_metadata, :public) }
+
+  before do
+    login_as admin
+    work.save!
+    visit '/dashboard/works'
+  end
+
+  context 'when choosing Public from the visibility facet' do
+    it 'displays the matching visibility badge in the list item' do
+      find('a.facet_select', text: "Public").click
+
+      expect(page).to have_selector('a.visibility-link span.label.label-success', text: 'Public')
+    end
+  end
+
+  context 'when choosing Emory High Download from the visibility facet' do
+    let(:work) { FactoryBot.build(:emory_high_work) }
+
+    it 'displays the matching visibility badge in the list item' do
+      find('a.facet_select', text: "Emory High Download").click
+
+      expect(page).to have_selector('a.visibility-link span.label.label-info', text: 'Emory High Download')
+    end
+  end
+end


### PR DESCRIPTION
- app/helpers/hyrax/ability_override_helper.rb: overrides Hyrax helper to instead read the `visibility_ssi` field.
- spec/system/filtering_on_dashboard_works_spec.rb: tests expectations.