### PR TITLE
Updates model specs

### DIFF
--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -500,9 +500,9 @@ RSpec.describe Collection, clean: true do
 
       context 'when multiple membership checker returns a non-nil value' do
         before do
-          allow(Hyrax::MultipleMembershipChecker).to receive(:new).with(item: work1).and_return(nil_checker)
-          allow(Hyrax::MultipleMembershipChecker).to receive(:new).with(item: work2).and_return(checker)
-          allow(Hyrax::MultipleMembershipChecker).to receive(:new).with(item: work3).and_return(nil_checker)
+          allow(Hyrax::MultipleMembershipChecker).to receive(:new).with(item: work1.valkyrie_resource).and_return(nil_checker)
+          allow(Hyrax::MultipleMembershipChecker).to receive(:new).with(item: work2.valkyrie_resource).and_return(checker)
+          allow(Hyrax::MultipleMembershipChecker).to receive(:new).with(item: work3.valkyrie_resource).and_return(nil_checker)
           allow(nil_checker).to receive(:check).and_return(nil)
           allow(checker).to receive(:check).and_return(error_message)
         end
@@ -512,9 +512,12 @@ RSpec.describe Collection, clean: true do
         let(:error_message) { 'Error: foo bar' }
 
         it 'fails to add the member' do
-          collection.add_member_objects [work1.id, work2.id, work3.id]
-          collection.save!
-          expect(collection.reload.member_objects).to match_array [work1, work3]
+          begin
+            Hyrax::Collections::CollectionMemberService.add_members_by_ids(collection_id: collection.id,
+                                                                           new_member_ids: [work1.id, work2.id, work3.id],
+                                                                           user: nil)
+          rescue; end # rubocop:disable Lint/SuppressedException
+          expect(collection.reload.member_objects.map(&:id)).to match_array [work1.id.to_s, work3.id.to_s]
         end
       end
     end

--- a/spec/models/concerns/hyrax/collection_behavior_spec.rb
+++ b/spec/models/concerns/hyrax/collection_behavior_spec.rb
@@ -3,15 +3,15 @@
 # [Hyrax-overwrite-v3.1.0]
 require 'rails_helper'
 
-RSpec.describe Hyrax::CollectionBehavior, clean_repo: true do
+RSpec.describe Hyrax::CollectionBehavior, clean: true do
   let(:collection) { FactoryBot.create(:collection_lw) }
-  let(:work) { FactoryBot.valkyrie_create(:hyrax_work) }
+  let(:work) { FactoryBot.create(:public_generic_work) }
 
   describe "#destroy" do
     it "removes the collection id from associated members" do
-      Hyrax::Collections::CollectionMemberService.add_members(collection_id: collection.id,
-                                                              new_members: [work],
-                                                              user: nil)
+      Hyrax::Collections::CollectionMemberService.add_members_by_ids(collection_id: collection.id,
+                                                                     new_member_ids: [work.id],
+                                                                     user: nil)
       collection.save
 
       collection_via_query = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: collection.id, use_valkyrie: false)


### PR DESCRIPTION
Update to collection_spec here is concerning because `item` arg for initialization of the MultipleMembershipChecker class expects a CurateGenericWork which we are providing but is being passed an a Hyrax::Work (valkyrie). I am not sure why this is happening.