### PR TITLE
BUG FIX: Turns off Turbolinks from Dashboard's Importer and Exporter links.

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -12,11 +12,11 @@
 <% end %>
 
 <% if can? :read, :admin_dashboard %>
-  <%= menu.nav_link(bulkrax.importers_path) do %>
+  <%= menu.nav_link(bulkrax.importers_path, data: { turbolinks: false }) do %>
     <span class="fa fa-cloud-upload" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.importers') %></span>
   <% end %>
 
-  <%= menu.nav_link(bulkrax.exporters_path) do %>
+  <%= menu.nav_link(bulkrax.exporters_path, data: { turbolinks: false }) do %>
     <span class="fa fa-cloud-download" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.exporters') %></span>
   <% end %>
 <% end %>


### PR DESCRIPTION
Since the Javascript code wasn't loading when returning to the Importer#index page after moving away from it (a common Turbolinks bug), I have turned off Turbolinks on both index pages so that current and future filtering can load without fail.