### PR TITLE
Fix manifest regeneration duplicate jobs

### DIFF
--- a/app/jobs/manifest_persistence_job.rb
+++ b/app/jobs/manifest_persistence_job.rb
@@ -9,6 +9,7 @@ class ManifestPersistenceJob < Hyrax::ApplicationJob
                                                                                                 manifest_metadata:  manifest_metadata,
                                                                                                 manifest_rendering: sequence_rendering,
                                                                                                 image_concerns:     image_concerns(curation_concern) })
+    remove_outdated_manifests(solr_doc[:id])
     persist_manifest(key: key, manifest_json: manifest_json)
   end
 
@@ -18,6 +19,14 @@ class ManifestPersistenceJob < Hyrax::ApplicationJob
       File.open(File.join(iiif_manifest_cache, key), 'w+') do |f|
         f.write(manifest_json)
       end
+    end
+
+    def remove_outdated_manifests(solr_doc_id)
+      outdated_manifests = Dir.glob(iiif_manifest_cache + '/*').select do |path|
+        path.ends_with?("_#{solr_doc_id}")
+      end
+
+      outdated_manifests.each { |path| File.delete(path) if File.exist?(path) }
     end
 
     def image_concerns(curation_concern)

--- a/app/services/manifest_builder_service.rb
+++ b/app/services/manifest_builder_service.rb
@@ -28,8 +28,9 @@ class ManifestBuilderService
     if File.exist?(File.join(iiif_manifest_cache, key))
       render_manifest_file(key: key)
     else
+      placeholder_manifest = persist_placeholder_manifest(key)
       regenerate_manifest_file
-      ApplicationController.render(template: 'manifest/placeholder.json', assigns: { root_url: @presenter.manifest_url })
+      placeholder_manifest
     end
   end
 
@@ -66,6 +67,14 @@ class ManifestBuilderService
       manifest = manifest_file.read
       manifest_file.close
       manifest
+    end
+
+    def persist_placeholder_manifest(key)
+      manifest_json = ApplicationController.render(template: 'manifest/placeholder.json', assigns: { root_url: @presenter.manifest_url })
+      File.open(File.join(iiif_manifest_cache, key), 'w+') do |f|
+        f.write(manifest_json)
+      end
+      manifest_json
     end
 
     def request_base_url


### PR DESCRIPTION
Fixes #2002

Based on feedback from @eporter23 and @rotated8, I implemented the following in this PR:
- When no manifest exists for a Work, in addition to queueing a Sidekiq job to regenerate the manifest, we now also save a placeholder manifest file. This ensures each subsequent request to view the Work does not queue an additional duplicate manifest regeneration job. While the manifest regeneration job is processed, each request for the manifest of a Work will still receive a response with the placeholder manifest, which is generated using the file `app/views/manifest/placeholder.json.jbuilder`
- Before saving the newly generated manifest, we now delete all outdated manifest files, to ensure we only keep one accurate manifest per work, and avoid keeping outdated files.