### PR TITLE
Resolve test failures in `spec/system/viewing_a_work_spec.rb`

### DIFF
--- a/spec/system/viewing_a_work_spec.rb
+++ b/spec/system/viewing_a_work_spec.rb
@@ -132,6 +132,7 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
     end
 
     it 'has a batch upload link on the works dashboard' do
+      allow(Flipflop).to receive(:batch_upload?).and_return(true)
       visit "/dashboard/works"
       expect(page).to have_link(href: /batch/)
     end


### PR DESCRIPTION
Resolve test failures in `spec/system/viewing_a_work_spec.rb`. To view the batch upload link, the `Flipflop` feature `batch_upload?` has to be enabled, which is not explicitly set in the test. The changes in this PR explicitly set that feature to `true` in the failing test.