### PR TITLE
Automates preprocessors in UI (#1567).

### DIFF
--- a/app/controllers/background_jobs_controller.rb
+++ b/app/controllers/background_jobs_controller.rb
@@ -6,21 +6,61 @@ class BackgroundJobsController < ApplicationController
   def create
     if params[:jobs] == 'cleanup'
       FileSetCleanUpJob.perform_later
-      msg = "File Set Cleanup Job"
+      redirect_to new_background_job_path, notice: "File Set Cleanup Job has started successfully."
     elsif params[:jobs] == 'preservation'
+      preservation_worklow_action
+      redirect_to new_background_job_path, notice: "Preservation Workflow Importer Job has started successfully."
+    elsif params[:jobs].include?('_preprocessor')
+      preprocessor_actions
+    else
+      reindex_objects_action
+      redirect_to new_background_job_path, notice: "Reindex Files Job has started successfully."
+    end
+  end
+
+  private
+
+    def preservation_worklow_action
       name = params[:preservation_csv].original_filename
       path = Rails.root.join('tmp', name)
       File.open(path, "w+") { |f| f.write(params[:preservation_csv].read) }
       PreservationWorkflowImporterJob.perform_later(path.to_s)
-      msg = "Preservation Workflow Importer Job"
-    else
+    end
+
+    def reindex_objects_action
       CSV.foreach(params[:reindex_csv].path, headers: true) do |row|
         r = row.to_h
         ReindexObjectJob.perform_later(r['id'])
       end
-      msg = "Reindex Files Job"
     end
-    flash_message = msg + " has started successfully."
-    redirect_to new_background_job_path, notice: flash_message
-  end
+
+    def preprocessor_actions
+      if params[:jobs].include?('dams')
+        preprocessor_action(params[:dams_csv].present?, DamsPreprocessor.new(params[:dams_csv].path))
+      elsif params[:jobs].include?('lang')
+        preprocessor_action(params[:lang_csv].present?, LangmuirPreprocessor.new(params[:lang_csv].path))
+      else
+        preprocessor_action(
+          params[:book_csv] && params[:book_xml] && params[:book_map],
+          YellowbackPreprocessor.new(
+            params[:book_csv].path,
+            params[:book_xml].path,
+            params[:book_repl],
+            params[:book_map].to_sym,
+            params[:book_start_num].to_i
+          )
+        )
+      end
+    end
+
+    def preprocessor_action(guard_test, preprocessor)
+      raise "This preprocessor requires a CSV file." unless guard_test
+      preprocessor = preprocessor
+      preprocessor.merge
+      respond_to do |format|
+        format.any { send_file preprocessor.processed_csv, filename: "processed_file.csv" }
+      end
+    rescue => error
+      "This preprocessor has encountered an error: #{error}"
+    end
 end

--- a/app/views/background_jobs/new.html.erb
+++ b/app/views/background_jobs/new.html.erb
@@ -1,37 +1,25 @@
 <%= render '/flash_msg' %>
 <%= form_tag background_jobs_path, method: :post, multipart: true, class: "form-horizontal" do %>
-<h3>Background Jobs</h3>
-<table class="table table-striped">
-  <tr>
-    <th>Select Job</th>
-    <th>Select Input File</th>
-   
-  </tr>
-  
+  <h3>Background Jobs</h3>
+  <table class="table table-striped">
+    <tr>
+      <th>Select Job</th>
+      <th>Select Input File</th>
+    </tr>
     <tr>
       <td>
         <%= radio_button_tag :jobs, 'cleanup', false, id: 'cleanup' %>
         <%= label :job_cleanup, 'FileSet Cleanup' %>
-        
-        
       </td>
-      <td>
-        N/A
-      </td>
-      
+      <td>N/A</td>
     </tr>
-
     <tr>
       <td>
         <%= radio_button_tag :jobs, 'reindex', false, id: 'reindex' %>
         <%= label :job_cleanup, 'Reindex Selected Files' %>
-        
-        
       </td>
       <td>
         <%= file_field_tag 'reindex_csv', class: 'files', :accept => 'text/csv' %>
-      
-            
       </td>
       
     </tr>
@@ -39,21 +27,65 @@
       <td>
         <%= radio_button_tag :jobs, 'preservation', false, id: 'preservation' %>
         <%= label :job_cleanup, 'Load Preservation Workflow Metadata' %>
-        
-        
       </td>
       <td>
         <%= file_field_tag 'preservation_csv', class: 'files', :accept => 'text/csv' %>
       </td>
-      
     </tr>
-
-</table>
-<button class="btn btn-primary" type="submit" value="Submit">Start Job</button>
+  </table>
+  <table class="table table-striped">
+    <tr>
+      <th>Preprocessors</th>
+      <th>CSV File</th>
+      <th>XML File</th>
+      <th>Replacement Path</th>
+      <th>Workflow</th>
+      <th>Starting Page Number</th>
+    </tr>
+    <tr>
+      <td>
+        <%= radio_button_tag :jobs, 'dams_preprocessor', false, id: 'dams_preprocessor' %>
+        <%= label :job_cleanup, 'DAMS Preprocessor' %>
+      </td>
+      <td>
+        <%= file_field_tag 'dams_csv', class: 'files', :accept => 'text/csv' %>
+      </td>
+      <td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td>
+    </tr>
+    <tr>
+      <td>
+        <%= radio_button_tag :jobs, 'lang_preprocessor', false, id: 'lang_preprocessor' %>
+        <%= label :job_cleanup, 'Langmuir Preprocessor' %>
+      </td>
+      <td>
+        <%= file_field_tag 'lang_csv', class: 'files', :accept => 'text/csv' %>
+      </td>
+      <td>N/A</td><td>N/A</td><td>N/A</td><td>N/A</td>
+    </tr>
+    <tr>
+      <td>
+        <%= radio_button_tag :jobs, 'book_preprocessor', false, id: 'book_preprocessor' %>
+        <%= label :job_cleanup, 'Book Preprocessor' %>
+      </td>
+      <td>
+        <%= file_field_tag 'book_csv', class: 'files', :accept => 'text/csv' %>
+      </td>
+      <td>
+        <%= file_field_tag 'book_xml', class: 'files', :accept => 'text/xml' %>
+      </td>
+      <td>
+        <%= text_field_tag 'book_repl', nil, class: 'repl_text', placeholder: 'optional' %>
+      </td>
+      <td>
+        <%= select_tag 'book_map', raw("<option>kirtas</option><option>limb</option>"), class: 'book_map_text', prompt: 'Please choose limb or kirtas' %>
+      </td>
+      <td>
+        <%= number_field_tag 'book_start_num', nil, class: 'book_start_num', prompt: 'Start page of book' %>
+      </td>
+    </tr>
+  </table>
+  <button class="btn btn-primary" type="submit" value="Submit">Start Job</button>
 <% end %>
-
-
-
 
 <script type="text/javascript">
 $(document).ready(function() {
@@ -61,14 +93,10 @@ $(document).ready(function() {
       $('.files').each(function(i) {
          $(this).removeAttr('required');
       });
-      
         var val = $(this).val()
         if(val !== 'cleanup'){
           $("input[name='" + val + "_csv']").prop('required',true);
-
         }
-
-
     }); 
 });
 </script>

--- a/spec/controllers/background_jobs_controller_spec.rb
+++ b/spec/controllers/background_jobs_controller_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe BackgroundJobsController, type: :controller, clean: true do
   let(:user) { FactoryBot.create(:user) }
   let(:csv_file) { fixture_file_upload((fixture_path + '/reindex_files.csv'), 'text/csv') }
   let(:csv_file2) { fixture_file_upload((fixture_path + '/preservation_workflows.csv'), 'text/csv') }
+  let(:new_call) { get :new }
 
   context "when signed in" do
     before do
@@ -23,26 +24,74 @@ RSpec.describe BackgroundJobsController, type: :controller, clean: true do
 
     describe "#new" do
       it 'has 200 code for new' do
-        get :new
+        new_call
         expect(response.status).to eq(200)
       end
     end
 
     describe "#create" do
+      let(:cleanup) { post :create, params: { jobs: 'cleanup', format: 'json' } }
+      let(:preservation) do
+        post :create, params: { jobs: 'preservation', preservation_csv: csv_file2, format: 'json' }
+      end
+      let(:reindex) { post :create, params: { jobs: 'reindex', reindex_csv: csv_file, format: 'json' } }
+
       it "successfully starts a file_set cleanup background job" do
-        post :create, params: { jobs: 'cleanup', format: 'json' }
-        response.should redirect_to(new_background_job_path)
+        expect(cleanup).to redirect_to(new_background_job_path)
       end
       it "successfully starts a preservation workflow background job" do
-        post :create, params: { jobs: 'preservation', preservation_csv: csv_file2, format: 'json' }
+        expect(preservation).to redirect_to(new_background_job_path)
         expect(PreservationWorkflowImporterJob).to have_been_enqueued
-        response.should redirect_to(new_background_job_path)
       end
       it "successfully starts a reindex background job" do
-        post :create, params: { jobs: 'reindex', reindex_csv: csv_file, format: 'json' }
+        expect(reindex).to redirect_to(new_background_job_path)
         # Needed to call out how many times the job will be enqueued.
         expect(ReindexObjectJob).to have_been_enqueued.twice
-        response.should redirect_to(new_background_job_path)
+      end
+
+      context 'books preprocessor' do
+        let(:preprocessor) { instance_double(YellowbackPreprocessor) }
+        let(:yellowback_pull_list_sample) do
+          fixture_file_upload('csv_import/yellowbacks/yellowbacks_pull_list.csv', 'text/csv')
+        end
+        let(:alma_export_sample) do
+          fixture_file_upload('csv_import/yellowbacks/yellowbacks_marc.xml', 'text/xml')
+        end
+
+        it 'goes through the expected processes' do
+          allow(preprocessor).to receive(:processed_csv)
+          expect(YellowbackPreprocessor).to receive(:new).with(any_args).and_return(preprocessor)
+          expect(preprocessor).to receive(:merge)
+          post :create, params: { jobs: 'book_preprocessor', book_csv: yellowback_pull_list_sample, book_xml: alma_export_sample, book_map: 'limb', format: 'json' }
+        end
+      end
+
+      context 'langmuir preprocessor' do
+        let(:preprocessor) { instance_double(LangmuirPreprocessor) }
+        let(:langmuir_sample) do
+          fixture_file_upload('csv_import/langmuir/langmuir-unprocessed.csv', 'text/csv')
+        end
+
+        it 'goes through the expected processes' do
+          allow(preprocessor).to receive(:processed_csv)
+          expect(LangmuirPreprocessor).to receive(:new).with(any_args).and_return(preprocessor)
+          expect(preprocessor).to receive(:merge)
+          post :create, params: { jobs: 'lang_preprocessor', lang_csv: langmuir_sample, format: 'json' }
+        end
+      end
+
+      context 'DAMS preprocessor' do
+        let(:preprocessor) { instance_double(DamsPreprocessor) }
+        let(:dams_sample) do
+          fixture_file_upload('csv_import/dams/dams-unprocessed.csv', 'text/csv')
+        end
+
+        it 'goes through the expected processes' do
+          allow(preprocessor).to receive(:processed_csv)
+          expect(DamsPreprocessor).to receive(:new).with(any_args).and_return(preprocessor)
+          expect(preprocessor).to receive(:merge)
+          post :create, params: { jobs: 'dams_preprocessor', dams_csv: dams_sample, format: 'json' }
+        end
       end
     end
   end
@@ -50,8 +99,7 @@ RSpec.describe BackgroundJobsController, type: :controller, clean: true do
   context "when not signed in" do
     describe "#new" do
       it 'has 302 found' do
-        get :new
-        response.should redirect_to(new_user_session_path.split('?').first)
+        expect(new_call).to redirect_to(new_user_session_path.split('?').first)
       end
     end
   end


### PR DESCRIPTION
- app/controllers/background_jobs_controller.rb: adds the preprocessor options to the create action.
- app/views/background_jobs/new.html.erb: inserts the three different preprocessors into the form used for background jobs.
- spec/controllers/background_jobs_controller_spec.rb: tests for new processes and refactors other tests to alleviate deprecation warnings.

<img width="2626" alt="Screen Shot 2021-09-14 at 9 25 00 AM" src="https://user-images.githubusercontent.com/18330149/133296752-83ba125d-fd3d-437f-8473-60750a1c85c5.png">
