### PR TITLE
Install Python2 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 orbs:
-    samvera: samvera/circleci-orb@0.3.1
+    samvera: samvera/circleci-orb@1.0.0
 jobs:
     build:
         parameters:
             ruby_version:
                 type: string
-                default: 2.5.3
+                default: 2.7.4
             bundler_version:
                 type: string
                 default: 2.0.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,10 @@ jobs:
             - restore_cache:
                 keys:
                     - v1-yarn-{{ checksum "yarn.lock" }}-{{ checksum "YARN_VERSION" }}
+                    
+            - run:
+                name: Install Python2
+                command: sudo apt-get update && sudo apt-get install -y python2
 
             - run: yarn
 


### PR DESCRIPTION
Until we can figure out our Node/Yarn/Webpacker dependencies, we need Python2 to install our node modules in CI.