### PR TITLE
Update Solr index for FileSet after characterization.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_gem:
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-    TargetRubyVersion: 2.5
+    TargetRubyVersion: 2.7
     Exclude:
         - bin/**/*
         - db/**/*

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -61,10 +61,11 @@ RSpec.describe CharacterizeJob, :clean do
     before do
       described_class.perform_now(file_set, file.id, "", user)
     end
-    it "adds a new preservation event for fileset characterization" do
+
+    it "adds a new preservation event for fileset characterization (Failure)" do
       expect(file_set.preservation_event.first.event_type).to eq ['Characterization']
-      expect(file_set.preservation_event.first.outcome).to eq ['Success']
-      expect(file_set.preservation_event.first.event_details).to eq ['preservation_master_file: picture.png - Technical metadata extracted from file, format identified, and file validated']
+      expect(file_set.preservation_event.first.outcome).to eq ['Failure']
+      expect(file_set.preservation_event.first.event_details).to eq ['The Characterization Service failed.']
       expect(file_set.preservation_event.first.initiating_user).to eq [user]
     end
   end


### PR DESCRIPTION
- .rubocop.yml: bumps up the Ruby version to our current.
- app/jobs/characterize_job.rb: 
  - the FS shows as not yet characterized because the Solr index hasn't updated in-between the Characterization process. `update_index` added after the persistence runs. 
  - moves the preservation event for Characterization creation to after the save and index updating of the FileSet.
  - because we clear characterization metadata before characterizing, checking for presence of any of those values is proof of characterization and that can be used for the preservation events.
  - spec/jobs/characterize_job_spec.rb: since we don't actually characterize a true file (connecting the tools in various test environments is problematic), we can only test for Characterization Failure here.