### PR TITLE
Removes the redlock and extra update_index from the FS association job.

### DIFF
--- a/app/jobs/associate_filesets_with_work_job.rb
+++ b/app/jobs/associate_filesets_with_work_job.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class AssociateFilesetsWithWorkJob < Hyrax::ApplicationJob
-  include ::Hyrax::Lockable
   queue_as :import
 
   def perform(importer)
@@ -49,12 +48,9 @@ class AssociateFilesetsWithWorkJob < Hyrax::ApplicationJob
   end
 
   def associate_filesets_to_work(file_sets, work)
-    acquire_lock_for(work.id) do
-      unless file_sets&.map(&:id)&.all? { |id| work.reload.ordered_member_ids.include?(id) }
-        work.ordered_members += file_sets
-        work.save
-        work.update_index
-      end
+    unless file_sets&.map(&:id)&.all? { |id| work.reload.ordered_member_ids.include?(id) }
+      work.ordered_members += file_sets
+      work.save
     end
   end
 

--- a/app/jobs/associate_filesets_with_work_job.rb
+++ b/app/jobs/associate_filesets_with_work_job.rb
@@ -48,10 +48,9 @@ class AssociateFilesetsWithWorkJob < Hyrax::ApplicationJob
   end
 
   def associate_filesets_to_work(file_sets, work)
-    unless file_sets&.map(&:id)&.all? { |id| work.reload.ordered_member_ids.include?(id) }
-      work.ordered_members += file_sets
-      work.save
-    end
+    return if file_sets&.map(&:id)&.all? { |id| work.reload.ordered_member_ids.include?(id) }
+    work.ordered_members += file_sets
+    work.save
   end
 
   def announce_filesets_attachement(file_sets)


### PR DESCRIPTION
The locking of the work has been backfiring on importation. Instead of ensuring that the work is free and clear to be persisted upon (which really shouldn't be an issue because this is the last Job to perform during the import), the built-in timeout of the locking is lapsing because each 
```
work.save
work.update_index
```
take about five minutes or longer to complete. I believe the lock is set to 4 minutes, which probably leads to the two recent issues in the production environment (the reindexing after saving not happening and the recent work not having the FileSets associated.)