### PR TITLE
Prevent duplicate manifest regeneration

### DIFF
--- a/app/controllers/manifest_regeneration_controller.rb
+++ b/app/controllers/manifest_regeneration_controller.rb
@@ -6,9 +6,7 @@ class ManifestRegenerationController < ApplicationController
 
   def regen_manifest
     solr_doc = SolrDocument.find(params[:work_id])
-    key = solr_doc[:manifest_cache_key_tesim]&.first.to_s + '_' + params[:work_id]
-    file_path = File.join(iiif_manifest_cache, key)
-    File.delete(file_path) if File.exist?(file_path)
+    ManifestBuilderService.regenerate_manifest(presenter: presenter(solr_doc), curation_concern: CurateGenericWork.find(params[:work_id]))
     redirect_to hyrax_curate_generic_work_path(params[:work_id])
   end
 

--- a/spec/controllers/manifest_regeneration_controller_spec.rb
+++ b/spec/controllers/manifest_regeneration_controller_spec.rb
@@ -28,13 +28,9 @@ RSpec.describe ManifestRegenerationController, type: :controller, clean: true do
       end
 
       it "queues up fileset cleanup job" do
-        # Below is a revision on 8/25/21. Since this method is only used on the show page
-        # and that page load always calls the build_manifest function, it is unnecessary
-        # to call it again. In the past, this has caused two simultaneous jobs to be enqueued.
-        expect(ManifestBuilderService).not_to receive(:build_manifest).with(presenter: presenter, curation_concern: work)
+        expect(ManifestBuilderService).to receive(:regenerate_manifest).with(presenter: presenter, curation_concern: work)
         post :regen_manifest, params: { work_id: work }, xhr: true
-        expect(File.exist?("./tmp/abc123_#{work.id}")).to be_falsey
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end


### PR DESCRIPTION
Fixes #2002

@eporter23 @rotated8 please refer to the following insights in regards to the duplicate manifest regeneration issue.

### Problem

For manifest regeneration, we previously relied on the following method from the `ManifestBuilderService`:

```ruby
def manifest_builder
      solr_doc = ::SolrDocument.find(@curation_concern.id)
      key = solr_doc[:manifest_cache_key_tesim]&.first.to_s + '_' + solr_doc[:id]

      if File.exist?(File.join(iiif_manifest_cache, key))
        render_manifest_file(key: key)
      else
        ManifestPersistenceJob.perform_later(key: key, solr_doc: solr_doc, root_url: @presenter.manifest_url, manifest_metadata: @presenter.manifest_metadata,
                                             curation_concern: @curation_concern, sequence_rendering: sequence_rendering)
        ApplicationController.render(template: 'manifest/placeholder.json', assigns: { root_url: @presenter.manifest_url })
      end
    end

    def render_manifest_file(key:)
      manifest_file = File.open(File.join(iiif_manifest_cache, key))
      manifest = manifest_file.read
      manifest_file.close
      manifest
    end
```

Based on this implementation, if the cached manifest exists you render it, if not you generate a new one. When a user clicks "Regenerate Manifest", the app made a call to `ManifestRegenerationController#regen_manifest`, which deleted the cache manifest file, without triggering any new manifest regeneration, as shown below:

```ruby
def regen_manifest
    solr_doc = SolrDocument.find(params[:work_id])
    key = solr_doc[:manifest_cache_key_tesim]&.first.to_s + '_' + params[:work_id]
    file_path = File.join(iiif_manifest_cache, key)
    File.delete(file_path) if File.exist?(file_path)
    redirect_to hyrax_curate_generic_work_path(params[:work_id])
  end
```

Given the context above, whenever a user regenerated the manifest, they basically just deleted the current cached manifest file, and each time they visit a work, the following method triggers the manifest regeneration from `ManifestBuilderService#build_manifest`:

```ruby
def manifest
      headers['Access-Control-Allow-Origin'] = '*'
      render json: ManifestBuilderService.build_manifest(presenter: presenter, curation_concern: _curation_concern_type.find(params[:id]))
    end
```

This explains why each time the manifest was regenerated by a user, each time they or another user were to visit the work whose manifest was regenerated, a new regeneration job is queued (the system assumes a new regeneration is needed each time it detects no cache file is found).

### Solution

In this PR, I separate "building a manifest" from "regenerating a manifest". A manifest is regenerated only if the following is true:
- a cached manifest file does not exist
- if a user explicitly triggers manifest regeneration. When manifest regeneration is triggered, the current cache file is not deleted. Instead, it remains as is until the manifest regeneration job that was explicitly triggered concludes and overwrites it.

Otherwise, if a cached manifest file exists, and no manifest regeneration was trigged by a user, the system uses the cached manifest file each time the work is viewed.