### PR TITLE
Moves FileSet association to Work to the end of the ingest process (Bulkrax only).

### DIFF
--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -92,7 +92,6 @@ module Hyrax
           # Save the work so the association between the work and the file_set is persisted (head_id)
           # NOTE: the work may not be valid, in which case this save doesn't do anything.
           work.save
-          Hyrax.config.callback.run(:after_create_fileset, file_set, user)
         end
       end
       alias attach_file_to_work attach_to_work

--- a/app/jobs/associate_filesets_with_work_job.rb
+++ b/app/jobs/associate_filesets_with_work_job.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class AssociateFilesetsWithWorkJob < Hyrax::ApplicationJob
+  queue_as :import
+
+  def perform(importer)
+    file_set_entries = pull_file_set_entries(importer)
+    parents = pull_parents(file_set_entries)
+
+    process_file_sets(parents, file_set_entries)
+  end
+
+  def pull_file_set_entries(importer)
+    entries_to_return = importer.entries.select { |e| e.factory_class == FileSet }
+    raise 'The are no FileSet entries to iterate over' if entries_to_return.blank?
+    entries_to_return
+  end
+
+  def pull_parents(file_set_entries)
+    file_set_entries.map { |e| e.parsed_metadata['parent'] }.compact.uniq.flatten
+  end
+
+  def pull_work(parent)
+    parent.include?('-cor') ? CurateGenericWork.find(parent) : CurateGenericWork.where(deduplication_key: [parent])&.first
+  end
+
+  def pull_fileset_entries_for_parent(file_set_entries, parent)
+    file_set_entries.select { |fse| fse.parsed_metadata['parent'] == [parent] }
+  end
+
+  def pull_file_sets(file_set_entries, parent)
+    pull_fileset_entries_for_parent(file_set_entries, parent).map { |v| v&.factory&.find }.compact
+  end
+
+  def process_file_sets(parents, file_set_entries)
+    raise "There are no parents to iterate over" if parents.blank?
+
+    parents.each do |p|
+      work = pull_work(p)
+      file_sets = pull_file_sets(file_set_entries, p)
+      raise 'A CurateGenericWork and/or FileSet objects could not be found' unless work.present? && file_sets.present?
+
+      file_sets.each do |fs|
+        work.ordered_members << fs
+        work.save
+      end
+    end
+  end
+end

--- a/app/jobs/associate_filesets_with_work_job.rb
+++ b/app/jobs/associate_filesets_with_work_job.rb
@@ -40,12 +40,10 @@ class AssociateFilesetsWithWorkJob < Hyrax::ApplicationJob
       file_sets = pull_file_sets(file_set_entries, p)
       raise 'A CurateGenericWork and/or FileSet objects could not be found' unless work.present? && file_sets.present?
 
-      file_sets.each do |fs|
-        work.ordered_members << fs
-        work.save
+      work.ordered_members += file_sets
+      work.save
 
-        Hyrax.config.callback.run(:after_create_fileset, fs, ::User.find_by(uid: fs.depositor))
-      end
+      file_sets.each { |fs|  Hyrax.config.callback.run(:after_create_fileset, fs, ::User.find_by(uid: fs.depositor)) }
     end
   end
 end

--- a/app/jobs/associate_filesets_with_work_job.rb
+++ b/app/jobs/associate_filesets_with_work_job.rb
@@ -43,7 +43,7 @@ class AssociateFilesetsWithWorkJob < Hyrax::ApplicationJob
       work.ordered_members += file_sets
       work.save
 
-      file_sets.each { |fs|  Hyrax.config.callback.run(:after_create_fileset, fs, ::User.find_by(uid: fs.depositor)) }
+      file_sets.each { |fs| Hyrax.config.callback.run(:after_create_fileset, fs, ::User.find_by(uid: fs.depositor)) }
     end
   end
 end

--- a/app/jobs/associate_filesets_with_work_job.rb
+++ b/app/jobs/associate_filesets_with_work_job.rb
@@ -29,7 +29,7 @@ class AssociateFilesetsWithWorkJob < Hyrax::ApplicationJob
   end
 
   def pull_file_sets(file_set_entries, parent)
-    pull_fileset_entries_for_parent(file_set_entries, parent).map { |v| v&.factory&.find }.compact
+    pull_fileset_entries_for_parent(file_set_entries, parent).map { |v| v&.factory&.find }.compact.uniq
   end
 
   def process_file_sets(parents, file_set_entries)

--- a/app/jobs/associate_filesets_with_work_job.rb
+++ b/app/jobs/associate_filesets_with_work_job.rb
@@ -43,6 +43,8 @@ class AssociateFilesetsWithWorkJob < Hyrax::ApplicationJob
       file_sets.each do |fs|
         work.ordered_members << fs
         work.save
+
+        Hyrax.config.callback.run(:after_create_fileset, fs, ::User.find_by(uid: fs.depositor))
       end
     end
   end

--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -67,6 +67,7 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
       work.ordered_members << actor.file_set
       work.save
       actor.file_set.save
+      Hyrax.config.callback.run(:after_create_fileset, actor.file_set, actor.user)
       actor.attach_to_work(work)
     end
 

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -110,12 +110,11 @@ Bulkrax::ObjectFactory.class_eval do
     uploaded_files = attrs['uploaded_files'].map { |ufid| ::Hyrax::UploadedFile.find(ufid) }
     @preferred = preferred_file(uploaded_files)
 
-    num_files = attrs['uploaded_files']&.size
-    uploaded_files.each_with_index do |uploaded_file, ind|
-      @uploaded_file = uploaded_file
+    attrs['uploaded_files'].each do |uploaded_file_id|
+      @uploaded_file = ::Hyrax::UploadedFile.find(uploaded_file_id)
       next if @uploaded_file.file_set_uri.present?
 
-      process_uploaded_file(work_permissions, file_set_attrs, ind, num_files)
+      process_uploaded_file(work_permissions, file_set_attrs)
     end
 
     object.save!
@@ -187,5 +186,19 @@ Bulkrax::CsvParser.class_eval do
     @path_to_files = File.join(
         zip? ? importer_unzip_path : File.dirname(import_file_path), 'files', filename
       )
+  end
+end
+
+Bulkrax::ScheduleRelationshipsJob.class_eval do
+  def perform(importer_id:)
+    importer = Importer.find(importer_id)
+    pending_num = importer.entries.left_outer_joins(:latest_status)
+                          .where('bulkrax_statuses.status_message IS NULL ').count
+    return reschedule(importer_id) unless pending_num.zero?
+
+    importer.last_run.parents.each do |parent_id|
+      AssociateFilesetsWithWorkJob.perform_later(importer)
+      CreateRelationshipsJob.perform_later(parent_identifier: parent_id, importer_run_id: importer.last_run.id)
+    end
   end
 end

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -191,14 +191,14 @@ end
 
 Bulkrax::ScheduleRelationshipsJob.class_eval do
   def perform(importer_id:)
-    importer = Importer.find(importer_id)
+    importer = ::Bulkrax::Importer.find(importer_id)
     pending_num = importer.entries.left_outer_joins(:latest_status)
                           .where('bulkrax_statuses.status_message IS NULL ').count
     return reschedule(importer_id) unless pending_num.zero?
 
     importer.last_run.parents.each do |parent_id|
-      AssociateFilesetsWithWorkJob.perform_later(importer)
-      CreateRelationshipsJob.perform_later(parent_identifier: parent_id, importer_run_id: importer.last_run.id)
+      ::AssociateFilesetsWithWorkJob.perform_later(importer)
+      ::Bulkrax::CreateRelationshipsJob.perform_later(parent_identifier: parent_id, importer_run_id: importer.last_run.id)
     end
   end
 end

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -110,8 +110,8 @@ Bulkrax::ObjectFactory.class_eval do
     uploaded_files = attrs['uploaded_files'].map { |ufid| ::Hyrax::UploadedFile.find(ufid) }
     @preferred = preferred_file(uploaded_files)
 
-    attrs['uploaded_files'].each do |uploaded_file_id|
-      @uploaded_file = ::Hyrax::UploadedFile.find(uploaded_file_id)
+    uploaded_files.each do |uploaded_file|
+      @uploaded_file = uploaded_file
       next if @uploaded_file.file_set_uri.present?
 
       process_uploaded_file(work_permissions, file_set_attrs)
@@ -196,8 +196,8 @@ Bulkrax::ScheduleRelationshipsJob.class_eval do
                           .where('bulkrax_statuses.status_message IS NULL ').count
     return reschedule(importer_id) unless pending_num.zero?
 
+    ::AssociateFilesetsWithWorkJob.perform_later(importer)
     importer.last_run.parents.each do |parent_id|
-      ::AssociateFilesetsWithWorkJob.perform_later(importer)
       ::Bulkrax::CreateRelationshipsJob.perform_later(parent_identifier: parent_id, importer_run_id: importer.last_run.id)
     end
   end

--- a/lib/importing_modules/file_set_methods.rb
+++ b/lib/importing_modules/file_set_methods.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module FileSetMethods
-  def process_uploaded_file(work_permissions, file_set_attrs, ind, num_files)
+  def process_uploaded_file(work_permissions, file_set_attrs)
     actor = ::Hyrax::Actors::FileSetActor.new(object, @user)
 
     @uploaded_file.update(file_set_uri: actor.file_set.uri)
@@ -9,10 +9,6 @@ module FileSetMethods
     actor.create_metadata(@uploaded_file.fileset_use, file_set_attrs)
     actor.fileset_name(@uploaded_file.file.to_s) if @uploaded_file.file.present?
     create_content_for_actor(actor, @uploaded_file)
-    if ind == num_files - 1
-      @work.ordered_members << actor.file_set
-      @work.save
-    end
     actor.file_set.save
     actor.attach_to_work(@work)
   end

--- a/spec/actors/hyrax/actors/curate_generic_work_actor_spec.rb
+++ b/spec/actors/hyrax/actors/curate_generic_work_actor_spec.rb
@@ -4,7 +4,7 @@
 #  `rails generate hyrax:work CurateGenericWork`
 require 'rails_helper'
 
-RSpec.describe Hyrax::Actors::CurateGenericWorkActor do
+RSpec.describe Hyrax::Actors::CurateGenericWorkActor, :clean do
   let(:env) { Hyrax::Actors::Environment.new(curation_concern, ability, attributes) }
   let(:user) { FactoryBot.create(:user) }
   let(:ability) { ::Ability.new(user) }


### PR DESCRIPTION
- app/actors/hyrax/actors/file_set_actor.rb: moves this callback to just after the FileSet/Work association point.
- app/jobs/associate_filesets_with_work_job.rb: creates a separate job that associates all of the FileSets going into a work at once.
- app/jobs/attach_files_to_work_job.rb: since we're processing the FileSet/Work association here instead of inside `file_set_actor`, this moves the callback to right after that association.
- config/initializers/bulkrax.rb: 
  - removes the index/number of files details as arguments since we're now doing the FileSet/Work association that needed that information to its own Job.
  - overrides the Bulkrax::ScheduleRelationshipsJob so that we can insert a call to the new AssociateFilesetsWithWorkJob at the end of the ingest process.
- lib/importing_modules/file_set_methods.rb: deletes the FileSet/Work association process and the looping information needed for it to run from this point in the ingestion process.