### PR TITLE
Loads AWS Fixity Events from CSV (#1658).

### DIFF
--- a/app/jobs/process_aws_fixity_preservation_events_job.rb
+++ b/app/jobs/process_aws_fixity_preservation_events_job.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ProcessAwsFixityPreservationEventsJob < Hyrax::ApplicationJob
+  include PreservationEvents
+
+  def perform(csv)
+    lines = CSV.read(csv, headers: true)
+
+    Rails.logger.info "AWS Fixity Event processing of #{csv} started at #{DateTime.current}"
+    process_lines(lines)
+    Rails.logger.info "AWS Fixity Event processing of #{csv} ended at #{DateTime.current}"
+  end
+
+  private
+
+    def process_lines(lines)
+      lines.each do |l|
+        event_obj = AwsFixityEvent.new(l)
+        next if event_obj.sha1.blank?
+        file_set = FileSet.where(sha1_tesim: event_obj.sha1)&.first
+        next if file_set.blank?
+        event = event_obj.process_event
+
+        create_preservation_event(file_set, event)
+      end
+    end
+end

--- a/app/jobs/process_aws_fixity_preservation_events_job.rb
+++ b/app/jobs/process_aws_fixity_preservation_events_job.rb
@@ -7,21 +7,19 @@ class ProcessAwsFixityPreservationEventsJob < Hyrax::ApplicationJob
     lines = CSV.read(csv, headers: true)
 
     Rails.logger.info "AWS Fixity Event processing of #{csv} started at #{DateTime.current}"
-    process_lines(lines)
+    lines.each { |l| process_line(l) }
     Rails.logger.info "AWS Fixity Event processing of #{csv} ended at #{DateTime.current}"
   end
 
   private
 
-    def process_lines(lines)
-      lines.each do |l|
-        event_obj = AwsFixityEvent.new(l)
-        next if event_obj.sha1.blank?
-        file_set = FileSet.where(sha1_tesim: event_obj.sha1)&.first
-        next if file_set.blank?
-        event = event_obj.process_event
+    def process_line(line)
+      event_obj = AwsFixityEvent.new(line)
+      return if event_obj.sha1.blank?
+      file_set = FileSet.where(sha1_tesim: event_obj.sha1)&.first
+      return if file_set.blank?
+      event = event_obj.process_event
 
-        create_preservation_event(file_set, event)
-      end
+      create_preservation_event(file_set, event)
     end
 end

--- a/app/lib/preservation_events.rb
+++ b/app/lib/preservation_events.rb
@@ -7,7 +7,7 @@ module PreservationEvents
   # @param event - hash with all event requirements (details, start, type, user, outcome, software_version)
   def create_preservation_event(object, event)
     object.preservation_event_attributes = [{ event_details:    event['details'],
-                                              event_end:        DateTime.current,
+                                              event_end:        event['end'] || DateTime.current,
                                               event_start:      event['start'],
                                               event_type:       event['type'],
                                               initiating_user:  event['user'],

--- a/app/models/aws_fixity_event.rb
+++ b/app/models/aws_fixity_event.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AwsFixityEvent
+  attr_reader :sha1
+
+  def initialize(line)
+    @sha1 = line['event_sha1']&.strip
+    @aws_bucket = line['event_bucket']&.strip
+    @fixity_start = line['event_start']&.strip
+    @fixity_end = line['event_end']&.strip
+    @event_type = line['event_type']&.strip || 'Fixity Check'
+    @user = line['initiating_user']&.strip || 'AWS Serverless Fixity'
+    @outcome = line['outcome']&.strip
+    @software_version = line['software_version']&.strip || 'Serverless Fixity v1.0'
+    @details_outcome = @outcome == 'failed' || @outcome.blank? ? 'check failed' : 'intact'
+  end
+
+  def process_event
+    { 'type' => @event_type, 'start' => @fixity_start, 'end' => @fixity_end,
+      'details' => "Fixity #{@details_outcome} for sha1: #{@sha1} in #{@aws_bucket}",
+      'software_version' => @software_version, 'user' => @user, 'outcome' => @outcome }
+  end
+end

--- a/app/views/background_jobs/new.html.erb
+++ b/app/views/background_jobs/new.html.erb
@@ -32,6 +32,15 @@
         <%= file_field_tag 'preservation_csv', class: 'files', :accept => 'text/csv' %>
       </td>
     </tr>
+    <tr>
+      <td>
+        <%= radio_button_tag :jobs, 'aws_fixity', false, id: 'aws_fixity' %>
+        <%= label :job_cleanup, 'Load AWS Fixity Preservation Events' %>
+      </td>
+      <td>
+        <%= file_field_tag 'aws_fixity_csv', class: 'files', :accept => 'text/csv' %>
+      </td>
+    </tr>
   </table>
   <table class="table table-striped">
     <tr>

--- a/lib/tasks/aws_fixity_check.rake
+++ b/lib/tasks/aws_fixity_check.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+namespace :curate do
+  namespace :file_sets do
+    desc "Process AWS Fixity Checks' Preservation Events"
+    task aws_fixity_check: :environment do
+      csv = ENV['csv']
+      valid_args = File.extname(csv) == '.csv'
+
+      if valid_args
+        ProcessAwsFixityPreservationEventsJob.perform_later(csv)
+        puts "Queued background jobs to process AWS Fixity preservation events for #{csv}"
+      else
+        abort "ERROR: file attached must be a CSV file."
+      end
+    end
+  end
+end

--- a/spec/fixtures/csv_import/aws_fixity_test.csv
+++ b/spec/fixtures/csv_import/aws_fixity_test.csv
@@ -1,0 +1,2 @@
+event_id,event_bucket,event_sha1,event_start,event_end,event_type,fileset_id,initiating_user,outcome,software_version,workflow_id
+,fedora-cor-arch-binaries,f43b4b662480a4477100bf3de73804f8efbcba30,2022-03-09 14:11:25,2022-03-09 14:11:35,Fixity Check,,AWS Serverless Fixity,Success,Serverless Fixity v1.0,

--- a/spec/jobs/process_aws_fixity_preservation_events_job_spec.rb
+++ b/spec/jobs/process_aws_fixity_preservation_events_job_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ProcessAwsFixityPreservationEventsJob, :clean do
+  let(:user) { FactoryBot.create(:user) }
+  let(:file_set) { FactoryBot.create(:file_set) }
+  let(:csv) { fixture_path + '/csv_import/aws_fixity_test.csv' }
+  let(:pmf) { File.open(fixture_path + '/book_page/0003_preservation_master.tif') }
+
+  before do
+    Hydra::Works::AddFileToFileSet.call(file_set, pmf, :preservation_master_file)
+    allow(FileSet).to receive(:where)
+      .with(sha1_tesim: 'f43b4b662480a4477100bf3de73804f8efbcba30')
+      .and_return([file_set])
+  end
+
+  describe "called with perform_now" do
+    it 'changes the number of preversation_events on the file_set' do
+      expect { described_class.perform_now(csv) }
+        .to change { file_set.preservation_event.size }.from(1).to(2)
+    end
+
+    it 'adds the expected preservation event' do
+      described_class.perform_now(csv)
+
+      expect(file_set.preservation_event.pluck(:event_details))
+        .to include(["Fixity intact for sha1: f43b4b662480a4477100bf3de73804f8efbcba30 in fedora-cor-arch-binaries"])
+      expect(file_set.preservation_event.pluck(:event_type)).to include(["Fixity Check"])
+      expect(file_set.preservation_event.pluck(:initiating_user)).to include(["AWS Serverless Fixity"])
+      expect(file_set.preservation_event.pluck(:outcome)).to include(["Success"])
+      expect(file_set.preservation_event.pluck(:software_version))
+        .to include(["Serverless Fixity v1.0"])
+      expect(file_set.preservation_event.pluck(:event_start)).to include(["2022-03-09 14:11:25"])
+      expect(file_set.preservation_event.pluck(:event_end)).to include(["2022-03-09 14:11:35"])
+    end
+  end
+end

--- a/spec/models/aws_fixity_event_spec.rb
+++ b/spec/models/aws_fixity_event_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe AwsFixityEvent, :clean, type: :model do
+  let(:full_line) do
+    { 'event_sha1': '3a1759f3e5591f0ef19c7ce67365f0a2dc6be076', 'event_bucket': 'fedora-cor-arch-binaries',
+      'event_start': '2022-03-09 14:11:25', 'event_end': '2022-03-09 14:11:35',
+      'event_type': 'AWS Fixity Check', 'initiating_user': 'AWS Fixity Tool',
+      'outcome': 'succeeded', 'software_version': 'Serverless Fixity v1.*' }.with_indifferent_access
+  end
+  let(:empty_line) { {} }
+  let(:full_line_object) { described_class.new(full_line) }
+  let(:empty_line_object) { described_class.new(empty_line) }
+  let(:full_line_results) do
+    ["3a1759f3e5591f0ef19c7ce67365f0a2dc6be076", "fedora-cor-arch-binaries", "2022-03-09 14:11:25",
+     "2022-03-09 14:11:35", "AWS Fixity Check", "AWS Fixity Tool", "succeeded",
+     "Serverless Fixity v1.*", "intact"]
+  end
+  let(:empty_line_results) do
+    [nil, nil, nil, nil, "Fixity Check", "AWS Serverless Fixity", nil, "Serverless Fixity v1.0",
+     "check failed"]
+  end
+  let(:full_line_hash) do
+    { "type" => "AWS Fixity Check", "start" => "2022-03-09 14:11:25", "end" => "2022-03-09 14:11:35",
+      "details" => "Fixity intact for sha1: 3a1759f3e5591f0ef19c7ce67365f0a2dc6be076 in fedora-cor-arch-binaries",
+      "software_version" => "Serverless Fixity v1.*", "user" => "AWS Fixity Tool",
+      "outcome" => "succeeded" }
+  end
+  let(:empty_line_hash) do
+    { "type" => "Fixity Check", "start" => nil, "end" => nil, "details" => "Fixity check failed for sha1:  in ",
+      "software_version" => "Serverless Fixity v1.0", "user" => "AWS Serverless Fixity",
+      "outcome" => nil }
+  end
+
+  describe '#new attributes' do
+    context 'full line of attributes' do
+      it 'contains the expected variables' do
+        expect([full_line_object.sha1] + pull_non_reader_vars(full_line_object))
+          .to match_array(full_line_results)
+      end
+    end
+
+    context 'empty line of attributes' do
+      it 'contains the expected variables' do
+        expect([empty_line_object.sha1] + pull_non_reader_vars(empty_line_object))
+          .to match_array(empty_line_results)
+      end
+    end
+  end
+
+  describe '#process_event' do
+    context 'full line of attributes' do
+      it 'returns the expected hash' do
+        expect(full_line_object.process_event).to eq(full_line_hash)
+      end
+    end
+
+    context ' empty line of attributes' do
+      it 'returns the expected hash' do
+        expect(empty_line_object.process_event).to eq(empty_line_hash)
+      end
+    end
+  end
+
+  def pull_non_reader_vars(obj)
+    ['@aws_bucket', '@fixity_start', '@fixity_end', '@event_type', '@user', '@outcome',
+     '@software_version', '@details_outcome'].map do |var|
+      obj.instance_variable_get(var.to_sym)
+    end
+  end
+end


### PR DESCRIPTION
- app/controllers/background_jobs_controller.rb: adds new CSV batch processing to the Background Jobs controller, as well as refactors the similar csv actions to a generic action call.
- app/jobs/process_aws_fixity_preservation_events_job.rb: creates a background job for batch AWS Fixity event processing.
- app/lib/preservation_events.rb: allows PreservationEvents to receive a variable for event start.
- app/models/aws_fixity_event.rb: initiates a class to properly process and test event hash structure.
- app/views/background_jobs/new.html.erb: adds the new background option to the view.
- lib/tasks/aws_fixity_check.rake: provides an option to process CSVs through a rake task.
- spec/*: tests all aspects of the new tool.
<img width="1342" alt="Screen Shot 2022-03-09 at 10 45 09 AM" src="https://user-images.githubusercontent.com/18330149/157707947-b9c033c5-b872-4e1a-a902-367fd24d248b.png">
<img width="1269" alt="Screen Shot 2022-03-10 at 11 22 05 AM" src="https://user-images.githubusercontent.com/18330149/157707950-79d9f636-f5ab-44d7-96b8-5f5687411d0b.png">

