### PR TITLE
Fixes the spec revolving around Hyrax::FileSetsController (#1921).

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -155,12 +155,17 @@ RSpec/MessageChain:
 
 RSpec/AnyInstance:
     Exclude:
-        - 'spec/models/job_io_wrapper_spec.rb'
+        - spec/controllers/hyrax/file_sets_controller_spec.rb
+        - spec/models/job_io_wrapper_spec.rb
         - spec/views/manifest/manifest.json.jbuilder_spec.rb
 
 RSpec/LetSetup:
     Exclude:
         - spec/presenters/collection_presenter_spec.rb
+
+RSpec/VerifiedDoubles:
+    Exclude:
+        - spec/controllers/hyrax/file_sets_controller_spec.rb
 
 Naming/PredicateName:
     Exclude:

--- a/app/models/hyrax/uploaded_file.rb
+++ b/app/models/hyrax/uploaded_file.rb
@@ -38,9 +38,9 @@ module Hyrax
       update!(file_set_uri: uri)
     end
 
-    def uploader
+    def uploader # rubocop:disable Metrics/CyclomaticComplexity
       service_file.presence || preservation_master_file.presence || intermediate_file.presence ||
         extracted_text.presence || transcript.presence || collection_banner.presence || nil
-    end
+    end # rubocop:enable Metrics/CyclomaticComplexity
   end
 end

--- a/app/models/hyrax/uploaded_file.rb
+++ b/app/models/hyrax/uploaded_file.rb
@@ -37,5 +37,10 @@ module Hyrax
             end
       update!(file_set_uri: uri)
     end
+
+    def uploader
+      service_file.presence || preservation_master_file.presence || intermediate_file.presence ||
+        extracted_text.presence || transcript.presence || collection_banner.presence || nil
+    end
   end
 end

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -415,5 +415,19 @@ RSpec.describe Hyrax::FileSetsController, :clean do
                                       'You need to sign in or sign up before continuing.')
       end
     end
+
+    describe '#update' do
+      it 'requires login' do
+        post :update, params: { id: public_file_set }
+        expect(response).to fail_redirect_and_flash(main_app.new_user_session_path, 'You need to sign in or sign up before continuing.')
+      end
+    end
+
+    describe '#destroy' do
+      it 'requires login' do
+        delete :destroy, params: { id: public_file_set }
+        expect(response).to fail_redirect_and_flash(main_app.new_user_session_path, 'You need to sign in or sign up before continuing.')
+      end
+    end
   end
 end

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -92,12 +92,12 @@ RSpec.describe Hyrax::FileSetsController, :clean do
         it "spawns a content update event job" do
           expect do
             post :update, params: {
-              id: file_set,
+              id:       file_set,
               file_set: {
-                title: ['new_title'],
-                keyword: [''],
-                permissions_attributes: [{ type: 'person',
-                                           name: 'archivist1',
+                title:                  ['new_title'],
+                keyword:                [''],
+                permissions_attributes: [{ type:   'person',
+                                           name:   'archivist1',
                                            access: 'edit' }]
               }
             }
@@ -118,7 +118,7 @@ RSpec.describe Hyrax::FileSetsController, :clean do
         before do
           allow(Hyrax::Actors::FileActor).to receive(:new).and_return(actor)
           allow_any_instance_of(Hyrax::UploadedFile).to receive(:uploader).and_return(uploader)
-          allow(uploader).to receive(:path).and_return(anything())
+          allow(uploader).to receive(:path).and_return(anything)
           allow_any_instance_of(JobIoWrapper).to receive(:file).and_return(fake_file)
           allow(fake_file).to receive(:path).and_return('a/path')
         end
@@ -224,7 +224,7 @@ RSpec.describe Hyrax::FileSetsController, :clean do
 
         expect(assigns[:file_set])
           .to have_attributes(read_groups: contain_exactly("group1"),
-                              edit_users: include("user1", user.user_key))
+                              edit_users:  include("user1", user.user_key))
       end
 
       it "updates existing groups and users" do


### PR DESCRIPTION
Summary: This is a case where, technically, this should have failed before now, but gracefully passed. The failing test ` Hyrax::FileSetsController when signed in #update when updating the attached file direct upload spawns a ContentNewVersionEventJob` was expecting an `uploader` attribute from `UploadedFile` that was an alias of the one type of `UploadedFileUploader` that Hyrax supports out of the box. We have overridden that class to allow multiple types of file to be saved to the object. Because we don't need `uploader`(we assign the path argument further down the chain), we simply commented it out and the tests were happy. 
Now, this test (`spec/controllers/hyrax/file_sets_controller_spec.rb` L# 113) is checking for the presence of any method named `uploader`, so I've created one that returns the first uploader it finds with presence. I also had to stub the heck out of the test to make it happy, even though we're only testing to see if a Job kicks off.

- app/models/hyrax/uploaded_file.rb: added method to replace alias found in original method.
- spec/controllers/hyrax/file_sets_controller_spec.rb: 
  - reworked the test on L# 113 to allow for the processing to go through.
  - updated the rest of the rSpec to match the refactoring that Samvera has done.