### PR TITLE
Corrects the flakiness of the Hyrax::AdminSetPresenter spec by creating FactoryBot objects (#1912).

### DIFF
--- a/spec/presenters/hyrax/admin_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_presenter_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# [Hyrax-overwrite-v3.0.0.pre.rc1]
+# [Hyrax-overwrite-v3.4.1]
 require 'rails_helper'
 
 RSpec.describe Hyrax::AdminSetPresenter, :clean do
@@ -18,7 +18,7 @@ RSpec.describe Hyrax::AdminSetPresenter, :clean do
   describe "total_items" do
     subject { presenter.total_items }
 
-    let(:admin_set) { FactoryBot.build(:admin_set) }
+    let(:admin_set) { FactoryBot.create(:admin_set) }
 
     context "empty admin set" do
       it { is_expected.to eq 0 }
@@ -48,7 +48,7 @@ RSpec.describe Hyrax::AdminSetPresenter, :clean do
 
     context "default admin set" do
       let(:admin_set) do
-        FactoryBot.build(:admin_set, id: AdminSet::DEFAULT_ID)
+        FactoryBot.create(:admin_set, id: AdminSet::DEFAULT_ID)
       end
 
       it { is_expected.to be true }
@@ -58,7 +58,7 @@ RSpec.describe Hyrax::AdminSetPresenter, :clean do
   describe '#collection_type' do
     subject { presenter.collection_type }
     let(:admin_set) do
-      FactoryBot.build(:admin_set, id: AdminSet::DEFAULT_ID)
+      FactoryBot.create(:admin_set, id: AdminSet::DEFAULT_ID)
     end
 
     it { is_expected.to eq(FactoryBot.create(:admin_set_collection_type)) }


### PR DESCRIPTION
Summary: I found that Samvera had experienced the same errors, and they fixed them by persisting the offending objects rather than purely initializing them.