### PR TITLE
Brad's Initializers work.

### DIFF
--- a/config/initializers/file_actor.rb
+++ b/config/initializers/file_actor.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# [Hyrax-overwrite-v3.0.0.pre.rc1] FileActor ingest_file method in Hyrax::Actors
+# [Hyrax-overwrite-v3.1.0] FileActor ingest_file method in Hyrax::Actors
 # Perform characterize job only on preservation_master_file
 require 'wings'
 Hyrax::Actors::FileActor.class_eval do
@@ -19,7 +19,7 @@ Hyrax::Actors::FileActor.class_eval do
     return false unless file_set.save
     # may cause error since new related_file method normalizes the relation, but may not if relation is always a symbol.
     repository_file = related_file
-    Hyrax::VersioningService.create(repository_file, user)
+    create_version(repository_file, user)
     pathhint = io.uploaded_file.uploader.path if io.uploaded_file # in case next worker is on same filesystem
     # Perform characterize job only on preservation_master_file
     CharacterizeJob.perform_later(file_set, repository_file.id, pathhint || io.path) if relation == :preservation_master_file

--- a/config/initializers/job_io_wrapper.rb
+++ b/config/initializers/job_io_wrapper.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# [Hyrax-overwrite-v3.0.0.pre.rc1]
+# [Hyrax-overwrite-v3.1.0]
 # ingest_file method in the JobIoWrapper method is modified. We save the response
 # from the `file_actor.ingest_file` method call. If false is returned from L#16 in
 # `config/intializers/file_actor.rb` then a failure event is created, else success

--- a/config/initializers/works_controller.rb
+++ b/config/initializers/works_controller.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-# [Hyrax-overwrite-v3.0.0.pre.rc1] Adds source collection search facet to works page
+# [Hyrax-overwrite-v3.1.0] Adds source collection search facet to works page
 # Change below was necessary to institute Source/Deposit Collection structure.
 # For more information, read the SOURCE_DEPOSIT_CHANGES_README.md in dlp-curate's root folder.
 Hyrax::My::WorksController.class_eval do
   # Define collection specific filter facets.
   def self.configure_facets
     configure_blacklight do |config|
+      config.search_builder_class = Hyrax::My::WorksSearchBuilder
       config.add_facet_field "source_collection_title_ssim", limit: 5, label: 'Source Collection'
     end
   end


### PR DESCRIPTION
- config/initializers/file_actor.rb: uses new method created for v3.1.0.
- config/initializers/job_io_wrapper.rb: bumps the version number.
- config/initializers/works_controller.rb: makes the search_builder_class a part of the config, per v3.1.0.

No screenshots necessary.