### PR TITLE
Add Sidekiq and csv import details tests

### DIFF
--- a/app/controllers/csv_import_details_controller.rb
+++ b/app/controllers/csv_import_details_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class CsvImportDetailsController < ApplicationController
+  load_and_authorize_resource class: Zizia::CsvImport
+  load_and_authorize_resource class: Zizia::CsvImportDetail
+
   def index
     @csv_import_details = Zizia::CsvImportDetail.all
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,8 +47,6 @@ Rails.application.routes.draw do
 
   authenticate :user, ->(u) { u.admin? } do
     mount Sidekiq::Web => '/sidekiq'
-    get 'csv_import_details/index'
-    get 'csv_import_details/show/:id', to: 'csv_import_details#show', as: 'csv_import_detail'
   end
 
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
@@ -70,6 +68,9 @@ Rails.application.routes.draw do
   post "/concern/file_sets/:file_set_id/clean_up", to: "derivatives#clean_up"
   post '/concern/file_sets/:file_set_id/re_characterize', to: 'characterization#re_characterize', as: 'file_set_re_characterization'
   post "/concern/curate_generic_works/:work_id/regen_manifest", to: "manifest_regeneration#regen_manifest", as: 'regen_manifest'
+
+  get 'csv_import_details/index'
+  get 'csv_import_details/show/:id', to: 'csv_import_details#show', as: 'csv_import_detail'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/controllers/csv_import_details_controller_spec.rb
+++ b/spec/controllers/csv_import_details_controller_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CsvImportDetailsController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  let(:admin) { FactoryBot.create(:admin) }
+
+  describe '#index' do
+    context 'when a non-admin user is signed in' do
+      before do
+        sign_in user
+      end
+
+      it 'redirects due to unauthorized access' do
+        get :index
+        expect(response)
+          .to fail_redirect_and_flash(root_path,
+                                      'You are not authorized to access this page.')
+      end
+    end
+
+    context 'when an admin user is signed in' do
+      before do
+        sign_in admin
+      end
+
+      it 'is successful' do
+        get :index
+        expect(response).to be_successful
+      end
+    end
+
+    context 'when no user is signed in' do
+      it 'redirects due to unauthorized access' do
+        get :index
+        expect(response)
+          .to fail_redirect_and_flash(main_app.new_user_session_path,
+                                      'You need to sign in or sign up before continuing.')
+      end
+    end
+  end
+end

--- a/spec/system/sidekiq_dashboard_spec.rb
+++ b/spec/system/sidekiq_dashboard_spec.rb
@@ -27,4 +27,12 @@ RSpec.describe 'Sidekiq dashboard', integration: true, clean: true, type: :syste
       expect(page).to have_content 'Processes'
     end
   end
+
+  context 'when no user is signed in' do
+    it 'redirects to the sign in page' do
+      visit '/sidekiq'
+      expect(current_path).to eq '/sign_in'
+      expect(page).to have_content 'You need to sign in or sign up before continuing.'
+    end
+  end
 end

--- a/spec/system/sidekiq_dashboard_spec.rb
+++ b/spec/system/sidekiq_dashboard_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe 'Sidekiq dashboard', integration: true, clean: true, type: :syste
   context 'when no user is signed in' do
     it 'redirects to the sign in page' do
       visit '/sidekiq'
-      expect(current_path).to eq '/sign_in'
       expect(page).to have_content 'You need to sign in or sign up before continuing.'
     end
   end


### PR DESCRIPTION
- Add `csv_import_details_controller_spec.rb` to ensure only admin users can access `csv_import_details` related pages
- Edit `routes.rb` to remove the `csv_import_details` routes from authenticated routes. Upon further testing, I figured that the admin status verification was not properly done, so non-admin users could load `csv_import_details` if we did not enforce the `CanCanCan` rules at the controller level. Therefore, I added the `CanCanCan` rules to the `csv_import_details_controller.rb` and removed those routes from the authenticated routes.
- Add a test for non-authenticated users to `spec/system/sidekiq_dashboard_spec.rb` to ensure they are redirected to the sign in page and cannot access the Sidekiq dashboard.