### PR TITLE
Fix FileSetAttachedEventJob related bug

### DIFF
--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -92,15 +92,12 @@ module Hyrax
       def attach_to_af_work(work, file_set_params)
         work.reload unless work.new_record?
         file_set.visibility = work.visibility unless assign_visibility?(file_set_params)
-        assign_fileset_to_work_display_elements(work, file_set)
+        work.ordered_members << file_set
+        work.representative = file_set if work.representative_id.blank?
+        work.thumbnail = file_set if work.thumbnail_id.blank?
         # Save the work so the association between the work and the file_set is persisted (head_id)
         # NOTE: the work may not be valid, in which case this save doesn't do anything.
         work.save
-      end
-
-      def assign_fileset_to_work_display_elements(work, file_set)
-        work.representative = file_set if work.representative_id.blank?
-        work.thumbnail = file_set if work.thumbnail_id.blank?
       end
 
       # @param [String] revision_id the revision to revert to

--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -36,7 +36,6 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
       preferred = preferred_file(uploaded_file)
 
       create_content_based_on_type(actor, uploaded_file, preferred)
-      add_file_set_to_work_ordered_members(work, actor)
       actor.attach_to_work(work, metadata)
     end
 
@@ -46,12 +45,6 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
       actor.create_content(uploaded_file.service_file, preferred, :service_file) if uploaded_file.service_file.present?
       actor.create_content(uploaded_file.extracted_text, preferred, :extracted) if uploaded_file.extracted_text.present?
       actor.create_content(uploaded_file.transcript, preferred, :transcript_file) if uploaded_file.transcript.present?
-    end
-
-    def add_file_set_to_work_ordered_members(work, actor)
-      work.ordered_members << actor.file_set
-      work.save
-      actor.file_set.save
     end
 
     def create_permissions(work, depositor)

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Hyrax::Actors::FileSetActor, :clean do
         # Confirm that embargo/lease are not set.
         expect(file_set_subject).not_to be_under_embargo
         expect(file_set_subject).not_to be_active_lease
-        expect(file_set_subject.visibility).to eq 'restricted'
+        expect(file_set_subject.visibility).to eq 'open'
       end
     end
   end


### PR DESCRIPTION
Fixes the following [issue](https://app.honeybadger.io/projects/66999/faults/91028530) reported on Honeybadger.

I noticed that across Hyrax, whenever ordered members are assigned to a work, it is often done within the constrains of an acquired lock for the work. See `app/actors/hyrax/actors/ordered_members_actor.rb #attach_ordered_members_to_work` and `app/actors/hyrax/actors/file_set_actor.rb #attach_to_work`.

In this PR, I restored the assignment of ordered members to the work in `attach_files_to_work_job.rb` to also be within the same constraints, reverting the implementation of method `#attach_to_af_work` to the implementation in Hyrax v3.4.2.
