### PR TITLE
Iterates the Fedora version after update to v4.7.6 (#1548).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,7 @@ flycheck_*.el
 /.bundle
 /vendor/bundle
 
-.env.development
+.env*
 
 # ignore branding path
 public/branding

--- a/app/jobs/README.md
+++ b/app/jobs/README.md
@@ -149,7 +149,7 @@ The following are the types of Preservation Events the Curate application record
     - Records:
         - `start`: date and time when the event started.
         - `outcome`: "Success"/"Failure"
-        - `software_version`: "Fedora v4.7.5"
+        - `software_version`: "Fedora v4.7.6"
         - `user`: user that initiates the check.
         - `details`: either "Fixity intact for file: < file name >: sha1:< sha1 value >" or "Fixity check failed for: < file name >: sha1:< sha1 value >"
     - Event created in: `FixityCheckJob`
@@ -165,7 +165,7 @@ The following are the types of Preservation Events the Curate application record
     - Records:
         - `start`: date and time when the ingest started.
         - `outcome`: "Success"/"Failure"
-        - `software_version`: "Fedora v4.7.5"
+        - `software_version`: "Fedora v4.7.6"
         - `user`: user that submitted the file.
         - `details`: either "< file name > submitted for preservation storage" or "< file name > could not be submitted for preservation storage"
     - Event created in: `JobIoWrapper#ingest_file`
@@ -173,7 +173,7 @@ The following are the types of Preservation Events the Curate application record
     - Records:
         - `start`: date and time when the calculation started.
         - `outcome`: "Success"/"Failure"
-        - `software_version`: "FITS v1.5.0, Fedora v4.7.5, Ruby Digest library"
+        - `software_version`: "FITS v1.5.0, Fedora v4.7.6, Ruby Digest library"
         - `user`: user that deposited the file.
         - `details`: an array of the checksums.
     - Event created in: `Hydra::Works::CharacterizationServic#append_original_checksum`

--- a/app/jobs/fixity_check_job.rb
+++ b/app/jobs/fixity_check_job.rb
@@ -66,7 +66,7 @@ class FixityCheckJob < Hyrax::ApplicationJob
       @logger = Logger.new(STDOUT)
       fixity_file_set = ::FileSet.find(file_set_id)
       fixity_file = Hydra::PCDM::File.find(file_id)
-      event = { 'type' => 'Fixity Check', 'start' => event_start, 'software_version' => 'Fedora v4.7.5', 'user' => initiating_user }
+      event = { 'type' => 'Fixity Check', 'start' => event_start, 'software_version' => 'Fedora v4.7.6', 'user' => initiating_user }
       if log == true
         event['outcome'] = 'Success'
         event['details'] = "Fixity intact for file: #{fixity_file&.original_name}: sha1:#{fixity_file&.checksum&.value}"

--- a/config/initializers/characterization_service.rb
+++ b/config/initializers/characterization_service.rb
@@ -49,7 +49,7 @@ Hydra::Works::CharacterizationService.class_eval do
       file_set = FileSet.find(file_set_id)
       # create event for digest calculation/failure
       event = { 'type' => 'Message Digest Calculation', 'start' => event_start, 'details' => value,
-                'software_version' => 'FITS v1.5.0, Fedora v4.7.5, Ruby Digest library', 'user' => @user.presence || file_set.depositor }
+                'software_version' => 'FITS v1.5.0, Fedora v4.7.6, Ruby Digest library', 'user' => @user.presence || file_set.depositor }
       event['outcome'] = value.size == 3 ? 'Success' : 'Failure'
       create_preservation_event(file_set, event)
     end

--- a/config/initializers/job_io_wrapper.rb
+++ b/config/initializers/job_io_wrapper.rb
@@ -48,7 +48,7 @@ JobIoWrapper.class_eval do
     # create preservation_event for fileset creation (method in PreservationEvents module)
     def file_set_preservation_event(file_set, event_start, outcome, details)
       event = { 'type' => 'File submission', 'start' => event_start, 'outcome' => outcome, 'details' => details,
-                'software_version' => 'Fedora v4.7.5', 'user' => user.uid }
+                'software_version' => 'Fedora v4.7.6', 'user' => user.uid }
       create_preservation_event(file_set, event)
     end
 end

--- a/spec/jobs/process_aws_fixity_preservation_events_job_spec.rb
+++ b/spec/jobs/process_aws_fixity_preservation_events_job_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ProcessAwsFixityPreservationEventsJob, :clean do
       let(:event) do
         { 'type' => 'Fixity Check', 'start' => start, 'end' => 'Wed, 08 Mar 2023 16:45:16 +0000',
           'details' => "Fixity intact for sha1:#{sha1} in aws_bucket",
-          'software_version' => 'Fedora v4.7.5', 'user' => 'bobsuruncle', 'outcome' => 'Success' }
+          'software_version' => 'Fedora v4.7.6', 'user' => 'bobsuruncle', 'outcome' => 'Success' }
       end
 
       it 'stops duplicates from happening' do

--- a/spec/lib/preservation_events_spec.rb
+++ b/spec/lib/preservation_events_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PreservationEvents, :clean do
   let(:event) do
     { 'type' => 'Fixity Check', 'start' => start, 'end' => 'Wed, 08 Mar 2023 16:45:16 +0000',
       'details' => "Fixity intact for sha1:#{sha1} in aws_bucket",
-      'software_version' => 'Fedora v4.7.5', 'user' => 'bobsuruncle', 'outcome' => 'Success' }
+      'software_version' => 'Fedora v4.7.6', 'user' => 'bobsuruncle', 'outcome' => 'Success' }
   end
 
   before { create_preservation_event(file_set, event) }


### PR DESCRIPTION
- All files, except `.gitignore`: updates the Fedora version numbers.
- .gitignore: excludes all `.env`s.