### PR TITLE
Adds WorkMembersCleanUpJob.

### DIFF
--- a/app/controllers/background_jobs_controller.rb
+++ b/app/controllers/background_jobs_controller.rb
@@ -7,6 +7,8 @@ class BackgroundJobsController < ApplicationController
     if params[:jobs] == 'cleanup'
       FileSetCleanUpJob.perform_later
       redirect_to new_background_job_path, notice: "File Set Cleanup Job has started successfully."
+    elsif params[:jobs] == 'work_members_cleanup'
+      process_work_members_cleanup(params[:work_members_cleanup_text])
     elsif params[:jobs] == 'preservation'
       generic_csv_action(params[:preservation_csv], PreservationWorkflowImporterJob)
       redirect_to new_background_job_path, notice: "Preservation Workflow Importer Job has started successfully."
@@ -77,5 +79,14 @@ class BackgroundJobsController < ApplicationController
       path = Rails.root.join('tmp', name)
       File.open(path, "w+") { |f| f.write(csv_param.read) }
       job_class.perform_later(path.to_s)
+    end
+
+    def process_work_members_cleanup(text_from_box)
+      if text_from_box.length < 14
+        redirect_to new_background_job_path, alert: 'Please enter at least one Work ID in the text box.'
+      else
+        WorkMembersCleanUpJob.perform_later(text_from_box)
+        redirect_to new_background_job_path, notice: "Work Members Cleanup Job has been added to the queue."
+      end
     end
 end

--- a/app/jobs/replace_work_members_job.rb
+++ b/app/jobs/replace_work_members_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ReplaceWorkMembersJob < Hyrax::ApplicationJob
+  def perform(work, cleaned_member_ids)
+    file_sets = cleaned_member_ids.map { |id| FileSet.find(id) }
+
+    work.ordered_members = file_sets
+    work.save
+    regen_manifest(work)
+  end
+
+  def regen_manifest(work)
+    solr_doc = SolrDocument.find(work.id)
+    ability = ManifestAbility.new
+    presenter = Hyrax::CurateGenericWorkPresenter.new(solr_doc, ability)
+
+    ManifestBuilderService.regenerate_manifest(presenter: presenter, curation_concern: work)
+  end
+end

--- a/app/jobs/work_members_clean_up_job.rb
+++ b/app/jobs/work_members_clean_up_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class WorkMembersCleanUpJob < Hyrax::ApplicationJob
+  def perform(comma_separated_work_ids = nil)
+    work_ids = comma_separated_work_ids&.split(',')
+    raise 'The required work ids separated by commas were not provided.' if work_ids.blank?
+
+    works = pull_works_by_ids(work_ids)
+    works.each { |work| clean_up_work_member(work) }
+  end
+
+  def pull_works_by_ids(work_ids)
+    ret_arr = []
+    work_ids.each do |id|
+      ret_arr << CurateGenericWork.find(id)
+    rescue
+      Rails.logger.error "The id #{id} did not match a work in the system."
+      next
+    end
+    ret_arr
+  end
+
+  def clean_up_work_member(work)
+    members_count = work.ordered_member_ids.size
+    cleaned_member_ids = work.ordered_member_ids.compact.uniq
+
+    if members_count != cleaned_member_ids.size
+      ReplaceWorkMembersJob.perform_later(work, cleaned_member_ids)
+    else
+      Rails.logger.error 'No nil or duplicate work members were found.'
+    end
+  end
+end

--- a/app/views/background_jobs/new.html.erb
+++ b/app/views/background_jobs/new.html.erb
@@ -15,6 +15,15 @@
     </tr>
     <tr>
       <td>
+        <%= radio_button_tag :jobs, 'work_members_cleanup', false, id: 'work_members_cleanup' %>
+        <%= label :work_members_cleanup, 'Work Members Cleanup' %>
+      </td>
+      <td>
+        <%= text_area_tag 'work_members_cleanup_text', nil, size: '60x2', placeholder: 'Work IDs separated by commas. e.g. "515bcc2hx0-cor,212bcc2hx0-cor"' %>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <%= radio_button_tag :jobs, 'reindex', false, id: 'reindex' %>
         <%= label :job_cleanup, 'Reindex Selected Files' %>
       </td>

--- a/app/views/background_jobs/new.html.erb
+++ b/app/views/background_jobs/new.html.erb
@@ -16,7 +16,7 @@
     <tr>
       <td>
         <%= radio_button_tag :jobs, 'work_members_cleanup', false, id: 'work_members_cleanup' %>
-        <%= label :work_members_cleanup, 'Work Members Cleanup' %>
+        <%= label :job_cleanup, 'Work Members Cleanup' %>
       </td>
       <td>
         <%= text_area_tag 'work_members_cleanup_text', nil, size: '60x2', placeholder: 'Work IDs separated by commas. e.g. "515bcc2hx0-cor,212bcc2hx0-cor"' %>

--- a/spec/controllers/background_jobs_controller_spec.rb
+++ b/spec/controllers/background_jobs_controller_spec.rb
@@ -43,6 +43,9 @@ RSpec.describe BackgroundJobsController, type: :controller, clean: true do
       let(:aws_fixity) do
         post :create, params: { jobs: 'aws_fixity', aws_fixity_csv: csv_file3, format: 'json' }
       end
+      let(:work_members_cleanup) do
+        post :create, params: { jobs: 'work_members_cleanup', work_members_cleanup_text: '576rxwdbs7-cor' }
+      end
 
       it "successfully starts a file_set cleanup background job" do
         expect(cleanup).to redirect_to(new_background_job_path)
@@ -62,6 +65,11 @@ RSpec.describe BackgroundJobsController, type: :controller, clean: true do
       it "successfully starts a AWS fixity background job" do
         expect(aws_fixity).to redirect_to(new_background_job_path)
         expect(ProcessAwsFixityPreservationEventsJob).to have_been_enqueued
+      end
+
+      it "successfully starts a work members cleanup background job" do
+        expect(work_members_cleanup).to redirect_to(new_background_job_path)
+        expect(WorkMembersCleanUpJob).to have_been_enqueued
       end
 
       # Deprecation Warning: As of Curate v3, Zizia will be removed. These preprocessors contain

--- a/spec/jobs/replace_work_members_job_spec.rb
+++ b/spec/jobs/replace_work_members_job_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ReplaceWorkMembersJob, :clean do
+  let(:work) { FactoryBot.create(:work) }
+  let(:file_set) { FactoryBot.create(:file_set) }
+
+  before do
+    work.ordered_members = [file_set, file_set]
+    work.save
+  end
+
+  # NOTE: We unfortunately cannot save nil objects into the #ordered_members attribute.
+  #   That phenomenon only occurs during Zizia imports using the "shovelling" technique
+  #   of adding FileSets to a Work.
+  it 'calls the expected methods' do
+    expect(FileSet).to receive(:find).with(file_set.id).and_return(file_set)
+    expect(work).to receive(:ordered_members=).with([file_set])
+    expect(work).to receive(:save)
+    described_class.perform_now(work, [file_set.id])
+  end
+end

--- a/spec/jobs/work_members_clean_up_job_spec.rb
+++ b/spec/jobs/work_members_clean_up_job_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe WorkMembersCleanUpJob, :clean do
+  let(:work) { FactoryBot.create(:work) }
+  let(:file_set) { FactoryBot.create(:file_set) }
+
+  context 'when called without ids' do
+    it 'returns an error' do
+      expect { described_class.perform_now }.to(
+        raise_error(
+          RuntimeError,
+           'The required work ids separated by commas were not provided.'
+        )
+      )
+    end
+  end
+
+  context 'when called with work with no duplicates or nil objects in #ordered_members' do
+    before do
+      work.ordered_members = [file_set]
+      work.save
+    end
+
+    it 'finds work and does not process ReplaceWorkMembersJob' do
+      expect(CurateGenericWork).to receive(:find).with(work.id).and_return(work)
+      expect(Rails.logger).to receive(:error).with('No nil or duplicate work members were found.')
+      expect(ReplaceWorkMembersJob).not_to receive(:perform_later).with(work, [file_set.id])
+      described_class.perform_now(work.id)
+    end
+  end
+
+  # NOTE: We unfortunately cannot save nil objects into the #ordered_members attribute.
+  #   That phenomenon only occurs during Zizia imports using the "shovelling" technique
+  #   of adding FileSets to a Work.
+  context 'when called with a work that contains duplicate objects in #ordered_members' do
+    before do
+      work.ordered_members = [file_set, file_set]
+      work.save
+    end
+
+    it 'finds work and processes ReplaceWorkMembersJob' do
+      expect(CurateGenericWork).to receive(:find).with(work.id).and_return(work)
+      expect(Rails.logger).not_to receive(:error).with('No nil or duplicate work members were found.')
+      expect(ReplaceWorkMembersJob).to receive(:perform_later).with(work, [file_set.id])
+      described_class.perform_now(work.id)
+    end
+  end
+end


### PR DESCRIPTION
Fixes the effects of intermittent "shoveling" of duplicate or nil objects into Works' ordered members (FileSets). These tools relieves issues like this: https://app.zenhub.com/workspaces/digital-library-project-5bf484ae4b5806bc2bf6875b/issues/gh/emory-libraries/dlp-curate/2237