### PR TITLE
Creates Bulkrax-specific option for the DAMS Preprocessor (#1984).

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,6 +63,7 @@ Metrics/ClassLength:
         - app/forms/hyrax/forms/collection_form.rb
         - app/importers/curate_mapper.rb
         - app/importers/curate_record_importer.rb
+        - app/importers/dams_preprocessor.rb
         - app/indexers/curate_generic_work_indexer.rb
         - app/models/curate_generic_work.rb
         - app/models/solr_document.rb

--- a/app/controllers/background_jobs_controller.rb
+++ b/app/controllers/background_jobs_controller.rb
@@ -32,7 +32,7 @@ class BackgroundJobsController < ApplicationController
 
     def preprocessor_actions
       if params[:jobs].include?('dams')
-        preprocessor_action(params[:dams_csv].present?, DamsPreprocessor.new(params[:dams_csv].path))
+        preprocessor_action(params[:dams_csv].present?, DamsPreprocessor.new(params[:dams_csv].path, 'zizia'))
       elsif params[:jobs].include?('lang')
         preprocessor_action(params[:lang_csv].present?, LangmuirPreprocessor.new(params[:lang_csv].path))
       else


### PR DESCRIPTION
Requirements to meet: 

- The deduplication_key column should only be populated for works, not FileSets.
- The model column is the same as Zizia’s type column, but should be formatted as:
  - CurateGenericWork for work rows
  - FileSet for fileset rows 
- The parent column should contain:
  - For works, the source_collection_id or the Curate ID for the deposit collection if one exists. 
  - For filesets, the deduplication_key for the work the fileset is attached to.
- The title field should include the value currently stored in fileset_label for FileSet entries. Currently the preprocessor repeats the work title.
- The file column contains a list of all the filenames to attach to each fileset, separated by a semicolon. They should formatted such as the following:
  - 0001.tif;0001.txt
  - If we are using the zip upload method for Bulkrax, the file column should only contain filenames, not the full file path. 
- file_types column contains a list of all the filenames to attach, plus their fileset use. They should be formatted as follows. Separate multiple file entries with a “|”.
  - This type of collection typically only has a single file per fileset which is preservation_master_file.
  - filename1:fileuse1|filename2:fileuse2
  - 0001.tif:preservation_master_file|0001.txt:transcript
  - The file use suffixes should be formatted as:
    - preservation_master_file (e.g. *_ ARCH files)
    - intermediate_file (e.g. *_PROD files or compressed derivatives)
    - service_file (used for lower res image/AV files)
    - extracted_text (e.g. OCR files: .xml or .pos)
    - transcript (plain text versions e.g. .txt or .rtf)
- pcdm_use
  - Should be populated for all FileSet rows.
  - See preprocessor-specific notes for which values are assigned for which files.
- copyright_date
  - We should only store a copyright date if it is specifically coded as such in the MARC record (which isn’t frequently done). Currently there is some kind of fallback that puts the value of date_issued in this field, but that isn’t always indicating copyright status.
  - Mapping should be to only store a value for this field (264 $c) if 264 is populated and has a second indicator of 4 (copyright date). 
- creators 
  - Column header should be creator, not creators (see ticket #1560)
 