### PR TITLE
Updates the affected methods of Hyrax::CollectionPresenter (#1868).

### DIFF
--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -182,10 +182,10 @@ module Hyrax
     def logo_record
       CollectionBrandingInfo.where(collection_id: id, role: "logo")
                             .select(:local_path, :alt_text, :target_url).map do |logo|
-        { alttext: logo.alt_text,
-          file: File.split(logo.local_path).last,
+        { alttext:       logo.alt_text,
+          file:          File.split(logo.local_path).last,
           file_location: "/#{logo.local_path.split('/')[-4..-1].join('/')}",
-          linkurl: logo.target_url }
+          linkurl:       logo.target_url }
       end
     end
 

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -173,7 +173,7 @@ module Hyrax
     end
 
     ##
-    # @return [#to_s, nil] a download path for the banner file
+    # @return [String, nil] a download path for the banner file
     def banner_file
       banner = CollectionBrandingInfo.find_by(collection_id: id, role: "banner")
       "/" + banner.local_path.split("/")[-4..-1].join("/") if banner


### PR DESCRIPTION
Updates the methods that perfectly match the original version's functions. 

Note: Collection Branding is updated here and may be worthwhile revisiting this file if we encounter problems displaying the collections' banners.