### PR TITLE
Ties changes to File Set visibility to Manifest Regeneration (#1591).

### DIFF
--- a/app/indexers/curate_generic_work_indexer.rb
+++ b/app/indexers/curate_generic_work_indexer.rb
@@ -175,7 +175,8 @@ class CurateGenericWorkIndexer < Hyrax::WorkIndexer
     rendering_ids = object.rendering_ids.sort.to_s # sorting so it always returns the same order when generating hash key
     holding_repository = object.holding_repository.class == 'Array' ? object.holding_repository.first : object.holding_repository # checking if holding repo is returned
     # from solr. If yes, this might be an array and we will need to get the first value; if it is from fedora, this will be a string always.
+    file_sets_visibility = object.file_sets.map(&:visibility).join
     Digest::MD5.hexdigest(object.title.first.to_s + object.file_sets.count.to_s + holding_repository.to_s + object.rights_statement.first.to_s + object.visibility.to_s +
-                          rendering_ids)
+                          file_sets_visibility + rendering_ids)
   end
 end

--- a/spec/indexers/curate_generic_work_indexer_spec.rb
+++ b/spec/indexers/curate_generic_work_indexer_spec.rb
@@ -310,5 +310,25 @@ RSpec.describe CurateGenericWorkIndexer do
         indexer.generate_solr_document
       end
     end
+
+    context 'when fileset visibility is changed' do
+      let(:work) { FactoryBot.create(:public_generic_work) }
+      let(:uf) do
+        FactoryBot.build(:uploaded_file,
+                         file:                     'Example title',
+                         preservation_master_file: File.open(fixture_path + '/book_page/0003_preservation_master.tif'),
+                         fileset_use:              'primary')
+      end
+
+      it 'returns manifest_cache_key' do
+        AttachFilesToWorkJob.perform_now(work, [uf])
+        file_set = work.file_sets.first
+        file_set.visibility = 'low_res'
+        file_set.save!
+
+        expect(Digest::MD5).to receive(:hexdigest).with("Test title1openlow_res[]")
+        indexer.generate_solr_document
+      end
+    end
   end
 end


### PR DESCRIPTION
- app/indexers/curate_generic_work_indexer.rb: adds the file sets' visibility to the hex.
- spec/indexers/curate_generic_work_indexer_spec.rb: tests for the string to be present.