### PR TITLE
Bug fix: jquery.treetable error.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,7 +19,7 @@
 //= require dataTables/jquery.dataTables
 //= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
 //= require blacklight/blacklight
-//= require hyrax
+//= require curate_hyrax
 //= require hyrax/autocomplete/default
 //= require almond
 //= require zizia/application

--- a/app/assets/javascripts/curate_hyrax.js
+++ b/app/assets/javascripts/curate_hyrax.js
@@ -1,0 +1,111 @@
+//= require jquery-ui/core
+//= require jquery-ui/widget
+//= require jquery-ui/widgets/menu
+//= require jquery-ui/widgets/autocomplete
+//= require jquery-ui/position
+//= require jquery-ui/effect
+//= require jquery-ui/effects/effect-highlight
+//= require jquery-ui/widgets/sortable
+
+//= require bootstrap/alert
+//= require bootstrap/button
+//= require bootstrap/collapse
+//= require bootstrap/dropdown
+//= require bootstrap/modal
+//= require bootstrap/tooltip
+// Popover requires that tooltip be loaded first
+//= require bootstrap/popover
+//= require bootstrap/tab
+// Affix is used for the file manager
+//= require bootstrap/affix
+
+//= require select2
+//= require fixedsticky
+
+// Graphing libraries
+//= require jquery.flot
+//= require jquery.flot.time
+//= require jquery.flot.selection
+//= require morris/raphael-min
+//= require morris/morris.min
+
+//= require clipboard
+//= require tinymce
+
+// This is required for Jasmine tests, specifically to polyfill the Symbol() function
+//= require babel/polyfill
+// CustomElements polyfill is a dependency of time-elements
+//= require webcomponentsjs/0.5.4/CustomElements.min
+//= require time-elements
+
+//= require action_cable
+
+//= require hyrax/monkey_patch_turbolinks
+//= require hyrax/fileupload
+// Provide AMD module support
+//= require almond
+//= require hyrax/notification
+//= require hyrax/app
+//= require hyrax/config
+//= require hyrax/initialize
+//= require hyrax/trophy
+//= require hyrax/facets
+//= require hyrax/featured_works
+//= require hyrax/batch_select_all
+//= require hyrax/search
+//= require hyrax/content_blocks
+//= require hyrax/nav_safety
+//= require hyrax/ga_events
+//= require hyrax/select_submit
+//= require hyrax/tabs
+//= require hyrax/user_search
+//= require hyrax/proxy_rights
+//= require hyrax/sorting
+//= require hyrax/single_use_links_manager
+//= require hyrax/dashboard_actions
+//= require hyrax/batch
+//= require hyrax/flot_stats
+//= require hyrax/admin/admin_set_controls
+//= require hyrax/admin/admin_set/group_participants
+//= require hyrax/admin/admin_set/registered_users
+//= require hyrax/admin/admin_set/participants
+//= require hyrax/admin/admin_set/visibility
+//= require hyrax/admin/collection_type_controls
+//= require hyrax/admin/collection_type/participants
+//= require hyrax/admin/collection_type/settings
+//= require hyrax/collections/editor
+//= require hyrax/editor
+//= require hyrax/editor/admin_set_widget
+//= require hyrax/editor/controlled_vocabulary
+//= require hyrax/admin/graphs
+//= require hyrax/save_work
+//= require hyrax/permissions
+//= require hyrax/autocomplete
+//= require hyrax/autocomplete/default
+//= require hyrax/autocomplete/linked_data
+//= require hyrax/autocomplete/resource
+//= require hyrax/relationships
+//= require hyrax/select_work_type
+//= require hyrax/collections
+//= require hyrax/collections_v2
+//= require hyrax/collection_types
+//= require hyrax/collections_utils
+//= require hyrax/select_collection_type
+//= require hydra-editor/hydra-editor
+//= require nestable
+//= require hyrax/file_manager/sorting
+//= require hyrax/file_manager/save_manager
+//= require hyrax/file_manager/member
+//= require hyrax/file_manager
+//= require hyrax/authority_select
+//= require hyrax/sort_and_per_page
+//= require hyrax/thumbnail_select
+//= require hyrax/batch_select
+//= require hyrax/tabbed_form
+//= require hyrax/turbolinks_events
+//= require hyrax/i18n_helper
+//= require hyrax/collapse
+//= require hyrax/skip_to_content
+
+// this needs to be after batch_select so that the form ids get setup correctly
+//= require hyrax/batch_edit

--- a/app/assets/stylesheets/curate_hyrax.scss
+++ b/app/assets/stylesheets/curate_hyrax.scss
@@ -1,0 +1,32 @@
+@import 'hydra-editor/multi_value_fields';
+@import 'hyrax/variables', 'hyrax/file_sets', 'hyrax/settings', 'hyrax/header',
+  'hyrax/styles', 'hyrax/file-listing', 
+  'hyrax/nestable', 'hyrax/collections', 'hyrax/collection_types',
+  'hyrax/batch-edit', 'hyrax/home-page', 'hyrax/featured', 'hyrax/usage-stats',
+  'hyrax/catalog', 'hyrax/buttons', 'hyrax/tinymce', 'hyrax/proxy-rights',
+  'hyrax/file-show', 'hyrax/work-show', 'hyrax/modal', 'hyrax/forms',
+  'hyrax/form', 'hyrax/file_manager', 'hyrax/form-progress', 'hyrax/positioning',
+  'hyrax/fixedsticky', 'hyrax/file_upload', 'hyrax/representative-media',
+  'hyrax/footer', 'hyrax/select_work_type', 'hyrax/users', 'hyrax/dashboard',
+  'hyrax/sidebar', 'hyrax/controlled_vocabulary', 'hyrax/accessibility',
+  'hyrax/recent', 'hyrax/viewer', 'hyrax/breadcrumbs';
+@import 'typeahead';
+@import 'sharing_buttons';
+
+/* This class is to workaround an issue in which Bootstrap requires a div to display a tooltip
+ * on a disabled button. Using a span instead of a div would be ideal but unfortunately it does
+ * not render the tooltip correctly in all browsers (e.g. in Chrome the tooltip is detected in
+ * the wrong position). This class forces the div to render inline, just like a span.
+ *
+ * More info:
+ *    http://getbootstrap.com/css/#responsive-utilities-classes
+ *    http://stackoverflow.com/a/19938049/446681
+ */
+.visible-all-inline-block {
+  display: inline-block;
+}
+
+.controlled_vocabulary {
+  @extend .multi_value;
+}
+

--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -13,5 +13,7 @@
 @import "blacklight_gallery/masonry";
 @import "blacklight_gallery/slideshow";
 @import "blacklight_gallery/osd_viewer";
-@import 'hyrax/hyrax';
+/* ...
+ *= require curate_hyrax
+*/
 @import 'hyrax/login_signup';


### PR DESCRIPTION
- app/assets/javascripts/application.js: points to our customized Javascript instead of the Gem file.
- app/assets/javascripts/curate_hyrax.js: brings in the hyrax.js file from Hyrax 3.1.0, minus the browse_everything code.
- app/assets/stylesheets/curate_hyrax.scss: creates an alternate version of Hyrax v3.1.0 hyrax.scss that removes browse_everything code.
- app/assets/stylesheets/hyrax.scss: inserts a requirement to our code in the exact place the last call was made.

No screenshots necessary.