### PR TITLE
Turns off Turbolinks cache call on edit page links (#1780).

### DIFF
--- a/app/helpers/hyrax/ability_override_helper.rb
+++ b/app/helpers/hyrax/ability_override_helper.rb
@@ -20,7 +20,8 @@ module Hyrax
         path,
         id:    "permission_#{document.id}",
         class: 'visibility-link',
-        title: "#{t('hyrax.works.form.tab.share')}: #{document.title_or_label}"
+        title: "#{t('hyrax.works.form.tab.share')}: #{document.title_or_label}",
+        data:  { turbolinks: false }
       )
     end
   end

--- a/app/views/hyrax/dashboard/collections/_show_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_actions.html.erb
@@ -4,7 +4,8 @@
     <%= link_to t('hyrax.collection.actions.edit.label'),
                 hyrax.edit_dashboard_collection_path(presenter),
                 title: t('hyrax.collection.actions.edit.desc'),
-                class: 'btn btn-primary' %>
+                class: 'btn btn-primary', 
+                data:  { turbolinks: false } %>
 <% end %>
 
 <% if presenter.collection_type_is_nestable? && presenter.user_can_nest_collection? && current_user.admin? %>

--- a/app/views/hyrax/my/_collection_action_menu.html.erb
+++ b/app/views/hyrax/my/_collection_action_menu.html.erb
@@ -19,7 +19,8 @@
       <li role="menuitem" tabindex="-1">
         <%= link_to hyrax.edit_dashboard_collection_path(id),
                     class: 'itemicon itemedit',
-                    title: t("hyrax.dashboard.my.action.edit_collection")  do %>
+                    title: t("hyrax.dashboard.my.action.edit_collection"), 
+                    data: { turbolinks: false }  do %>
           <%= t("hyrax.dashboard.my.action.edit_collection") %>
         <% end %>
       </li>


### PR DESCRIPTION
All: adds `data:  { turbolinks: false }` to the links, disabling the use of cache to load the edit destination pages.