### PR TITLE
Corrects the problems blocking custom sorting options in Importer index.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,10 +16,10 @@
 //= require turbolinks
 //
 // Required by Blacklight
-//= require jquery
-//= require jquery_ujs
-//= require dataTables/jquery.dataTables
-//= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
+//= require jquery3
+//= require rails-ujs
+//= require datatables.net/js/jquery.dataTables
+//= require datatables.net-bs4/js/dataTables.bootstrap4
 //= require blacklight/blacklight
 //= require hyrax
 //= require hyrax/autocomplete/default

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -15,7 +15,6 @@
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
 
-import 'jquery'
 import 'jquery-validation';
 import 'bootstrap/dist/js/bootstrap';
-import 'validation'
+import 'validation';

--- a/app/views/bulkrax/importers/index.html.erb
+++ b/app/views/bulkrax/importers/index.html.erb
@@ -41,8 +41,8 @@
               <tr>
                 <th scope="row"><%= link_to importer.name, importer_path(importer) %></th>
                 <td><%= importer.status %></td>
-                <td><%= importer.last_imported_at.strftime("%b %d, %Y %T") if importer.last_imported_at %></td>
-                <td><%= importer.next_import_at.strftime("%b %d, %Y %T") if importer.next_import_at %></td>
+                <td><%= importer.last_imported_at.strftime("%F %T") if importer.last_imported_at %></td>
+                <td><%= importer.next_import_at.strftime("%F %T") if importer.next_import_at %></td>
                 <td><%= importer.last_run&.enqueued_records %></td>
                 <td><%= (importer.last_run&.processed_records || 0) %></td>
                 <td><%= (importer.last_run&.failed_records || 0) %></td>

--- a/app/views/bulkrax/importers/index.html.erb
+++ b/app/views/bulkrax/importers/index.html.erb
@@ -1,4 +1,4 @@
-<%# Bulkrax v4.2.1 Override: L#6 adds turbolinks block so that Javascript can remove the rest of the form options. %>
+<%# Bulkrax v4.3.0 Override: L#6 adds turbolinks block so that Javascript can remove the rest of the form options. %>
 
 <% provide :page_header do %>
   <h1><span class="fa fa-cloud-upload" aria-hidden="true"></span> Importers</h1>
@@ -41,8 +41,8 @@
               <tr>
                 <th scope="row"><%= link_to importer.name, importer_path(importer) %></th>
                 <td><%= importer.status %></td>
-                <td><%= importer.last_imported_at.strftime("%b %d, %Y") if importer.last_imported_at %></td>
-                <td><%= importer.next_import_at.strftime("%b %d, %Y") if importer.next_import_at %></td>
+                <td><%= importer.last_imported_at.strftime("%b %d, %Y %T") if importer.last_imported_at %></td>
+                <td><%= importer.next_import_at.strftime("%b %d, %Y %T") if importer.next_import_at %></td>
                 <td><%= importer.last_run&.enqueued_records %></td>
                 <td><%= (importer.last_run&.processed_records || 0) %></td>
                 <td><%= (importer.last_run&.failed_records || 0) %></td>
@@ -68,6 +68,7 @@
   $(function() {
     $('#DataTables_Table_0').DataTable({
       destroy: true, /* Reinitialize DataTable with config below */
+      order: [[2, 'desc']],
       'columnDefs': [
           { 'orderable': true, 'targets': [...Array(10).keys()] },
           { 'orderable': false, 'targets': [10, 11, 12] }

--- a/app/views/bulkrax/importers/index.html.erb
+++ b/app/views/bulkrax/importers/index.html.erb
@@ -70,8 +70,8 @@
       destroy: true, /* Reinitialize DataTable with config below */
       order: [[2, 'desc']],
       'columnDefs': [
-          { 'orderable': true, 'targets': [...Array(10).keys()] },
-          { 'orderable': false, 'targets': [10, 11, 12] }
+          { 'orderable': true, 'targets': [...Array(11).keys()] },
+          { 'orderable': false, 'targets': [11, 12, 13] }
       ],
       'language': {
         'info': 'Showing _START_ to _END_ of _TOTAL_ importers',

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "jquery": "*",
     "jquery-validation": "*",
     "popper.js": "*",
-    "universalviewer": "3.0.16"
+    "universalviewer": "3.0.16",
+    "datatables.net-bs4": "*",
+    "handlebars": "^4"
   },
   "scripts": {
     "preinstall": "rm -rf ./public/uv",

--- a/spec/system/create_collection_spec.rb
+++ b/spec/system/create_collection_spec.rb
@@ -28,8 +28,11 @@ RSpec.describe 'Creating a collection', :perform_jobs, clean: true, admin_set: t
       visit("dashboard/collections/new?collection_type_id=1")
       expect(page).to have_css("textarea#collection_title")
       click_link('Additional fields')
-      expect(page).to have_css("input#collection_creator")
-      expect(page).to have_content("Add another Creator (creator)")
+
+      within('.form-group.multi_value.required.collection_creator.managed') do
+        expect(page).to have_css("input#collection_creator")
+        expect(page).to have_content("Add another")
+      end
     end
 
     it "validates url fields" do

--- a/spec/system/create_curate_generic_work_spec.rb
+++ b/spec/system/create_curate_generic_work_spec.rb
@@ -52,20 +52,25 @@ RSpec.describe 'Create a CurateGenericWork', integration: true, clean: true, typ
       expect(page).to have_css('#metadata select#curate_generic_work_rights_statement')
 
       click_link('Additional descriptive fields')
-      expect(page).to have_content('Add another Note (notes)')
-
-      expect(page).to have_css('#metadata textarea#curate_generic_work_staff_notes')
-      expect(page).to have_content('Add another Staff Note (staff_notes)')
+      within('.form-group.multi_value.optional.curate_generic_work_notes.managed') do
+        expect(page).to have_content('Add another')
+      end
+      within('.form-group.multi_value.optional.curate_generic_work_staff_notes.managed') do
+        expect(page).to have_css('#metadata textarea#curate_generic_work_staff_notes')
+        expect(page).to have_content('Add another')
+      end
     end
 
     scenario "repeating entries in the form", js: true do
       new_cgw_form.visit_new_page
-      expect(page).to have_content('Creator (creator)')
-      expect(page).to have_css('input#curate_generic_work_creator.multi_value')
-      fill_in "curate_generic_work[creator][]", with: "first creator"
-      click_on 'Add another Creator (creator)'
-      expect(all("input[name='curate_generic_work[creator][]']").count).to eq(2)
-      expect(page).not_to have_css('input#curate_generic_work_title.multi_value')
+      within('.form-group.multi_value.optional.curate_generic_work_creator.managed') do
+        expect(page).to have_content('Creator (creator)')
+        expect(page).to have_css('input#curate_generic_work_creator.multi_value')
+        fill_in "curate_generic_work[creator][]", with: "first creator"
+        click_on 'Add another'
+        expect(all("input[name='curate_generic_work[creator][]']").count).to eq(2)
+        expect(page).not_to have_css('input#curate_generic_work_title.multi_value')
+      end
     end
 
     scenario "invalid etdf of Date Created", js: true do

--- a/yarn.lock
+++ b/yarn.lock
@@ -2228,6 +2228,21 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==
 
+datatables.net-bs4@*:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/datatables.net-bs4/-/datatables.net-bs4-1.13.1.tgz#b704d9639bbe650c996e614dc37f529e8c09ff47"
+  integrity sha512-GBTOzUT8ooEUMPtjVHktvDk0MyakFGh89F8aHj8VwF1OFLbqTGEAPacO8XAgSfej/Ng3dbFJA6sjrk4gFra8kg==
+  dependencies:
+    datatables.net ">=1.12.1"
+    jquery ">=1.7"
+
+datatables.net@>=1.12.1:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.13.1.tgz#199f7cb63f4536c135e161f95254212835a1c130"
+  integrity sha512-cX5dDHsbVdLLYKsWOSE0MvuGUcV88zU5dZ/taK2puJV6F9Fw0CFsP3+U/kr+qpDSFOBLWISRyM4Q9wWWovPTNg==
+  dependencies:
+    jquery ">=1.7"
+
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -2871,6 +2886,18 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
+handlebars@^4:
+  version "4.7.7"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
+  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -3418,6 +3445,11 @@ jquery@*:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
 
+jquery@>=1.7:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.2.tgz#8302bbc9160646f507bdf59d136a478b312783c4"
+  integrity sha512-/e7ulNIEEYk1Z/l4X0vpxGt+B/dNsV8ghOPAWZaJs8pkGvsSC0tm33aMGylXcj/U7y4IcvwtMXPMyBFZn/gK9A==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -3713,7 +3745,7 @@ minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
   integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
@@ -3849,7 +3881,7 @@ nearley@^2.19.7:
     railroad-diagrams "^1.0.0"
     randexp "0.4.6"
 
-neo-async@^2.5.0, neo-async@^2.6.1, neo-async@^2.6.2:
+neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
@@ -5815,6 +5847,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
+uglify-js@^3.1.4:
+  version "3.17.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"
+  integrity sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==
+
 unbox-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
@@ -6089,6 +6126,11 @@ which@^1.2.14, which@^1.2.9, which@^1.3.1:
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
+
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 worker-farm@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
- app/assets/javascripts/application.js: before this change, we were working with the combo of jQuery 1 and Bootstrap3 Datatables. Since we are using both jQuery3 and Bootstrap 4, this code makes clear what is required by the application.
- app/javascript/packs/application.js: removes the other reference to jQuery 1, bringing the application into v3.
- app/views/bulkrax/importers/index.html.erb: 
  - changes the date/time format so that they are easily sortable.
  - default sorts by `Last Run` column, so that it shows the latest import at the top of the list.
  - corrects the columns that should be sortable.
- package.json and yarn.lock: brings in the new javascript requirements.