### PR TITLE
Updates the kirtas side of Yellowbacks for Bulkrax (#1984).

### DIFF
--- a/app/controllers/background_jobs_controller.rb
+++ b/app/controllers/background_jobs_controller.rb
@@ -41,7 +41,7 @@ class BackgroundJobsController < ApplicationController
           YellowbackPreprocessor.new(
             params[:book_csv].path,
             params[:book_xml].path,
-            params[:book_repl],
+            'zizia'
             params[:book_map].to_sym,
             params[:book_start_num].to_i
           )

--- a/app/controllers/background_jobs_controller.rb
+++ b/app/controllers/background_jobs_controller.rb
@@ -41,7 +41,7 @@ class BackgroundJobsController < ApplicationController
           YellowbackPreprocessor.new(
             params[:book_csv].path,
             params[:book_xml].path,
-            'zizia'
+            'zizia',
             params[:book_map].to_sym,
             params[:book_start_num].to_i
           )

--- a/spec/fixtures/csv_import/yellowbacks/yellowbacks_marc.xml
+++ b/spec/fixtures/csv_import/yellowbacks/yellowbacks_marc.xml
@@ -304,7 +304,7 @@
     <datafield tag="250" ind1=" " ind2=" ">
       <subfield code="a">5th edition.</subfield>
     </datafield>
-    <datafield tag="264" ind1=" " ind2="1">
+    <datafield tag="264" ind1=" " ind2="4">
       <subfield code="a">London :</subfield>
       <subfield code="b">J.M. Dent,</subfield>
       <subfield code="c">1898.</subfield>

--- a/spec/importers/books_preprocessor_metadata_spec.rb
+++ b/spec/importers/books_preprocessor_metadata_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe YellowbackPreprocessor do
     # running #merge is expensive, only set it up and run it once and then check the results
     yellowback_pull_list_sample = File.join(fixture_path, 'csv_import', 'yellowbacks', 'yellowbacks_pull_list.csv')
     alma_export_sample = File.join(fixture_path, 'csv_import', 'yellowbacks', 'yellowbacks_marc.xml')
-    preprocessor = described_class.new(yellowback_pull_list_sample, alma_export_sample)
+    preprocessor = described_class.new(yellowback_pull_list_sample, alma_export_sample, 'zizia')
     preprocessor.merge
   end
 

--- a/spec/importers/kirtas_preprocessor_file_bulkrax_spec.rb
+++ b/spec/importers/kirtas_preprocessor_file_bulkrax_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe YellowbackPreprocessor do
     # running #merge is expensive, only set it up and run it once and then check the results
     yellowback_pull_list_sample = File.join(fixture_path, 'csv_import', 'yellowbacks', 'yellowbacks_pull_list.csv')
     alma_export_sample = File.join(fixture_path, 'csv_import', 'yellowbacks', 'yellowbacks_marc.xml')
-    preprocessor = described_class.new(yellowback_pull_list_sample, alma_export_sample, 'zizia')
+    preprocessor = described_class.new(yellowback_pull_list_sample, alma_export_sample, 'bulkrax')
     preprocessor.merge
   end
 
@@ -33,10 +33,15 @@ RSpec.describe YellowbackPreprocessor do
 
   it 'processes the expected works', :aggregate_failures do
     expect(import_rows[0]['title']).to eq('Edge cases : miscellaneous & sundry') # Edge cases
+    expect(import_rows[0]['model']).to eq('CurateGenericWork')
     expect(import_rows[shakespeare_start]['title']).to eq('Shakespeare\'s comedy of The merchant of Venice') # Shakespeare's comedy of The merchant of Venice
+    expect(import_rows[shakespeare_start]['model']).to eq('CurateGenericWork')
     expect(import_rows[twain_start]['title']).to eq('Choice bits from Mark Twain.') # Choice bits from Mark Twain
+    expect(import_rows[twain_start]['model']).to eq('CurateGenericWork')
     expect(import_rows[moths1_start]['title']).to eq('The common moths of England [Copy 2]') # The common moths of England
+    expect(import_rows[moths1_start]['model']).to eq('CurateGenericWork')
     expect(import_rows[moths2_start]['title']).to eq('The common moths of England [Copy 3]') # The common moths of England
+    expect(import_rows[moths2_start]['model']).to eq('CurateGenericWork')
   end
 
   it 'provides a deduplication key', :aggregate_failures do
@@ -46,31 +51,60 @@ RSpec.describe YellowbackPreprocessor do
 
   it 'adds filesets for PDFs', :aggregate_failures do
     shakespeare_pdf = import_rows[shakespeare_start + pdf_offset] # Shakespeare's comedy of The merchant of Venice
-    expect(shakespeare_pdf['type']).to eq('fileset')
-    expect(shakespeare_pdf['fileset_label']).to eq('PDF for volume')
+    expect(shakespeare_pdf['type']).to be_nil
+    expect(shakespeare_pdf['model']).to eq('FileSet')
+    expect(shakespeare_pdf['fileset_label']).to be_nil
+    expect(shakespeare_pdf['title']).to eq('PDF for volume')
+    expect(shakespeare_pdf['deduplication_key']).to be_empty
+    expect(shakespeare_pdf['parent']).to eq('7stsg')
+    expect(shakespeare_pdf['pcdm_use']).to eq('Primary Content')
+    expect(shakespeare_pdf['file']).to eq('Output.pdf')
+    expect(shakespeare_pdf['file_types']).to eq('Output.pdf:preservation_master_file')
     expect(shakespeare_pdf['preservation_master_file']).to eq('/Yellowbacks/lsdi2/ocm04416480-2987/ocm04416480/Images/Output/Output.pdf')
   end
 
   it 'adds filesets for volume-level OCR', :aggregate_failures do
     shakespeare_pdf = import_rows[shakespeare_start + ocr_offset] # Shakespeare's comedy of The merchant of Venice
-    expect(shakespeare_pdf['type']).to eq('fileset')
-    expect(shakespeare_pdf['fileset_label']).to eq('OCR Output for Volume')
+    expect(shakespeare_pdf['type']).to be_nil
+    expect(shakespeare_pdf['model']).to eq('FileSet')
+    expect(shakespeare_pdf['fileset_label']).to be_nil
+    expect(shakespeare_pdf['title']).to eq('OCR Output for Volume')
+    expect(shakespeare_pdf['deduplication_key']).to be_empty
+    expect(shakespeare_pdf['parent']).to eq('7stsg')
+    expect(shakespeare_pdf['pcdm_use']).to eq('Supplemental Content')
+    expect(shakespeare_pdf['file']).to eq('Output.xml')
+    expect(shakespeare_pdf['file_types']).to eq('Output.xml:preservation_master_file')
     expect(shakespeare_pdf['preservation_master_file']).to eq('/Yellowbacks/lsdi2/ocm04416480-2987/ocm04416480/Images/Output/Output.xml')
   end
 
   it 'adds page-level filesets', :aggregate_failures do
     first_page = import_rows[shakespeare_start + pages_offset + 1] # Shakespeare's comedy of The merchant of Venice
-    expect(first_page['type']).to eq('fileset')
-    expect(first_page['fileset_label']).to eq('Page 1')
+    expect(first_page['type']).to be_nil
+    expect(first_page['model']).to eq('FileSet')
+    expect(first_page['fileset_label']).to be_nil
+    expect(first_page['title']).to eq('Page 1')
+    expect(first_page['deduplication_key']).to be_empty
+    expect(first_page['parent']).to eq('7stsg')
+    expect(first_page['pcdm_use']).to eq('Primary Content')
     expect(first_page['preservation_master_file']).to eq('/Yellowbacks/lsdi2/ocm04416480-2987/ocm04416480/Images/Output/0001.tif')
     expect(first_page['extracted']).to be_nil
     expect(first_page['transcript_file']).to eq('/Yellowbacks/lsdi2/ocm04416480-2987/ocm04416480/Images/Output/0001.txt')
+    expect(first_page['file']).to eq('0001.tif;0001.txt')
+    expect(first_page['file_types']).to eq('0001.tif:preservation_master_file|0001.txt:transcript')
+
     last_page = import_rows[shakespeare_start + pages_offset + 198]
-    expect(last_page['type']).to eq('fileset')
-    expect(last_page['fileset_label']).to eq('Page 198')
+    expect(last_page['type']).to be_nil
+    expect(last_page['model']).to eq('FileSet')
+    expect(last_page['fileset_label']).to be_nil
+    expect(last_page['title']).to eq('Page 198')
+    expect(last_page['deduplication_key']).to be_empty
+    expect(last_page['parent']).to eq('7stsg')
+    expect(last_page['pcdm_use']).to eq('Primary Content')
     expect(last_page['preservation_master_file']).to eq('/Yellowbacks/lsdi2/ocm04416480-2987/ocm04416480/Images/Output/0198.tif')
     expect(last_page['extracted']).to be_nil
     expect(last_page['transcript_file']).to eq('/Yellowbacks/lsdi2/ocm04416480-2987/ocm04416480/Images/Output/0198.txt')
+    expect(last_page['file']).to eq('0198.tif;0198.txt')
+    expect(last_page['file_types']).to eq('0198.tif:preservation_master_file|0198.txt:transcript')
   end
 
   it 'handles file paths correctly', :aggregate_failures do

--- a/spec/importers/limb_preprocessor_file_spec.rb
+++ b/spec/importers/limb_preprocessor_file_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe YellowbackPreprocessor do
     # running #merge is expensive, only set it up and run it once and then check the results
     yearbook_pull_list_sample = File.join(fixture_path, 'csv_import', 'yearbooks', 'Yearbooks-LIMB.csv')
     alma_export_sample = File.join(fixture_path, 'csv_import', 'yearbooks', 'yearbooks_marc.xml')
-    preprocessor = described_class.new(yearbook_pull_list_sample, alma_export_sample, 'Yearbooks/Emory', :limb)
+    preprocessor = described_class.new(yearbook_pull_list_sample, alma_export_sample, 'zizia', :limb)
     preprocessor.merge
   end
 
@@ -55,21 +55,21 @@ RSpec.describe YellowbackPreprocessor do
     campus_1981_pdf = import_rows[campus_1981_start + pdf_offset] # The Campus '81
     expect(campus_1981_pdf['type']).to eq('fileset')
     expect(campus_1981_pdf['fileset_label']).to eq('PDF for volume')
-    expect(campus_1981_pdf['preservation_master_file']).to eq('/Yearbooks/Emory/lsdi2/ftp/000011743488/PDF/000011743488.pdf')
+    expect(campus_1981_pdf['preservation_master_file']).to include('lsdi2/ftp/000011743488/PDF/000011743488.pdf')
   end
 
   it 'adds filesets for volume-level METS', :aggregate_failures do
     campus_1985_mets = import_rows[campus_1985_start + mets_offset] # The Campus '85
     expect(campus_1985_mets['type']).to eq('fileset')
     expect(campus_1985_mets['fileset_label']).to eq('METS File')
-    expect(campus_1985_mets['preservation_master_file']).to eq('/Yearbooks/Emory/lsdi2/ftp/000011909908/METS/000011909908.mets.xml')
+    expect(campus_1985_mets['preservation_master_file']).to include('lsdi2/ftp/000011909908/METS/000011909908.mets.xml')
   end
 
   it 'adds filesets for volume-level OCR', :aggregate_failures do
     campus_1989_ocr = import_rows[campus_1989_start + ocr_offset] # The Campus '89
     expect(campus_1989_ocr['type']).to eq('fileset')
     expect(campus_1989_ocr['fileset_label']).to eq('OCR Output for Volume')
-    expect(campus_1989_ocr['preservation_master_file']).to eq('/Yearbooks/Emory/lsdi2/ocm25899106-4402/ocm25899106/Output/XML/Output.xml')
+    expect(campus_1989_ocr['preservation_master_file']).to include('lsdi2/ocm25899106-4402/ocm25899106/Output/XML/Output.xml')
   end
 
   it 'skips volume-level OCR if pull list info is missing', :aggregate_failures do
@@ -82,15 +82,15 @@ RSpec.describe YellowbackPreprocessor do
     first_page = import_rows[campus_1981_start + campus_81_offset + 1] # The Campus '81
     expect(first_page['type']).to eq('fileset')
     expect(first_page['fileset_label']).to eq('Page 1')
-    expect(first_page['preservation_master_file']).to eq('/Yearbooks/Emory/lsdi2/ftp/000011743488/TIFF/00000001.tif')
-    expect(first_page['extracted']).to eq('/Yearbooks/Emory/lsdi2/ftp/000011743488/ALTO/00000001.xml')
-    expect(first_page['transcript_file']).to eq('/Yearbooks/Emory/lsdi2/ftp/000011743488/OCR/00000001.txt')
+    expect(first_page['preservation_master_file']).to include('lsdi2/ftp/000011743488/TIFF/00000001.tif')
+    expect(first_page['extracted']).to include('lsdi2/ftp/000011743488/ALTO/00000001.xml')
+    expect(first_page['transcript_file']).to include('lsdi2/ftp/000011743488/OCR/00000001.txt')
     last_page = import_rows[campus_1981_start + campus_81_offset + 304]
     expect(last_page['type']).to eq('fileset')
     expect(last_page['fileset_label']).to eq('Page 304')
-    expect(last_page['preservation_master_file']).to eq('/Yearbooks/Emory/lsdi2/ftp/000011743488/TIFF/00000304.tif')
-    expect(last_page['extracted']).to eq('/Yearbooks/Emory/lsdi2/ftp/000011743488/ALTO/00000304.xml')
-    expect(last_page['transcript_file']).to eq('/Yearbooks/Emory/lsdi2/ftp/000011743488/OCR/00000304.txt')
+    expect(last_page['preservation_master_file']).to include('lsdi2/ftp/000011743488/TIFF/00000304.tif')
+    expect(last_page['extracted']).to include('lsdi2/ftp/000011743488/ALTO/00000304.xml')
+    expect(last_page['transcript_file']).to include('lsdi2/ftp/000011743488/OCR/00000304.txt')
   end
 
   it 'adds handles base-0 numbered works correctly', :aggregate_failures do
@@ -103,14 +103,14 @@ RSpec.describe YellowbackPreprocessor do
     first_page = base0_import_rows[emocad_1924_start + pages_offset + 1] # Emocad '24
     expect(first_page['type']).to eq('fileset')
     expect(first_page['fileset_label']).to eq('Page 0')
-    expect(first_page['preservation_master_file']).to eq('/Yearbooks/Emory/lsdi2/ftp/050000084033/TIFF/00000000.tif')
-    expect(first_page['extracted']).to eq('/Yearbooks/Emory/lsdi2/ftp/050000084033/ALTO/00000000.xml')
-    expect(first_page['transcript_file']).to eq('/Yearbooks/Emory/lsdi2/ftp/050000084033/OCR/00000000.txt')
+    expect(first_page['preservation_master_file']).to include('lsdi2/ftp/050000084033/TIFF/00000000.tif')
+    expect(first_page['extracted']).to include('lsdi2/ftp/050000084033/ALTO/00000000.xml')
+    expect(first_page['transcript_file']).to include('lsdi2/ftp/050000084033/OCR/00000000.txt')
     last_page = base0_import_rows[emocad_1924_start + pages_offset + 5]
     expect(last_page['type']).to eq('fileset')
     expect(last_page['fileset_label']).to eq('Page 4')
-    expect(last_page['preservation_master_file']).to eq('/Yearbooks/Emory/lsdi2/ftp/050000084033/TIFF/00000004.tif')
-    expect(last_page['extracted']).to eq('/Yearbooks/Emory/lsdi2/ftp/050000084033/ALTO/00000004.xml')
-    expect(last_page['transcript_file']).to eq('/Yearbooks/Emory/lsdi2/ftp/050000084033/OCR/00000004.txt')
+    expect(last_page['preservation_master_file']).to include('lsdi2/ftp/050000084033/TIFF/00000004.tif')
+    expect(last_page['extracted']).to include('lsdi2/ftp/050000084033/ALTO/00000004.xml')
+    expect(last_page['transcript_file']).to include('lsdi2/ftp/050000084033/OCR/00000004.txt')
   end
 end


### PR DESCRIPTION
- app/controllers/background_jobs_controller.rb: updates the argument list since the Replacement argument is no longer used.
- app/importers/yellowback_preprocessor.rb: 
  - removes the unwanted replacement path option.
  - adds importer argument to enable feature switching.
  - unfreezes the header_fields so that they can be interpolated into.
  - refactors and alters logic to accommodate for bulkrax.
  - removes the errant | (pipes) from populating in contributors.
  - excises .pos (extracted) from delivering for kirtas imports.
  - fixes copyright_date
 - spec/fixtures/csv_import/yellowbacks/yellowbacks_marc.xml: ensures there's at least one copyright value in the merged CSV.
 - spec/importers/kirtas_preprocessor_file_bulkrax_spec.rb: updates the expectations of the spec file below.
 - spec/importers/kirtas_preprocessor_file_spec.rb: brings the old spec file into compliance with the preprocessor-wide changes.

Requirements:

- The deduplication_key column should only be populated for works, not FileSets.
- The model column is the same as Zizia’s type column, but should be formatted as:
  - CurateGenericWork for work rows
  - FileSet for fileset rows 
- The parent column should contain:
  - For works, the source_collection_id or the Curate ID for the deposit collection if one exists. 
  - For filesets, the deduplication_key for the work the fileset is attached to.
- The title field should include the value currently stored in fileset_label for FileSet entries.
- The file column contains a list of all the filenames to attach to each fileset, separated by a semicolon. They should formatted such as the following:
  - 0001.tif;0001.txt
  - If we are using the zip upload method for Bulkrax, the file column should only contain filenames, not the full file path. 
- file_types column contains a list of all the filenames to attach, plus their fileset use. They should be formatted as follows. Separate multiple file entries with a “|”.
  - This type of collection typically only has a single file per fileset which is preservation_master_file.
  - filename1:fileuse1|filename2:fileuse2
  - 0001.tif:preservation_master_file|0001.txt:transcript
  - The file use suffixes should be formatted as:
    - preservation_master_file (e.g. *_ ARCH files)
    - intermediate_file (e.g. *_PROD files or compressed derivatives)
    - service_file (used for lower res image/AV files)
    - extracted_text (e.g. OCR files: .xml or .pos)
    - transcript (plain text versions e.g. .txt or .rtf)
- pcdm_use
  - Should be populated for all FileSet rows.
  - Primary Content is the default for all FileSet rows where the preservation_master_file is either a PDF, TIFF, or JP2 file. 
  - Supplemental Content is assigned for the OCR for Output for Volume FileSet (.xml file) only.
- contributors
  - This currently outputs a “|” character if the input is empty; we should remove this.
  - Related work: remove the MARC mapping that outputs “GEU” - [Alma output adjustments for book records](https://app.zenhub.com/workspaces/digital-library-project-5bf484ae4b5806bc2bf6875b/issues/emory-libraries/dlp-curate/738)
- copyright_date
  - We should only store a copyright date if it is specifically coded as such in the MARC record (which isn’t frequently done). Currently there is some kind of fallback that puts the value of date_issued in this field, but that isn’t always indicating copyright status.
  - Mapping should be to only store a value for this field (264 $c) if 264 is populated and has a second indicator of 4 (copyright date).
 