### PR TITLE
Adds the Object IDs type to the exporter.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,6 +59,7 @@ Metrics/CyclomaticComplexity:
         - app/indexers/curate/file_set_indexer.rb
         - app/jobs/characterize_job.rb
         - app/models/concerns/hydra/access_controls/visibility.rb
+        - config/initializers/bulkrax.rb
         - config/initializers/file_actor.rb
 
 Layout/HashAlignment:
@@ -91,6 +92,7 @@ Metrics/MethodLength:
         - app/presenters/hyrax/collection_presenter.rb
         - app/presenters/hyrax/curate_collection_presenter.rb
         - app/uploaders/zizia/csv_manifest_validator.rb
+        - config/initializers/bulkrax.rb
         - spec/fixtures/manifest_output.rb
         - spec/fixtures/placeholder_manifest_output.rb
 
@@ -155,3 +157,7 @@ RSpec/NestedGroups:
     Exclude:
         - spec/controllers/hyrax/downloads_controller_spec.rb
         - spec/controllers/hyrax/file_sets_controller_spec.rb
+
+Style/Alias:
+    Exclude:
+        - config/initializers/bulkrax.rb

--- a/app/views/bulkrax/exporters/_form.html.erb
+++ b/app/views/bulkrax/exporters/_form.html.erb
@@ -1,0 +1,144 @@
+<div class="panel-body">
+  <% if exporter.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(exporter.errors.count, "error") %> prohibited this exporter from being saved:</h2>
+
+      <ul>
+        <% exporter.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <%= form.input :name, label: t('bulkrax.exporter.labels.name') %>
+
+  <%= form.hidden_field :user_id, value: current_user.id %>
+
+  <%= form.input :export_type,
+    collection:  form.object.export_type_list,
+    label: t('bulkrax.exporter.labels.export_type'),
+    required: true,
+    prompt: 'Please select an export type' %>
+
+  <%= form.input :export_from,
+    collection: form.object.export_from_list,
+    label: t('bulkrax.exporter.labels.export_from'),
+    required: true,
+    prompt: 'Please select an export source' %>
+
+  <%= form.input :export_source_importer,
+    label: t('bulkrax.exporter.labels.importer'),
+    # required: true,
+    prompt: 'Select from the list',
+    label_html: { class: 'importer export-source-option hidden' },
+    input_html: { class: 'importer export-source-option hidden' },
+    collection:  form.object.importers_list.sort %>
+
+  <%= form.input :export_source_collection,
+    prompt: 'Start typing ...',
+    label: t('bulkrax.exporter.labels.collection'),
+    # required: true,
+    placeholder: @collection&.title&.first,
+    label_html: { class: 'collection export-source-option hidden' },
+    input_html: {
+      class: 'collection export-source-option hidden',
+      data: {
+        'autocomplete-url' => '/authorities/search/collections',
+        'autocomplete' => 'collection'
+      }
+    }
+  %>
+
+  <%= form.input :export_source_object_ids,
+    as: :text,
+    placeholder: "Enter IDs of only collections or works separated by a pipe (\"|\"). When a collection's ID is provided, the child works of the collection will not automatically be added to the exported CSV. The desired works must be added to the ID list. When works are detected, the associated filesets will be found and added to the list by this application.",
+    label: 'Object IDs',
+    # required: true,
+    label_html: { class: 'object_ids export-source-option hidden' },
+    input_html: {
+      class: 'object_ids export-source-option hidden'
+    }
+  %>
+
+  <%= form.input :export_source_worktype,
+    label: t('bulkrax.exporter.labels.worktype'),
+    # required: true,
+    prompt: 'Select from the list',
+    label_html: { class: 'worktype export-source-option hidden' },
+    input_html: { class: 'worktype export-source-option hidden' },
+    collection: Hyrax.config.curation_concerns.map {|cc| [cc.to_s, cc.to_s] } %>
+
+  <%= form.input :limit,
+    as: :integer,
+    hint: 'leave blank or 0 for all records',
+    label: t('bulkrax.exporter.labels.limit') %>
+
+  <%= form.input :generated_metadata?,
+                 as: :boolean,
+                 label: t('bulkrax.exporter.labels.generated_metadata'),
+                 hint: t('bulkrax.exporter.hints.generated_metadata') %>
+
+  <%= form.input :include_thumbnails?,
+                 as: :boolean,
+                 label: t('bulkrax.exporter.labels.include_thumbnails'),
+                 hint: t('bulkrax.exporter.hints.include_thumbnails') %>
+
+  <%= form.input :date_filter,
+                 as: :boolean,
+                 label: t('bulkrax.exporter.labels.filter_by_date') %>
+  <div id="date_filter_picker" class="hidden">
+    <%= form.input :start_date,
+                   as: :date,
+                   label: t('bulkrax.exporter.labels.start_date') %>
+
+    <%= form.input :finish_date,
+                   as: :date,
+                   label: t('bulkrax.exporter.labels.finish_date') %>
+  </div>
+  <%= form.input :work_visibility,
+                 collection: form.object.work_visibility_list,
+                 label: t('bulkrax.exporter.labels.visibility') %>
+
+  <%= form.input :workflow_status,
+                 collection: form.object.workflow_status_list,
+                 label: t('bulkrax.exporter.labels.status') %>
+
+  <%= form.input :parser_klass,
+    collection: Bulkrax.parsers.map {|p| [p[:name], p[:class_name], {'data-partial' => p[:partial]}] if p[:class_name].constantize.export_supported? }.compact,
+    label: t('bulkrax.exporter.labels.export_format') %>
+</div>
+
+<%# Find definitions for the functions called in this script in
+    app/assets/javascripts/bulkrax/exporters.js %>
+<script>
+  $(function() {
+    // show the selected export_source option
+    var selectedVal = $('.exporter_export_from option:selected').val();
+    hideUnhide(selectedVal);
+
+    // Select2 dropdowns don't like taking a value param. Thus,
+    // if export_source_collection is present, we populate the input.
+    var selectedCollectionId = "<%= @collection&.id %>"
+    if (selectedCollectionId.length > 0) {
+      $('#exporter_export_source_collection').val(selectedCollectionId)
+    }
+
+    // get the selected export_from option and show the corresponding export_source
+    $('.exporter_export_from').change(function() {
+      var selectedVal = $('.exporter_export_from option:selected').val();
+      hideUnhide(selectedVal);
+    });
+
+    // get the date filter option and show the corresponding date selectors
+    $('.exporter_date_filter').change(function() {
+        if($('.exporter_date_filter').find(".boolean").is(":checked"))
+            $('#date_filter_picker').removeClass('hidden');
+        else
+            $('#date_filter_picker').addClass('hidden');
+    });
+
+    if($('.exporter_date_filter').find(".boolean").is(":checked"))
+        $('#date_filter_picker').removeClass('hidden');
+  });
+</script>

--- a/app/views/bulkrax/exporters/_form.html.erb
+++ b/app/views/bulkrax/exporters/_form.html.erb
@@ -1,3 +1,5 @@
+<%# Bulkrax v4.3.0 override: inserts the new option of `export_source_object_ids` on L#55 %>
+
 <div class="panel-body">
   <% if exporter.errors.any? %>
     <div id="error_explanation">

--- a/lib/bulkrax/export_assistive_methods.rb
+++ b/lib/bulkrax/export_assistive_methods.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+module ExportAssistiveMethods
+  def process_multiple_file_export(file_sets, folder_count)
+    file_sets.each { |fileset| process_export_fileset_files(fileset, folder_count) }
+  end
+
+  def process_export_fileset_files(fileset, folder_count)
+    path = export_file_path(folder_count)
+    FileUtils.mkdir_p(path) unless File.exist? path
+    files = filename(fileset)&.split(';')
+    return if files.empty?
+
+    shovel_files_into_folder(files, fileset, path)
+  end
+
+  def shovel_files_into_folder(files, file_set, path)
+    files.each do |file|
+      file_split = file.split(':')
+      io = open(file_set.send(file_split.last).uri)
+      File.open(File.join(path, file_split.first), 'wb') do |f|
+        f.write(io.read)
+        f.close
+      end
+    end
+  end
+
+  def pull_export_filesets(record)
+    record.file_set? ? Array.wrap(record) : record.file_sets
+  end
+
+  def export_file_path(folder_count)
+    File.join(exporter_export_path, folder_count, 'files')
+  end
+
+  def process_model_to_write(entries_to_write, model)
+    entries_to_write.map.with_index do |e, ind|
+      e.parsed_metadata['model'] == model ? ind : nil
+    end.compact
+  end
+
+  def process_filesets_to_write(entries_to_write, work_id)
+    entries_to_write.map.with_index do |e, ind|
+      e.parsed_metadata['model'] == 'FileSet' && e.parsed_metadata['parent'] == work_id ? ind : nil
+    end.compact
+  end
+
+  def process_filesets_and_work_to_write(entries_to_write)
+    work_file_set_grouping = []
+    works_in_entries = process_model_to_write(entries_to_write, 'CurateGenericWork')
+
+    works_in_entries.each do |w|
+      work_id = entries_to_write[w].identifier
+
+      file_set_indexes = process_filesets_to_write(entries_to_write, work_id)
+
+      work_file_set_grouping += ([w] + file_set_indexes)
+    end
+
+    work_file_set_grouping
+  end
+
+  def sort_entries_to_write(entries_to_write)
+    collections_to_write = process_model_to_write(entries_to_write, 'Collection')
+
+    work_file_set_grouping = process_filesets_and_work_to_write(entries_to_write)
+
+    sorted_order = collections_to_write + work_file_set_grouping
+    entries_to_write.values_at(*sorted_order)
+  end
+
+  def process_current_record_object_ids
+    ids = importerexporter.export_source.split('|')
+
+    ids.each do |id|
+      record = ActiveFedora::Base.find(id)
+
+      if record.is_a?(Collection)
+        @collection_ids += [id]
+      elsif record.is_a?(CurateGenericWork)
+        @work_ids += [id]
+      end
+    end
+    find_child_file_sets(@work_ids)
+  end
+
+  def build_preservation_workflow_metadata
+    work_pres_workflows = hyrax_record.preservation_workflow
+    return if work_pres_workflows.blank?
+
+    work_pres_workflows.each do |workflow|
+      type = workflow.workflow_type.first
+      workflow_attrs = %w[workflow_notes workflow_rights_basis workflow_rights_basis_note workflow_rights_basis_date workflow_rights_basis_reviewer workflow_rights_basis_uri]
+
+      workflow_attrs.each do |attrib|
+        handle_join_on_export("#{type}.#{attrib}", workflow.send(attrib.to_sym).to_a, '|')
+      end
+    end
+  end
+
+  def build_triples_value(key, value, data)
+    if value['join']
+      processed_value = key == 'creator' && hyrax_record.is_a?(FileSet) ? nil : data.map { |d| prepare_export_data(d) }.join(value['join']).to_s
+      parsed_metadata[key_for_export(key)] = processed_value
+    else
+      data.each_with_index do |d, i|
+        parsed_metadata["#{key_for_export(key)}_#{i + 1}"] = prepare_export_data(d)
+      end
+    end
+  end
+end

--- a/lib/bulkrax/export_assistive_methods.rb
+++ b/lib/bulkrax/export_assistive_methods.rb
@@ -99,12 +99,16 @@ module ExportAssistiveMethods
 
   def build_triples_value(key, value, data)
     if value['join']
-      processed_value = key == 'creator' && hyrax_record.is_a?(FileSet) ? nil : data.map { |d| prepare_export_data(d) }.join(value['join']).to_s
-      parsed_metadata[key_for_export(key)] = processed_value
+      triples_values_joined(key, value, data)
     else
       data.each_with_index do |d, i|
         parsed_metadata["#{key_for_export(key)}_#{i + 1}"] = prepare_export_data(d)
       end
     end
+  end
+
+  def triples_values_joined(key, value, data)
+    processed_value = key == 'creator' && hyrax_record.is_a?(FileSet) ? nil : data.map { |d| prepare_export_data(d) }.join(value['join']).to_s
+    parsed_metadata[key_for_export(key)] = processed_value
   end
 end

--- a/lib/bulkrax/override_assistive_methods.rb
+++ b/lib/bulkrax/override_assistive_methods.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require_relative './export_assistive_methods'
+require_relative './ingest_assistive_methods'
+
+module OverrideAssistiveMethods
+  include ExportAssistiveMethods
+  include IngestAssistiveMethods
+end

--- a/spec/system/bulkrax_csv_export_spec.rb
+++ b/spec/system/bulkrax_csv_export_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Bulkrax CSV exporter', clean: true, js: true, type: :system do
       expect(page).to have_css('li a span.sidebar-action-text', text: 'Exporters')
     end
 
-    context 'within exporters/new' do
+    context 'creating a Collection export' do
       before do
         visit '/exporters/new'
         fill_in 'Name required', with: 'Test'
@@ -75,6 +75,41 @@ RSpec.describe 'Bulkrax CSV exporter', clean: true, js: true, type: :system do
           click_link 'Test'
 
           expect(page).to have_selector('th', text: 'Title', count: 3, visible: false)
+        end
+      end
+    end
+
+    context 'Object IDs export' do
+      before do
+        visit '/exporters/new'
+      end
+
+      it 'contains the right elements for Object IDs' do
+        expect(page).to have_css("option[value='object_ids']", text: 'Object IDs')
+        select 'Object IDs', from: 'exporter_export_from'
+        expect(page).to have_css('div.form-group.text.optional.exporter_export_source_object_ids label', text: 'Object IDs')
+      end
+
+      context 'creating a new export' do
+        before do
+          fill_in 'Name required', with: 'ID Test'
+          select 'Metadata Only', from: 'exporter_export_type'
+          select 'Object IDs', from: 'exporter_export_from'
+          fill_in 'Object IDs', with: "#{collection.id}|#{work.id}"
+          select 'CSV - Comma Separated Values', from: 'exporter_parser_klass'
+          find("input[value='Create and Export']").click
+        end
+
+        it 'redirects to index with a Test link present' do
+          expect(page).to have_link('ID Test', href: '/exporters/1?locale=en')
+        end
+
+        context 'on exporter show page' do
+          it 'has Title as a column on all entry lists' do
+            click_link 'ID Test'
+
+            expect(page).to have_selector('th', text: 'Title', count: 3, visible: false)
+          end
         end
       end
     end


### PR DESCRIPTION
- .rubocop.yml: allows exceptions for new Bulkrax overrides.
- app/views/bulkrax/exporters/_form.html.erb: adds in `export_source_object_ids` as a new exporting type.
- config/initializers/bulkrax.rb:
  - L#331 and L#442-476: hijacks these methods to allow new option to process.
  -  deletions: removes assistive methods to their own Modules to reduce possible Code Climate issues.
- lib/*: refactors the containing modules so that the module names are more descriptive, they are grouped by how they assist, and that including one module still contains all methods.