### PR TITLE
Add keyword matches to search results

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,3 +26,4 @@
 //= require almond
 //= require zizia/application
 //= require bulkrax/application
+//= require newspaper_works/ocr_search

--- a/app/assets/javascripts/newspaper_works/ocr_search.js.erb
+++ b/app/assets/javascripts/newspaper_works/ocr_search.js.erb
@@ -1,0 +1,14 @@
+<%#
+# gem 'newspaper_works', v1.0.2
+# Refer to the gem repository for more details: https://github.com/samvera-labs/newspaper_works
+# Released under license Apache License 2.0: https://github.com/samvera-labs/newspaper_works/blob/main/LICENSE
+# This gem is not yet compatible with Hyrax v3, hence why I am only using the portions relevant to our use case
+# This gem is used for keyword highlighting in search results
+%>
+
+/* toggle the ocr snippets collapse link text */
+$(document).ready(function(){
+  $('.ocr_snippets_expand').click(function() {
+    $(this).text($(this).text() == '<%= I18n.t('blacklight.search.results.snippets.more') %>' ? '<%= I18n.t('blacklight.search.results.snippets.less') %>' : '<%= I18n.t('blacklight.search.results.snippets.more') %>');
+  });
+});

--- a/app/assets/stylesheets/_search_results.scss
+++ b/app/assets/stylesheets/_search_results.scss
@@ -4,6 +4,14 @@
 // This gem is not yet compatible with Hyrax v3, hence why I am only using the portions relevant to our use case
 // This gem is used for keyword highlighting in search results
 
+$highlight-background-color: rgba(5,166,86,0.36);
+
+#search-results .thumbnail_highlight, #documents .thumbnail_highlight {
+  background-color: $highlight-background-color;
+  z-index: 1000;
+  position: absolute;
+}
+
 .metadata em {
   background-color: $highlight-background-color;
   font-weight: bold;

--- a/app/assets/stylesheets/_search_results.scss
+++ b/app/assets/stylesheets/_search_results.scss
@@ -1,0 +1,10 @@
+// gem 'newspaper_works', v1.0.2
+// Refer to the gem repository for more details: https://github.com/samvera-labs/newspaper_works
+// Released under license Apache License 2.0: https://github.com/samvera-labs/newspaper_works/blob/main/LICENSE
+// This gem is not yet compatible with Hyrax v3, hence why I am only using the portions relevant to our use case
+// This gem is used for keyword highlighting in search results
+
+.metadata em {
+  background-color: $highlight-background-color;
+  font-weight: bold;
+}

--- a/app/assets/stylesheets/curate.scss
+++ b/app/assets/stylesheets/curate.scss
@@ -1,3 +1,5 @@
+@import 'search_results';
+
 .ui-autocomplete-loading {
   background: #fff url("/assets/loading.gif") right center no-repeat;
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -3,7 +3,6 @@
 class CatalogController < ApplicationController
   include Hydra::Catalog
   include Hydra::Controller::ControllerBehavior
-  include NewspaperWorks::NewspaperWorksHelperBehavior
 
   # This filter applies the hydra access controls
   before_action :enforce_show_permissions, only: :show

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -3,6 +3,7 @@
 class CatalogController < ApplicationController
   include Hydra::Catalog
   include Hydra::Controller::ControllerBehavior
+  include NewspaperWorks::NewspaperWorksHelperBehavior
 
   # This filter applies the hydra access controls
   before_action :enforce_show_permissions, only: :show
@@ -84,6 +85,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'human_readable_visibility_ssi', label: 'Visibility', itemprop: 'human_readable_visibility'
     config.add_index_field 'deduplication_key_tesim', label: 'Deduplication Key', itemprop: 'deduplication_key'
     config.add_index_field 'id', label: 'ID', itemprop: 'id'
+    config.add_index_field 'all_text_tsimv', highlight: true, helper_method: :render_ocr_snippets
 
     # solr fields to be displayed in the show (single result) view
     # The ordering of the field names is the order of the display

--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -4,4 +4,5 @@ module HyraxHelper
   include ::BlacklightHelper
   include Hyrax::BlacklightOverride
   include Hyrax::HyraxHelperBehavior
+  include NewspaperWorks::NewspaperWorksHelperBehavior
 end

--- a/app/helpers/newspaper_works/newspaper_works_helper_behavior.rb
+++ b/app/helpers/newspaper_works/newspaper_works_helper_behavior.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+# gem 'newspaper_works', v1.0.2
+# Refer to the gem repository for more details: https://github.com/samvera-labs/newspaper_works
+# Released under license Apache License 2.0: https://github.com/samvera-labs/newspaper_works/blob/main/LICENSE
+# This gem is not yet compatible with Hyrax v3, hence why I am only using the portions relevant to our use case
+# This gem is used for keyword highlighting in search results
+
+module NewspaperWorks
+  module NewspaperWorksHelperBehavior
+    ##
+    # create link anchor to be read by UniversalViewer
+    # in order to show keyword search
+    # @param query_params_hash [Hash] current_search_session.query_params
+    # @return [String] or [nil] anchor
+    def iiif_search_anchor(query_params_hash)
+      query = search_query(query_params_hash)
+      return nil if query.blank?
+      "?h=#{query}"
+    end
+
+    ##
+    # get the query, which may be in a different object,
+    #   depending if regular search or newspapers_search was run
+    # @param query_params_hash [Hash] current_search_session.query_params
+    # @return [String] or [nil] query
+    def search_query(query_params_hash)
+      query_params_hash[:q] || query_params_hash[:all_fields]
+    end
+
+    ##
+    # based on Blacklight::CatalogHelperBehavior#render_thumbnail_tag
+    # setup the thumbnail link for a NewspaperPage or Article
+    #
+    # @param document [SolrDocument]
+    # @param query_params_hash [Hash] current_search_session.query_params
+    # @return [String]
+    def render_newspaper_thumbnail_tag(document, query_params_hash)
+      thumbnail = newspaper_thumbnail_tag(document)
+      return unless thumbnail
+      anchor = iiif_search_anchor(query_params_hash)
+      case document[blacklight_config.view_config(document_index_view_type).display_type_field].first
+      when 'NewspaperPage'
+        link_to(thumbnail, hyrax_newspaper_page_path(document.id, anchor: anchor))
+      when 'NewspaperArticle'
+        link_to(thumbnail, hyrax_newspaper_article_path(document.id, anchor: anchor))
+      else
+        link_to_document document, thumbnail
+      end
+    end
+
+    ##
+    # based on Blacklight::CatalogHelperBehavior#render_thumbnail_tag
+    # return the thumbnail image_tag
+    #
+    # @param document [SolrDocument]
+    # @return [String]
+    def newspaper_thumbnail_tag(document)
+      if blacklight_config.view_config(document_index_view_type).thumbnail_method
+        send(blacklight_config.view_config(document_index_view_type).thumbnail_method,
+             document)
+      elsif blacklight_config.view_config(document_index_view_type).thumbnail_field
+        url = thumbnail_url(document)
+        image_tag url if url.present?
+      end
+    end
+
+    ##
+    # return the matching highlighted terms from Solr highlight field
+    #
+    # @param document [SolrDocument]
+    # @param hl_fl [String] the name of the Solr field with highlights
+    # @param hl_tag [String] the HTML element name used for marking highlights
+    #   configured in Solr as hl.tag.pre value
+    # @return [String]
+    def highlight_matches(document, hl_fl, hl_tag)
+      hl_matches = []
+      # regex: find all chars between hl_tag, but NOT other <element>
+      regex = /<#{hl_tag}>[^<>]+<\/#{hl_tag}>/
+      hls = document.highlight_field(hl_fl)
+      return nil if hls.blank?
+      hls.each do |hl|
+        matches = hl.scan(regex)
+        matches.each do |match|
+          hl_matches << match.gsub(/<[\/]*#{hl_tag}>/, '').downcase
+        end
+      end
+      hl_matches.uniq.sort.join(' ')
+    end
+
+    ##
+    # print the ocr snippets. if more than one, separate with <br/>
+    #
+    # @param options [Hash] options hash provided by Blacklight
+    # @return [String] snippets HTML to be rendered
+    # rubocop:disable Rails/OutputSafety
+    def render_ocr_snippets(options = {})
+      snippets = options[:value]
+      snippets_content = [tag.div("... #{snippets.first} ...".html_safe,
+                                      class: 'ocr_snippet first_snippet')]
+      if snippets.length > 1
+        snippets_content << render(partial: 'catalog/snippets_more',
+                                   locals:  { snippets: snippets.drop(1),
+                                              options:  options })
+      end
+      snippets_content.join("\n").html_safe
+    end
+    # rubocop:enable Rails/OutputSafety
+  end
+end

--- a/app/lib/newspaper_works/highlight_search_params.rb
+++ b/app/lib/newspaper_works/highlight_search_params.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+# gem 'newspaper_works', v1.0.2
+# Refer to the gem repository for more details: https://github.com/samvera-labs/newspaper_works
+# Released under license Apache License 2.0: https://github.com/samvera-labs/newspaper_works/blob/main/LICENSE
+# This gem is not yet compatible with Hyrax v3, hence why I am only using the portions relevant to our use case
+# This gem is used for keyword highlighting in search results
+
+module NewspaperWorks
+  # add highlighting on _stored_ full text field if this is a keyword search
+  # can be added to default_processor_chain in a SearchBuilder class
+  module HighlightSearchParams
+    # add highlights on full text field, if there is a keyword query
+    def highlight_search_params(solr_parameters = {})
+      return unless solr_parameters[:q] || solr_parameters[:all_fields]
+      solr_parameters[:hl] = true
+      solr_parameters[:'hl.fl'] = 'all_text_tsimv'
+      solr_parameters[:'hl.fragsize'] = 100
+      solr_parameters[:'hl.snippets'] = 5
+    end
+  end
+end

--- a/app/models/curate_generic_work.rb
+++ b/app/models/curate_generic_work.rb
@@ -329,9 +329,9 @@ class CurateGenericWork < ActiveFedora::Base
   def full_text_data
     label = "Full Text Data - #{id}"
     # rubocop:disable Rails/FindBy
-    file_set = FileSet.where(label: label)&.last
+    file_set = FileSet.where(label: label)&.order('date_uploaded_dtsi desc')&.first
     # rubocop:enable Rails/FindBy
-    file_set.present? ? file_set.files&.last&.content : nil
+    file_set.present? ? file_set.preservation_master_file&.content : nil
   end
 
   # accepts_nested_attributes_for can not be called until all

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
+
+require './app/lib/newspaper_works/highlight_search_params.rb'
+
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
   # Add a filter query to restrict the search to documents the current user has access to
   include Hydra::AccessControlsEnforcement
   include Hyrax::SearchFilters
+  include NewspaperWorks::HighlightSearchParams
+
+  self.default_processor_chain += [:highlight_search_params]
 
   ##
   # @example Adding a new step to the processor chain

--- a/app/views/catalog/_snippets_more.html.erb
+++ b/app/views/catalog/_snippets_more.html.erb
@@ -1,0 +1,24 @@
+<%#
+# gem 'newspaper_works', v1.0.2
+# Refer to the gem repository for more details: https://github.com/samvera-labs/newspaper_works
+# Released under license Apache License 2.0: https://github.com/samvera-labs/newspaper_works/blob/main/LICENSE
+# This gem is not yet compatible with Hyrax v3, hence why I am only using the portions relevant to our use case
+# This gem is used for keyword highlighting in search results
+%>
+
+<%# additional ocr snippets, with a Bootstrap collapse toggle control %>
+<% document_id = options[:document].id %>
+<div class="collapse ocr_snippet" id="<%= "snippet_collapse_#{document_id}" %>">
+  <% snippets.each do |snippet| %>
+    <%= content_tag('div',
+                    "... #{snippet} ...".html_safe,
+                    class: 'ocr_snippet') %>
+  <% end %>
+</div>
+<%= link_to(t('blacklight.search.results.snippets.more'),
+            "#snippet_collapse_#{document_id}",
+            data: {toggle: 'collapse'},
+            'aria-expanded' => 'false',
+            'aria-controls' => "#snippet_collapse_#{document_id}",
+            class: 'ocr_snippets_expand js-controls')
+%>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,3 +1,10 @@
 en:
   blacklight:
     application_name: 'Blacklight'
+    search:
+      fields:
+        all_text_tsimv: 'Keyword matches'
+      results:
+        snippets:
+          less: '<< less'
+          more: 'more >>'


### PR DESCRIPTION
Implements #2063

In this PR, I used the OCR search implementation from the Samvera [newspaper_works](https://github.com/samvera-labs/newspaper_works) to implement keyword matches highlighting for search results. See example below:

![Screenshot 2022-12-20 at 12 23 40 PM](https://user-images.githubusercontent.com/13107510/208739808-9ee8c056-a0eb-43df-8c78-1a4dbd1ab23c.png)

The reason I use some files from the `newspaper_works` gem directly instead of installing an entire version using bundler is the current dependence of the gem on Hyrax v2, and the unavailability of any official release that supports Hyrax v3. In this PR, I only use files from v1.0.2 of the gem to server our specific use case, which is displaying keyword matches under search results, for any results that actually have full text data that matches the keywords searched.
