### PR TITLE
Updates Characterization Service's spec to expect array (#1680).

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -197,7 +197,6 @@ module Hyrax
 
       def initialize_edit_form
         @parent = @file_set.in_objects.first
-        original = @file_set.original_file
         @version_list = Hyrax::VersionListPresenter.for(file_set: @file_set)
         @groups = current_user.groups
       end

--- a/app/helpers/hyrax/file_set_helper.rb
+++ b/app/helpers/hyrax/file_set_helper.rb
@@ -11,7 +11,7 @@ module Hyrax::FileSetHelper
   #
   # @return [Boolean] whether to display the download link for the given file
   #   set
-  def display_media_download_link?(file_set:)
+  def display_media_download_link?(*)
     Hyrax.config.display_media_download_link?
   end
 

--- a/spec/services/characterization_service_spec.rb
+++ b/spec/services/characterization_service_spec.rb
@@ -21,7 +21,7 @@ describe Hydra::Works::CharacterizationService, :clean do
       # Persist our file with some content and reload
       file.content = "junk"
       expect(file.save).to be true
-      expect(file.reload).to eq({})
+      expect(file.reload).to eq([])
       # Re-check property values
       expect(file.file_size).to eq(["7618"])
       expect(file.file_title).to eq(["sample-file"])


### PR DESCRIPTION
spec/services/characterization_service_spec.rb: I confirmed that the reason this now returns an empty array instead of a hash is because the `reload` method calls a function pulled from ActiveModel's Dirty module, which has changed with an update. The last line of that method (`clear_attribute_changes`) in version 5.1.7 operates on a hash of values and returns an empty hash, fulfilling it's purpose. In version 5.2.6, however, that last line is followed by an each statement that further operates on each attribute, therefore returning an empty array. Since the line of this test is checking to make sure the file reloads as expected and we are not using the return value of reload in our application, changing the expectations here is harmless. Proof: https://github.com/emory-libraries/dlp-curate/commit/629d682a03ec667a8b2a5cb3c5d502529115fe2f .