### PR TITLE
Show Bulkrax sidebar links only to admins (#1939).

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -1,0 +1,22 @@
+<% # [Bulkrax-overwrite-v4.2.1] Restricts the last two nav_links to admins. %>
+<li class="h5"><%= t('hyrax.admin.sidebar.repository_objects') %></li>
+
+<%= menu.nav_link(hyrax.my_collections_path,
+                  also_active_for: hyrax.dashboard_collections_path) do %>
+  <span class="fa fa-folder-open" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.collections') %></span>
+<% end %>
+
+<%= menu.nav_link(hyrax.my_works_path,
+                  also_active_for: hyrax.dashboard_works_path) do %>
+  <span class="fa fa-file" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
+<% end %>
+
+<% if can? :read, :admin_dashboard %>
+  <%= menu.nav_link(bulkrax.importers_path) do %>
+    <span class="fa fa-cloud-upload" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.importers') %></span>
+  <% end %>
+
+  <%= menu.nav_link(bulkrax.exporters_path) do %>
+    <span class="fa fa-cloud-download" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.exporters') %></span>
+  <% end %>
+<% end %>

--- a/spec/system/admin_dashboard_spec.rb
+++ b/spec/system/admin_dashboard_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe 'Admin dashboard', integration: true, clean: true, type: :system 
     scenario 'does not have import csv link' do
       expect(page).not_to have_link 'Import Content From a CSV'
     end
+
+    scenario 'does not have Bulkrax Importers link' do
+      expect(page).not_to have_link 'Importers'
+    end
+
+    scenario 'does not have Bulkrax Exporters link' do
+      expect(page).not_to have_link 'Exporters'
+    end
   end
 
   context 'as an admin user' do
@@ -47,6 +55,14 @@ RSpec.describe 'Admin dashboard', integration: true, clean: true, type: :system 
     scenario 'view background jobs page' do
       click_on 'Background Jobs'
       expect(page).to have_content 'Select Job'
+    end
+
+    scenario 'does have Bulkrax Importers link' do
+      expect(page).to have_link 'Importers'
+    end
+
+    scenario 'does have Bulkrax Exporters link' do
+      expect(page).to have_link 'Exporters'
     end
     # TODO: Add more admin tests, for eg: stats page, when work is created
 

--- a/spec/system/bulkrax_csv_import_spec.rb
+++ b/spec/system/bulkrax_csv_import_spec.rb
@@ -15,12 +15,11 @@ RSpec.describe 'Bulkrax CSV importer', clean: true, js: true, type: :system do
     end
   end
 
-  context 'logged in user' do
-    let(:user_attributes) { { uid: 'test@example.com' } }
-    let(:user) { User.new(user_attributes) { |u| u.save(validate: false) } }
+  context 'logged in admin user' do
+    let(:admin) { FactoryBot.create(:admin) }
     let(:csv_file) { File.join(fixture_path, 'csv_import', 'good', 'Bulkrax_Test_CSV.csv') }
 
-    before { login_as user }
+    before { login_as admin }
 
     it 'displays importers on Dashboard' do
       visit '/dashboard'


### PR DESCRIPTION
- app/views/hyrax/dashboard/sidebar/_repository_content.html.erb: overrides Bulkrax' customized partial to add in admin protections.
- spec/*: tests that the above changes work.