### PR TITLE
Corrects the InvalidAuthenticityToken errors related to Collection form (#1780). [DO NOT REVIEW YET]

### DIFF
--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -24,7 +24,7 @@
     <% end %>
   </ul>
 
-  <%= simple_form_for @form, url: [hyrax, :dashboard, @form], html: { class: 'editor nav-safety', data: { behavior: 'collection-form' } } do |f| %>
+  <%= simple_form_for @form, url: [hyrax, :dashboard, @form], html: { class: 'editor nav-safety', data: { behavior: 'collection-form' } }, remote: true do |f| %>
     <div class="tab-content">
       <div id="description" class="tab-pane active">
         <div class="panel panel-default labels">


### PR DESCRIPTION
Either a recent Rails or simple_form update has required that the attribute of `remote: true` be set in the creation of the simple_form. This passes along the already created csrf info to any contained AJAX request (file uploads) so that those requests can send the same csrf details back after AJAX processing. 