### PR TITLE
Avoids creating duplicates when processing AWS Fixity CSV.

### DIFF
--- a/app/jobs/process_aws_fixity_preservation_events_job.rb
+++ b/app/jobs/process_aws_fixity_preservation_events_job.rb
@@ -19,6 +19,7 @@ class ProcessAwsFixityPreservationEventsJob < Hyrax::ApplicationJob
       file_set = FileSet.where(sha1_tesim: event_obj.sha1)&.first
       return if file_set.blank?
       event = event_obj.process_event
+      return if check_for_preexisting_preservation_events(file_set, event_obj.sha1, event_obj.fixity_start)
 
       create_preservation_event(file_set, event)
     end

--- a/app/lib/preservation_events.rb
+++ b/app/lib/preservation_events.rb
@@ -15,4 +15,12 @@ module PreservationEvents
                                               software_version: event['software_version'] }]
     object.save! if object.errors.empty? # save object only if there aren't any errors, eg: validation errors
   end
+
+  def check_for_preexisting_preservation_events(file_set, sha1, event_start)
+    matching_preservation_events = file_set.preservation_event.select do |e|
+      e.event_type == ['Fixity Check'] && e.event_start == [DateTime.parse(event_start)]
+    end
+
+    matching_preservation_events.select { |mpe| mpe.event_details.first.include? sha1 }.present?
+  end
 end

--- a/app/models/aws_fixity_event.rb
+++ b/app/models/aws_fixity_event.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AwsFixityEvent
-  attr_reader :sha1
+  attr_reader :sha1, :fixity_start
 
   def initialize(line)
     @sha1 = line['event_sha1']&.strip

--- a/spec/jobs/process_aws_fixity_preservation_events_job_spec.rb
+++ b/spec/jobs/process_aws_fixity_preservation_events_job_spec.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 require 'rails_helper'
+include PreservationEvents
 
 RSpec.describe ProcessAwsFixityPreservationEventsJob, :clean do
   let(:user) { FactoryBot.create(:user) }
   let(:file_set) { FactoryBot.create(:file_set) }
   let(:csv) { fixture_path + '/csv_import/aws_fixity_test.csv' }
   let(:pmf) { File.open(fixture_path + '/book_page/0003_preservation_master.tif') }
+  let(:sha1) { 'f43b4b662480a4477100bf3de73804f8efbcba30' }
+  let(:start) { "2022-03-09 14:11:25" }
 
   before do
     Hydra::Works::AddFileToFileSet.call(file_set, pmf, :preservation_master_file)
-    allow(FileSet).to receive(:where)
-      .with(sha1_tesim: 'f43b4b662480a4477100bf3de73804f8efbcba30')
-      .and_return([file_set])
+    allow(FileSet).to receive(:where).with(sha1_tesim: sha1).and_return([file_set])
   end
 
   describe "called with perform_now" do
@@ -24,14 +25,38 @@ RSpec.describe ProcessAwsFixityPreservationEventsJob, :clean do
       described_class.perform_now(csv)
 
       expect(file_set.preservation_event.pluck(:event_details))
-        .to include(["Fixity intact for sha1:f43b4b662480a4477100bf3de73804f8efbcba30 in fedora-cor-arch-binaries"])
+        .to include(["Fixity intact for sha1:#{sha1} in fedora-cor-arch-binaries"])
       expect(file_set.preservation_event.pluck(:event_type)).to include(["Fixity Check"])
       expect(file_set.preservation_event.pluck(:initiating_user)).to include(["AWS Serverless Fixity"])
       expect(file_set.preservation_event.pluck(:outcome)).to include(["Success"])
       expect(file_set.preservation_event.pluck(:software_version))
         .to include(["Serverless Fixity v1.0"])
-      expect(file_set.preservation_event.pluck(:event_start)).to include(["2022-03-09 14:11:25"])
+      expect(file_set.preservation_event.pluck(:event_start)).to include([start])
       expect(file_set.preservation_event.pluck(:event_end)).to include(["2022-03-09 14:11:35"])
     end
+
+    context '#check_for_preexisting_preservation_events' do
+      let(:event) do
+        { 'type' => 'Fixity Check', 'start' => start, 'end' => 'Wed, 08 Mar 2023 16:45:16 +0000',
+          'details' => "Fixity intact for sha1:#{sha1} in aws_bucket",
+          'software_version' => 'Fedora v4.7.5', 'user' => 'bobsuruncle', 'outcome' => 'Success' }
+      end
+
+      it 'stops duplicates from happening' do
+        create_preservation_event(file_set, event)
+
+        check_for_only_one_fixity_event
+
+        described_class.perform_now(csv)
+
+        check_for_only_one_fixity_event
+      end
+    end
+  end
+
+  def check_for_only_one_fixity_event
+    expect(
+      file_set.preservation_event.count { |e| e.event_type == ['Fixity Check'] }
+    ).to eq(1)
   end
 end

--- a/spec/lib/preservation_events_spec.rb
+++ b/spec/lib/preservation_events_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+include PreservationEvents
+
+RSpec.describe PreservationEvents, :clean do
+  let(:file_set) { FactoryBot.create(:file_set) }
+  let(:sha1) { '267d6c28761a0c95680bde0797f73c0837b2c8cz' }
+  let(:start) { 'Wed, 08 Mar 2023 14:45:16 +0000' }
+  let(:event) do
+    { 'type' => 'Fixity Check', 'start' => start, 'end' => 'Wed, 08 Mar 2023 16:45:16 +0000',
+      'details' => "Fixity intact for sha1:#{sha1} in aws_bucket",
+      'software_version' => 'Fedora v4.7.5', 'user' => 'bobsuruncle', 'outcome' => 'Success' }
+  end
+
+  before { create_preservation_event(file_set, event) }
+
+  context '#check_for_preexisting_preservation_events' do
+    it 'finds a matching event' do
+      expect(
+        check_for_preexisting_preservation_events(file_set, sha1, start)
+      ).to be_truthy
+    end
+
+    describe 'info that does not match' do
+      it 'finds nothing with wrong sha1' do
+        expect(
+          check_for_preexisting_preservation_events(file_set, '267d6c28761a0c95680bde0797f73c0837b2c8cd', start)
+        ).to be_falsey
+      end
+
+      it 'finds nothing with wrong start' do
+        expect(
+          check_for_preexisting_preservation_events(file_set, sha1, 'Wed, 09 Mar 2023 14:45:16 +0000')
+        ).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
- app/jobs/process_aws_fixity_preservation_events_job.rb: stops processing the line if we already have a Fixity event that matches.
- app/lib/preservation_events.rb: first pulls the Fixity events that perfectly match the date provided from CSV, and then checks if the SHA1 in question has an event tied to it. The `select` calls are separated here because Fixity events are structured differently that others due to `event_details` values. Running `event_details.first.include?` on different types of Events throws errors.
- app/models/aws_fixity_event.rb: made `fixity_start` readable outside of the class so that we can call `check_for_preexisting_preservation_events` with the value.
- spec/*: tests expectations.