### PR TITLE
Fixes errors.

### DIFF
--- a/app/controllers/hyrax/curate_generic_works_controller.rb
+++ b/app/controllers/hyrax/curate_generic_works_controller.rb
@@ -37,7 +37,7 @@ module Hyrax
 
     def manifest
       headers['Access-Control-Allow-Origin'] = '*'
-      render json: ManifestBuilderService.build_manifest(presenter: presenter, curation_concern: _curation_concern_type.find(params[:id]))
+      render json: ::ManifestBuilderService.build_manifest(presenter: presenter, curation_concern: _curation_concern_type.find(params[:id]))
     end
 
     # [Hyrax-overwrite-v3.0.0.pre.rc1] Restrict deletion to admins only

--- a/app/models/concerns/hyrax/file_metadata.rb
+++ b/app/models/concerns/hyrax/file_metadata.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+# [Hyrax-overwrite-v3.1.0] expands the #uri_for use options.
+module Hyrax
+  class FileMetadata < Valkyrie::Resource
+    GENERIC_MIME_TYPE = 'application/octet-stream'
+
+    ##
+    # Constants for PCDM Use URIs; use these constants in place of hard-coded
+    # URIs in the `::Valkyrie::Vocab::PCDMUse` vocabulary.
+    module Use
+      ORIGINAL_FILE = ::Valkyrie::Vocab::PCDMUse.OriginalFile
+      EXTRACTED_TEXT = ::Valkyrie::Vocab::PCDMUse.ExtractedText
+      THUMBNAIL = ::Valkyrie::Vocab::PCDMUse.ThumbnailImage
+      PRESERVATION_FILE = ::Valkyrie::Vocab::PCDMUse.PreservationFile
+      SERVICE_FILE = ::Valkyrie::Vocab::PCDMUse.ServiceFile
+      INTERMEDIATE_FILE = ::Valkyrie::Vocab::PCDMUse.IntermediateFile
+      TRANSCRIPT_FILE = ::Valkyrie::Vocab::PCDMUse.Transcript
+
+      ##
+      # @param use [RDF::URI, Symbol]
+      #
+      # @return [RDF::URI]
+      # @raise [ArgumentError] if no use is known for the argument
+      def uri_for(use:)
+        case use
+        when RDF::URI
+          use
+        when :original_file
+          ORIGINAL_FILE
+        when :extracted_file
+          EXTRACTED_TEXT
+        when :thumbnail_file
+          THUMBNAIL
+        when :preservation_master_file
+          PRESERVATION_FILE
+        when :service_file
+          SERVICE_FILE
+        when :intermediate_file
+          INTERMEDIATE_FILE
+        when :transcript_file
+          TRANSCRIPT_FILE
+        when :extracted
+          EXTRACTED_TEXT
+        else
+          raise ArgumentError, "No PCDM use is recognized for #{use}"
+        end
+      end
+      module_function :uri_for
+    end
+
+    attribute :file_identifier, Valkyrie::Types::ID # id of the file stored by the storage adapter
+    attribute :alternate_ids, Valkyrie::Types::Set.of(Valkyrie::Types::ID) # id of the Hydra::PCDM::File which holds metadata and the file in ActiveFedora
+    attribute :file_set_id, ::Valkyrie::Types::ID # id of parent file set resource
+
+    # all remaining attributes are on AF::File metadata_node unless otherwise noted
+    attribute :label, ::Valkyrie::Types::Set
+    attribute :original_filename, ::Valkyrie::Types::String
+    attribute :mime_type, ::Valkyrie::Types::String.default(GENERIC_MIME_TYPE)
+    attribute :type, ::Valkyrie::Types::Set.default([Use::ORIGINAL_FILE].freeze)
+
+    # attributes set by fits
+    attribute :format_label, ::Valkyrie::Types::Set
+    attribute :size, ::Valkyrie::Types::Set
+    attribute :well_formed, ::Valkyrie::Types::Set
+    attribute :valid, ::Valkyrie::Types::Set
+    attribute :date_created, ::Valkyrie::Types::Set
+    attribute :fits_version, ::Valkyrie::Types::Set
+    attribute :exif_version, ::Valkyrie::Types::Set
+    attribute :checksum, ::Valkyrie::Types::Set
+
+    # shared attributes across multiple file types
+    attribute :frame_rate, ::Valkyrie::Types::Set # audio, video
+    attribute :bit_rate, ::Valkyrie::Types::Set # audio, video
+    attribute :duration, ::Valkyrie::Types::Set # audio, video
+    attribute :sample_rate, ::Valkyrie::Types::Set # audio, video
+
+    attribute :height, ::Valkyrie::Types::Set # image, video
+    attribute :width, ::Valkyrie::Types::Set # image, video
+
+    # attributes set by fits for audio files
+    attribute :bit_depth, ::Valkyrie::Types::Set
+    attribute :channels, ::Valkyrie::Types::Set
+    attribute :data_format, ::Valkyrie::Types::Set
+    attribute :offset, ::Valkyrie::Types::Set
+
+    # attributes set by fits for documents
+    attribute :file_title, ::Valkyrie::Types::Set
+    attribute :creator, ::Valkyrie::Types::Set
+    attribute :page_count, ::Valkyrie::Types::Set
+    attribute :language, ::Valkyrie::Types::Set
+    attribute :word_count, ::Valkyrie::Types::Set
+    attribute :character_count, ::Valkyrie::Types::Set
+    attribute :line_count, ::Valkyrie::Types::Set
+    attribute :character_set, ::Valkyrie::Types::Set
+    attribute :markup_basis, ::Valkyrie::Types::Set
+    attribute :markup_language, ::Valkyrie::Types::Set
+    attribute :paragraph_count, ::Valkyrie::Types::Set
+    attribute :table_count, ::Valkyrie::Types::Set
+    attribute :graphics_count, ::Valkyrie::Types::Set
+
+    # attributes set by fits for images
+    attribute :byte_order, ::Valkyrie::Types::Set
+    attribute :compression, ::Valkyrie::Types::Set
+    attribute :color_space, ::Valkyrie::Types::Set
+    attribute :profile_name, ::Valkyrie::Types::Set
+    attribute :profile_version, ::Valkyrie::Types::Set
+    attribute :orientation, ::Valkyrie::Types::Set
+    attribute :color_map, ::Valkyrie::Types::Set
+    attribute :image_producer, ::Valkyrie::Types::Set
+    attribute :capture_device, ::Valkyrie::Types::Set
+    attribute :scanning_software, ::Valkyrie::Types::Set
+    attribute :gps_timestamp, ::Valkyrie::Types::Set
+    attribute :latitude, ::Valkyrie::Types::Set
+    attribute :longitude, ::Valkyrie::Types::Set
+
+    # attributes set by fits for video
+    attribute :aspect_ratio, ::Valkyrie::Types::Set
+
+    # @param [ActionDispatch::Http::UploadedFile] file
+    def self.for(file:)
+      new(label: file.original_filename,
+          original_filename: file.original_filename,
+          mime_type: file.content_type)
+    end
+
+    ##
+    # @return [Boolean]
+    def original_file?
+      type.include?(Use::ORIGINAL_FILE)
+    end
+
+    ##
+    # @return [Boolean]
+    def thumbnail_file?
+      type.include?(Use::THUMBNAIL)
+    end
+
+    ##
+    # @return [Boolean]
+    def extracted_file?
+      type.include?(Use::EXTRACTED_TEXT)
+    end
+
+    def title
+      label
+    end
+
+    def download_id
+      id
+    end
+
+    def valid?
+      file.valid?(size: size.first, digests: { sha256: checksum&.first&.sha256 })
+    end
+
+    ##
+    # @deprecated get content from #file instead
+    #
+    # @return [#to_s]
+    def content
+      Deprecation.warn('This convienince method has been deprecated. ' \
+                       'Retrieve the file from the storage adapter instead.')
+      file.read
+    rescue Valkyrie::StorageAdapter::FileNotFound
+      ''
+    end
+
+    def file
+      Hyrax.storage_adapter.find_by(id: file_identifier)
+    end
+  end
+end

--- a/app/models/concerns/hyrax/file_set/characterization.rb
+++ b/app/models/concerns/hyrax/file_set/characterization.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# [Hyrax-overwrite-v3.0.0.pre.rc1] Change `characterization_proxy`
+# [Hyrax-overwrite-v3.1.0] Change `characterization_proxy`
 # This module points the FileSet to the location of the technical metdata.
 # By default, the file holding the metadata is :preservation_master_file and the terms
 # are listed under ::characterization_terms.

--- a/spec/actors/hyrax/actors/curate_generic_work_actor_spec.rb
+++ b/spec/actors/hyrax/actors/curate_generic_work_actor_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Hyrax::Actors::CurateGenericWorkActor do
     context 'success' do
       it "invokes the after_create_concern callback, creates work, and its preservation_events" do
         expect(Hyrax.config.callback).to receive(:run)
-          .with(:after_create_concern, curation_concern, user)
+          .with(:after_create_concern, curation_concern, user, warn: false)
         middleware.create(env)
         expect(curation_concern.preservation_event.pluck(:event_type)).to include ['Validation']
         expect(curation_concern.preservation_event.first.outcome).to eq ['Success']
@@ -51,7 +51,7 @@ RSpec.describe Hyrax::Actors::CurateGenericWorkActor do
 
       it "invokes the after_update_metadata callback, updates work, creates modification preservation_event" do
         expect(Hyrax.config.callback).to receive(:run)
-          .with(:after_update_metadata, curation_concern, user)
+          .with(:after_update_metadata, curation_concern, user, warn: false)
         work_actor.update(env)
         expect(curation_concern.preservation_event.pluck(:event_type)).to include ['Modification']
       end


### PR DESCRIPTION
- app/controllers/hyrax/curate_generic_works_controller.rb: makes clear that `ManifestBuilderService` is our own service and not the Hyrax class.
- app/models/concerns/hyrax/file_metadata.rb: addresses our PCDM use cases in the new code.
- app/models/concerns/hyrax/file_set/characterization.rb: updates version number.
- spec/actors/hyrax/actors/curate_generic_work_actor_spec.rb: makes tests aware of new argument.