### PR TITLE
Revisions to Bulkrax v5 behaviour.

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,11 +6,11 @@ class Ability
   self.ability_logic += [:everyone_can_create_curation_concerns]
 
   def can_import_works?
-    can_create_any_work?
+    can? :read, :admin_dashboard
   end
 
   def can_export_works?
-    can_create_any_work?
+    can? :read, :admin_dashboard
   end
 
   # Define any customized permissions here.

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,11 +6,11 @@ class Ability
   self.ability_logic += [:everyone_can_create_curation_concerns]
 
   def can_import_works?
-    can? :read, :admin_dashboard
+    admin?
   end
 
   def can_export_works?
-    can? :read, :admin_dashboard
+    admin?
   end
 
   # Define any customized permissions here.

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -428,7 +428,7 @@ Bulkrax::ExportBehavior.module_eval do
       rescue
         file = nil
       end
-      working_array << "#{file.file_name.first}:#{type}" if file.present?
+      working_array << "#{file.file_name.first}:#{type == 'extracted' ? 'extracted_text' : type}" if file.present?
     end
 
     working_array.compact.join('|')

--- a/spec/system/admin_dashboard_spec.rb
+++ b/spec/system/admin_dashboard_spec.rb
@@ -32,12 +32,6 @@ RSpec.describe 'Admin dashboard', integration: true, clean: true, type: :system 
     let(:admin) { FactoryBot.create(:admin) }
     before do
       login_as admin
-      # The 2 mocks below are necessary now that we're using Bulkrax' new out-of-box
-      #   Ability methods that check whether an admin user can create at least one work
-      #   and deposit that work into one AdminSet. It's easier to mock this response
-      #   then to alter the user's specific AdminSet abilities.
-      allow_any_instance_of(Ability).to receive(:can_export_works?).and_return(true)
-      allow_any_instance_of(Ability).to receive(:can_import_works?).and_return(true)
       visit '/dashboard'
     end
 

--- a/spec/system/bulkrax_csv_export_spec.rb
+++ b/spec/system/bulkrax_csv_export_spec.rb
@@ -47,11 +47,6 @@ RSpec.describe 'Bulkrax CSV exporter', clean: true, js: true, type: :system do
       work.member_of_collections << collection
       work.save!
       login_as admin
-      # The mock below is necessary now that we're using Bulkrax' new out-of-box
-      #   Ability methods that check whether an admin user can create at least one work
-      #   and deposit that work into one AdminSet. It's easier to mock this response
-      #   then to alter the user's specific AdminSet abilities.
-      allow_any_instance_of(Ability).to receive(:can_export_works?).and_return(true)
     end
 
     it 'displays exporters on Dashboard' do

--- a/spec/system/bulkrax_csv_import_spec.rb
+++ b/spec/system/bulkrax_csv_import_spec.rb
@@ -69,14 +69,7 @@ RSpec.describe 'Bulkrax CSV importer', clean: true, js: true, type: :system do
     let(:admin) { FactoryBot.create(:admin) }
     let(:csv_file) { File.join(fixture_path, 'csv_import', 'good', 'Bulkrax_Test_CSV.csv') }
 
-    before do
-      login_as admin
-      # The mock below is necessary now that we're using Bulkrax' new out-of-box
-      #   Ability methods that check whether an admin user can create at least one work
-      #   and deposit that work into one AdminSet. It's easier to mock this response
-      #   then to alter the user's specific AdminSet abilities.
-      allow_any_instance_of(Ability).to receive(:can_import_works?).and_return(true)
-    end
+    before { login_as admin }
 
     it 'displays importers on Dashboard' do
       visit '/dashboard'


### PR DESCRIPTION
- app/models/ability.rb: new permissions were undesired.
- config/initializers/bulkrax.rb: because the setter method and the "get" methods are different for this one file type, it is necessary to convert the filetype when exporting.
- spec/*: this is reverting the changes that were needed to test the new permissions.