### PR TITLE
Updates the affected methods of FixityCheckJob (#1863).

### DIFF
--- a/app/jobs/fixity_check_job.rb
+++ b/app/jobs/fixity_check_job.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# [Hyrax-overwrite-v3.0.0.pre.rc1]
+# [Hyrax-overwrite-v3.4.1]
 # Adds fixity_check preservation_event
 
 require 'sidekiq-limit_fetch'
@@ -7,7 +7,7 @@ require 'sidekiq-limit_fetch'
 class FixityCheckJob < Hyrax::ApplicationJob
   queue_as :fixity_check_job
   include PreservationEvents
-  # A Job class that runs a fixity check (using ActiveFedora::FixityService,
+  # A Job class that runs a fixity check (using Hyrax.config.fixity_service)
   # which contacts fedora and requests a fixity check), and stores the results
   # in an ActiveRecord ChecksumAuditLog row. It also prunes old ChecksumAuditLog
   # rows after creating a new one, to keep old ones you don't care about from
@@ -32,43 +32,33 @@ class FixityCheckJob < Hyrax::ApplicationJob
   # @param file_set_id [FileSet] the id for FileSet parent object of URI being checked.
   # @param file_id [String] File#id, used for logging/reporting.
   def perform(uri, file_set_id:, file_id:, initiating_user:)
-    uri = uri.to_s # sometimes we get an RDF::URI gah
-    log = run_check(file_set_id, file_id, uri, initiating_user)
-
-    if log.failed? && Hyrax.config.callback.set?(:after_fixity_check_failure)
+    run_check(file_set_id, file_id, uri, initiating_user).tap do |audit|
+      result   = audit.failed? ? :failure : :success
       file_set = ::FileSet.find(file_set_id)
-      Hyrax.config.callback.run(:after_fixity_check_failure,
-                                file_set,
-                                checksum_audit_log: log)
-    end
 
-    log
+      Hyrax.publisher.publish('file.set.audited', file_set: file_set, audit_log: audit, result: result)
+
+      # @todo remove this callback call for Hyrax 4.0.0
+      if audit.failed? && Hyrax.config.callback.set?(:after_fixity_check_failure)
+        Hyrax.config.callback.run(:after_fixity_check_failure,
+                                  file_set,
+                                  checksum_audit_log: audit, warn: false)
+      end
+    end
   end
 
   private
 
     def run_check(file_set_id, file_id, uri, initiating_user)
       event_start = DateTime.current
-      service = ActiveFedora::FixityService.new(uri)
-      begin
-        fixity_ok = service.check
-        expected_result = service.expected_message_digest
-      rescue Ldp::NotFound
-        # Either the #check or #expected_message_digest could raise this exception
-        error_msg = 'resource not found'
-      end
+      service = fixity_service_for(id: uri)
+      expected_result = service.expected_message_digest
+      fixity_ok = service.check
 
-      log = ChecksumAuditLog.create_and_prune!(passed: fixity_ok, file_set_id: file_set_id, checked_uri: uri, file_id: file_id, expected_result: expected_result)
-      file_set_preservation_event(log, file_set_id, file_id, event_start, initiating_user)
-      # Note that the after_fixity_check_failure will be called if the fixity check fail. This
-      # logging is for additional information related to the failure. Wondering if we should
-      # also include the error message?
-      logger.error "FIXITY CHECK FAILURE: Fixity failed for #{uri} #{error_msg}: #{log}" unless fixity_ok
-      log
-    end
-
-    def logger
-      Hyrax.logger
+      file_set_preservation_event(fixity_ok, file_set_id, file_id, event_start, initiating_user)
+      ChecksumAuditLog.create_and_prune!(passed: fixity_ok, file_set_id: file_set_id, checked_uri: uri.to_s, file_id: file_id, expected_result: expected_result)
+    rescue Hyrax::Fixity::MissingContentError
+      ChecksumAuditLog.create_and_prune!(passed: false, file_set_id: file_set_id, checked_uri: uri.to_s, file_id: file_id, expected_result: expected_result)
     end
 
     def file_set_preservation_event(log, file_set_id, file_id, event_start, initiating_user)
@@ -76,7 +66,7 @@ class FixityCheckJob < Hyrax::ApplicationJob
       fixity_file_set = ::FileSet.find(file_set_id)
       fixity_file = Hydra::PCDM::File.find(file_id)
       event = { 'type' => 'Fixity Check', 'start' => event_start, 'software_version' => 'Fedora v4.7.5', 'user' => initiating_user }
-      if log.passed == true
+      if log == true
         event['outcome'] = 'Success'
         event['details'] = "Fixity intact for file: #{fixity_file&.original_name}: sha1:#{fixity_file&.checksum&.value}"
         @logger.info "Ran fixity check successfully on #{fixity_file&.original_name}"
@@ -86,5 +76,12 @@ class FixityCheckJob < Hyrax::ApplicationJob
         @logger.error "Fixity check failure: Fixity failed for #{fixity_file&.original_name}"
       end
       create_preservation_event(fixity_file_set, event)
+    end
+
+    ##
+    # @api private
+    # @return [Class]
+    def fixity_service_for(id:)
+      Hyrax.config.fixity_service.new(id)
     end
 end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -10,6 +10,8 @@ Hyrax.config do |config|
   #   registry.add(name: 'captaining', description: 'For those that really like the front lines')
   # end
 
+  config.fixity_service = Hyrax::Fixity::ActiveFedoraFixityService
+
   # When an admin set is created, we need to activate a workflow.
   # The :default_active_workflow_name is the name of the workflow we will activate.
   # @see Hyrax::Configuration for additional details and defaults.


### PR DESCRIPTION
- app/jobs/fixity_check_job.rb: swaps out to the new procedure while integrating our preservation logging work.
- config/initializers/hyrax.rb: moves to defining the fixity service in the config initializer so that others can be easily swapped to.