### PR TITLE
Fixes the spec revolving around CurateGenericWork (#1921).

### DIFF
--- a/spec/models/curate_generic_work_spec.rb
+++ b/spec/models/curate_generic_work_spec.rb
@@ -788,12 +788,15 @@ RSpec.describe CurateGenericWork do
     end
 
     context "with a CurateGenericWork work that has data_collection_dates" do
-      subject do
+      subject(:saved_data_collection_dates) do
         described_class.create.tap do |cgw|
           cgw.data_collection_dates = data_collection_dates
         end
       end
-      its(:data_collection_dates) { is_expected.to eq data_collection_dates }
+
+      it 'is expected to be parsed to display date and time' do
+        expect(saved_data_collection_dates.data_collection_dates.first).to eq 'Fri, 30 Mar 2018 00:00:00 +0000'
+      end
     end
   end
 


### PR DESCRIPTION
Nothing about our code or Hyrax' has changed about the way this value is processed (see below).
```
        def iso8601_date(value)
          if value.is_a?(Date) || value.is_a?(Time)
            DateTime.parse(value.to_s).to_time.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
          elsif !value.empty?
            DateTime.parse(value).to_time.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
          end
        rescue ArgumentError
          raise ArgumentError, "Unable to parse `#{value}' as a date-time object"
        end
```
My suspicion is that the return value of `DateTime.parse` has changed with the Ruby version change we're instituting. Hopefully, this doesn't break anything in the system, especially in facets, but the good thing there is that this value is treated as only a reference for `human_readable_data_collection_dates`, which does it's own further parsing.