### PR TITLE
Refines the finding of the parent work (#1955).

### DIFF
--- a/app/jobs/associate_filesets_with_work_job.rb
+++ b/app/jobs/associate_filesets_with_work_job.rb
@@ -21,7 +21,9 @@ class AssociateFilesetsWithWorkJob < Hyrax::ApplicationJob
   end
 
   def pull_work(parent)
-    parent.include?('-cor') ? CurateGenericWork.find(parent) : CurateGenericWork.where(deduplication_key: [parent])&.first
+    CurateGenericWork.find(parent)
+  rescue
+    CurateGenericWork.where(deduplication_key: [parent])&.first || nil
   end
 
   def pull_fileset_entries_for_parent(file_set_entries, parent)

--- a/config/emory/index_file_set_results.csv
+++ b/config/emory/index_file_set_results.csv
@@ -1,1 +1,0 @@
-160cvdncjx-cor,Thumbnail_path mismatch in solr_doc,Queued

--- a/config/emory/index_file_set_results.csv
+++ b/config/emory/index_file_set_results.csv
@@ -1,0 +1,1 @@
+160cvdncjx-cor,Thumbnail_path mismatch in solr_doc,Queued


### PR DESCRIPTION
This eliminates the need to not have `-cor` in a dedupe key.