### PR TITLE
Fixes errors for CollectionType model and success? deprecation (#1680).

### DIFF
--- a/app/models/curate/collection_type.rb
+++ b/app/models/curate/collection_type.rb
@@ -6,6 +6,7 @@
 # was also examined and deemed to not have any alterations that would affect us.gst
 module Curate
   class CollectionType < Hyrax::CollectionType
+    after_initialize :configure
     USER_COLLECTION_DEFAULT_TITLE = 'Library Collection'
 
     # If a Curate::CollectionType already exists, ensure it adheres to expectations and return it.
@@ -18,11 +19,6 @@ module Curate
       end
       new_library_collection_type = Curate::CollectionType.new
       new_library_collection_type
-    end
-
-    def initialize
-      super
-      configure
     end
 
     def configure

--- a/spec/controllers/characterization_controller_spec.rb
+++ b/spec/controllers/characterization_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CharacterizationController, type: :controller, clean: true do
       it 'queues up characterize job' do
         expect(ReCharacterizeJob).to receive(:perform_later).with(file_set: file_set, user: user.uid)
         post :re_characterize, params: { file_set_id: file_set.id }, xhr: true
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end

--- a/spec/controllers/derivates_controller_spec.rb
+++ b/spec/controllers/derivates_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DerivativesController, type: :controller, clean: true do
       it "queues up fileset cleanup job" do
         expect(FileSetCleanUpJob).to receive(:perform_later).with(file_set.id)
         post :clean_up, params: { file_set_id: file_set }, xhr: true
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Hyrax::DownloadsController, :clean do
 
           it 'sends requested file content' do
             get :show, params: { id: file_set, file: 'thumbnail' }
-            expect(response).to be_success
+            expect(response).to be_successful
             expect(response.body).to eq content
             expect(response.headers['Content-Length']).to eq "0"
             expect(response.headers['Accept-Ranges']).to eq "bytes"

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Hyrax::FileSetsController, :clean do
         expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.file_set.browse_view'), Rails.application.routes.url_helpers.hyrax_file_set_path(file_set, locale: 'en'))
         get :edit, params: { id: file_set }
 
-        expect(response).to be_success
+        expect(response).to be_successful
         expect(assigns[:file_set]).to eq file_set
         expect(assigns[:version_list]).to be_kind_of Hyrax::VersionListPresenter
         expect(assigns[:parent]).to eq parent
@@ -312,7 +312,7 @@ RSpec.describe Hyrax::FileSetsController, :clean do
       describe '#show' do
         it 'allows access to the file' do
           get :show, params: { id: public_file_set }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
     end
@@ -347,7 +347,7 @@ RSpec.describe Hyrax::FileSetsController, :clean do
       it 'allows access to public files' do
         expect(controller).to receive(:additional_response_formats).with(ActionController::MimeResponds::Collector)
         get :show, params: { id: public_file_set }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end

--- a/spec/controllers/hyrax/fixity_checks_controller_spec.rb
+++ b/spec/controllers/hyrax/fixity_checks_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Hyrax::FixityChecksController do
       end
 
       it "returns result and redirects to file_set page" do
-        expect(response).to be_success
+        expect(response).to be_successful
         expect(response.redirect_url).to include "/concern/file_sets/#{file_set.id}"
       end
     end

--- a/spec/controllers/hyrax/uploads_controller_spec.rb
+++ b/spec/controllers/hyrax/uploads_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Hyrax::UploadsController do
       end
       it "is successful with pmf" do
         post :create, params: { preservation_master_file: file, format: 'json' }
-        expect(response).to be_success
+        expect(response).to be_successful
         expect(assigns(:upload)).to be_kind_of Hyrax::UploadedFile
         expect(assigns(:upload)).to be_persisted
         expect(assigns(:upload).user).to eq user

--- a/spec/controllers/manifest_regeneration_controller_spec.rb
+++ b/spec/controllers/manifest_regeneration_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ManifestRegenerationController, type: :controller, clean: true do
         expect(ManifestBuilderService).to receive(:build_manifest).with(presenter: presenter, curation_concern: work)
         post :regen_manifest, params: { work_id: work }, xhr: true
         expect(File.exist?("./tmp/abc123_#{work.id}")).to be_falsey
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end


### PR DESCRIPTION
- app/models/curate/collection_type.rb: changes the super plus method to an `after_initialize` callback.
- spec/*: replaces `success?` with `successful?` to eliminate deprecation warnings.