### PR TITLE
Reverting the thumbnail dropdown option to our original override.

### DIFF
--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -38,7 +38,7 @@
                 <% unless f.object.select_files.blank? %>
                   <%# we're loading these values dynamically to speed page load %>
                   <%= f.input :thumbnail_id,
-                            input_html: { data: { text: thumbnail_label_for(object: f.object) } } %>
+                            input_html: { data: { text: f.object.thumbnail_id } } %>
                 <% end %>
               <% end %>
             </div>


### PR DESCRIPTION
Originally, this value in Hyrax v3.0.0.pre.rc1 was tied to `f.object.thumbnail_title`, but at sometime in the past, we preferred the FS id to display instead. The rspec test was checking for that customization, which was removed in favor of Hyrax v3.4.2's new helper method. I'm reversing that choice.