### PR TITLE
Bug: eliminates duplicate Manifest Regeneration jobs (#1637).

### DIFF
--- a/app/controllers/manifest_regeneration_controller.rb
+++ b/app/controllers/manifest_regeneration_controller.rb
@@ -9,7 +9,6 @@ class ManifestRegenerationController < ApplicationController
     key = solr_doc[:manifest_cache_key_tesim]&.first.to_s + '_' + params[:work_id]
     file_path = File.join(iiif_manifest_cache, key)
     File.delete(file_path) if File.exist?(file_path)
-    ManifestBuilderService.build_manifest(presenter: presenter(solr_doc), curation_concern: CurateGenericWork.find(params[:work_id]))
     redirect_to hyrax_curate_generic_work_path(params[:work_id])
   end
 

--- a/spec/controllers/manifest_regeneration_controller_spec.rb
+++ b/spec/controllers/manifest_regeneration_controller_spec.rb
@@ -28,7 +28,10 @@ RSpec.describe ManifestRegenerationController, type: :controller, clean: true do
       end
 
       it "queues up fileset cleanup job" do
-        expect(ManifestBuilderService).to receive(:build_manifest).with(presenter: presenter, curation_concern: work)
+        # Below is a revision on 8/25/21. Since this method is only used on the show page
+        # and that page load always calls the build_manifest function, it is unnecessary
+        # to call it again. In the past, this has caused two simultaneous jobs to be enqueued.
+        expect(ManifestBuilderService).not_to receive(:build_manifest).with(presenter: presenter, curation_concern: work)
         post :regen_manifest, params: { work_id: work }, xhr: true
         expect(File.exist?("./tmp/abc123_#{work.id}")).to be_falsey
         expect(response).to be_success


### PR DESCRIPTION
- app/controllers/manifest_regeneration_controller.rb: removes the regeneration method since it's called automatically when the controller redirects to the show page.
- spec/controllers/manifest_regeneration_controller_spec.rb: adjusts expectations to reflect the omission of the Regen method call.

No screenshots necessary.