### PR TITLE
Moves the loading of Aspace repositories to the controller action (#2168).

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller_override.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller_override.rb
@@ -27,6 +27,7 @@ module Hyrax
         end
       end
 
+      # [Hyrax-overwrite-v3.4.2] Creates instance variable for aspace repositories.
       def new
         # Coming from the UI, a collection type id should always be present.  Coming from the API, if a collection type id is not specified,
         # use the default collection type (provides backward compatibility with versions < Hyrax 2.1.0)

--- a/app/views/hyrax/dashboard/collections/new.html.erb
+++ b/app/views/hyrax/dashboard/collections/new.html.erb
@@ -20,7 +20,10 @@
           <p>Select an ArchivesSpace Repository.</p>
           <div class="form-group">
             <label for="sel1">Select list:</label>
-            <select class="form-control" id="sel1"></select>
+            <% repositories = @aspace_repositories.presence || [] %>
+            <%= select_tag('sel1', 
+                           options_for_select(repositories.collect{ |ar| [ar[:name], ar[:repository_id]] }), 
+                           class: 'form-control')  %>
           </div>
           <div class="call-number-field">
             <label for="aspace-call-number">Call Number: (must be exact)</label>
@@ -70,22 +73,6 @@
   var repository_id;
   var result_success;
   var result_error;
-
-  $.ajax({
-    url: '/aspace/repositories',
-    type: 'GET',
-    dataType: 'json',
-    async: false,
-    success: function(repositories) {
-      jQuery.each( repositories, function(i, val) {
-        var o = new Option(val.name, val.repository_id);
-        /// jquerify the DOM object 'o' so we can use the html method
-        $(o).html(val.name);
-        $("#sel1").append(o);
-        repository_id = val.repository_id;
-      });
-    }
-  });
 
   $("#aspace-loader").click(function (e) {
     $("#aspace-error").hide();


### PR DESCRIPTION
- app/controllers/hyrax/dashboard/collections_controller_override.rb: overrides #new to inject an instance variable containing aspace repositories into the ERB.
- app/views/hyrax/dashboard/collections/new.html.erb: swaps from loading aspace repositories via AJAX to within the controller action because the AJAX-loaded repositories were not loading in production the majority of requests during ingests.