### PR TITLE
Refines the AWS details text (#1658).

### DIFF
--- a/app/models/aws_fixity_event.rb
+++ b/app/models/aws_fixity_event.rb
@@ -17,7 +17,7 @@ class AwsFixityEvent
 
   def process_event
     { 'type' => @event_type, 'start' => @fixity_start, 'end' => @fixity_end,
-      'details' => "Fixity #{@details_outcome} for sha1: #{@sha1} in #{@aws_bucket}",
+      'details' => "Fixity #{@details_outcome} for sha1:#{@sha1} in #{@aws_bucket}",
       'software_version' => @software_version, 'user' => @user, 'outcome' => @outcome }
   end
 end

--- a/spec/jobs/process_aws_fixity_preservation_events_job_spec.rb
+++ b/spec/jobs/process_aws_fixity_preservation_events_job_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ProcessAwsFixityPreservationEventsJob, :clean do
       described_class.perform_now(csv)
 
       expect(file_set.preservation_event.pluck(:event_details))
-        .to include(["Fixity intact for sha1: f43b4b662480a4477100bf3de73804f8efbcba30 in fedora-cor-arch-binaries"])
+        .to include(["Fixity intact for sha1:f43b4b662480a4477100bf3de73804f8efbcba30 in fedora-cor-arch-binaries"])
       expect(file_set.preservation_event.pluck(:event_type)).to include(["Fixity Check"])
       expect(file_set.preservation_event.pluck(:initiating_user)).to include(["AWS Serverless Fixity"])
       expect(file_set.preservation_event.pluck(:outcome)).to include(["Success"])

--- a/spec/models/aws_fixity_event_spec.rb
+++ b/spec/models/aws_fixity_event_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe AwsFixityEvent, :clean, type: :model do
   end
   let(:full_line_hash) do
     { "type" => "AWS Fixity Check", "start" => "2022-03-09 14:11:25", "end" => "2022-03-09 14:11:35",
-      "details" => "Fixity intact for sha1: 3a1759f3e5591f0ef19c7ce67365f0a2dc6be076 in fedora-cor-arch-binaries",
+      "details" => "Fixity intact for sha1:3a1759f3e5591f0ef19c7ce67365f0a2dc6be076 in fedora-cor-arch-binaries",
       "software_version" => "Serverless Fixity v1.*", "user" => "AWS Fixity Tool",
       "outcome" => "Success" }
   end
   let(:empty_line_hash) do
-    { "type" => "Fixity Check", "start" => nil, "end" => nil, "details" => "Fixity check failed for sha1:  in ",
+    { "type" => "Fixity Check", "start" => nil, "end" => nil, "details" => "Fixity check failed for sha1: in ",
       "software_version" => "Serverless Fixity v1.0", "user" => "AWS Serverless Fixity",
       "outcome" => nil }
   end


### PR DESCRIPTION
All: removes space from in-between sha1 label and value, per request.