### PR TITLE
Adds option to reindex child pages to work show page.

### DIFF
--- a/app/assets/stylesheets/_work_show_page.scss
+++ b/app/assets/stylesheets/_work_show_page.scss
@@ -2,4 +2,19 @@
   form {padding-left: 0.5rem;}
   display: inline-flex;
   margin: 0;
+  margin-top: 0.5rem;
+
+  > .btn-group {
+    padding-left: 0.5rem;
+
+    > .dropdown-menu {
+      margin-left: 0.5rem;
+
+      > a {
+      display: block;
+      padding: 0.3rem 2rem;
+      color: #333333;
+      }
+    }
+  }
 }

--- a/app/controllers/full_text_indexing_controller.rb
+++ b/app/controllers/full_text_indexing_controller.rb
@@ -4,7 +4,23 @@ class FullTextIndexingController < ApplicationController
   before_action :authenticate_user!
 
   def full_text_index
-    CompileFullTextJob.perform_later(work_id: params[:work_id], user_id: params[:user_id].to_i)
+    call_compiling_job
     redirect_to hyrax_curate_generic_work_path(params[:work_id]), notice: "Full-Text Indexing has been queued for this work."
   end
+
+  def full_text_index_with_pages
+    reindex_work_child_members
+    call_compiling_job
+    redirect_to hyrax_curate_generic_work_path(params[:work_id]), notice: "Full-Text Indexing has been queued for this work."
+  end
+
+  private
+
+    def call_compiling_job
+      CompileFullTextJob.perform_later(work_id: params[:work_id], user_id: params[:user_id].to_i)
+    end
+
+    def reindex_work_child_members
+      ReindexObjectChildrenJob.perform_later(params[:work_id])
+    end
 end

--- a/app/jobs/reindex_object_children_job.rb
+++ b/app/jobs/reindex_object_children_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ReindexObjectChildrenJob < Hyrax::ApplicationJob
+  def perform(id)
+    @id = id
+
+    object_children.each(&:update_index)
+    Rails.logger.info "Objects reindexed: #{object_children}"
+  end
+
+  def object_children
+    obj = ActiveFedora::Base.find(@id)
+    obj_children_ids = obj.try(:member_ids)
+
+    obj_children_ids.present? ? pull_child_objects(obj_children_ids) : []
+  end
+
+  def pull_child_objects(child_ids)
+    child_ids.compact.map { |child_id| ActiveFedora::Base.find(child_id) }
+  end
+end

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -37,7 +37,17 @@
         <%= link_to t('.delete'), [main_app, presenter], class: 'btn btn-danger', data: { confirm: t('.confirm_delete', work_type: presenter.human_readable_type) }, method: :delete %>
         <div class="row second-row-buttons">
           <%= button_to t('.regen_manifest'), "/concern/curate_generic_works/#{@presenter.id}/regen_manifest", class: 'btn btn-primary' %>
-          <%= button_to 'Index for Full-Text Search', "/concern/curate_generic_works/#{@presenter.id}/full_text_index?user_id=#{current_user.id}", class: 'btn btn-primary' %>
+          <div class='btn-group' role='group'>
+            <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+              Index for Full-Text Search
+              <span class="caret"></span>
+            </button>
+
+            <div class="dropdown-menu">
+              <%= link_to 'Volume Only', "/concern/curate_generic_works/#{@presenter.id}/full_text_index?user_id=#{current_user.id}", class: 'dropdown-item', method: :post %>
+              <%= link_to 'Volume and Pages', "/concern/curate_generic_works/#{@presenter.id}/full_text_index_with_pages?user_id=#{current_user.id}", class: 'dropdown-item', method: :post %>
+            </div>
+          </div>
         </div>
       <% end %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,7 @@ Rails.application.routes.draw do
   post '/concern/file_sets/:file_set_id/re_characterize', to: 'characterization#re_characterize', as: 'file_set_re_characterization'
   post "/concern/curate_generic_works/:work_id/regen_manifest", to: "manifest_regeneration#regen_manifest", as: 'regen_manifest'
   post "/concern/curate_generic_works/:work_id/full_text_index", to: "full_text_indexing#full_text_index", as: 'full_text_index'
+  post "/concern/curate_generic_works/:work_id/full_text_index_with_pages", to: "full_text_indexing#full_text_index_with_pages", as: 'full_text_index_with_pages'
 
   # Deprecation warning: Zizia will be removed with Curate v3.
   get 'csv_import_details/index'

--- a/spec/controllers/full_text_indexing_controller_spec.rb
+++ b/spec/controllers/full_text_indexing_controller_spec.rb
@@ -4,17 +4,26 @@ require 'rails_helper'
 
 RSpec.describe FullTextIndexingController, type: :controller, clean: true do
   let(:admin) { FactoryBot.create(:admin) }
-  let(:work) { FactoryBot.create(:public_generic_work, user: admin) }
+  let!(:work) { FactoryBot.create(:public_generic_work, user: admin) }
 
   context "when signed in" do
     describe "POST full_text_index" do
-      before do
-        sign_in admin
-      end
+      before { sign_in admin }
 
       it "queues up compile full text job" do
         expect(CompileFullTextJob).to receive(:perform_later).with(work_id: work.id, user_id: admin.id)
+
         post :full_text_index, params: { work_id: work.id, user_id: admin.id }, xhr: true
+
+        expect(response).to be_successful
+      end
+
+      it "queues up compile full text and reindex jobs" do
+        expect(CompileFullTextJob).to receive(:perform_later).with(work_id: work.id, user_id: admin.id)
+        expect(ReindexObjectChildrenJob).to receive(:perform_later).with(work.id)
+
+        post :full_text_index_with_pages, params: { work_id: work.id, user_id: admin.id }, xhr: true
+
         expect(response).to be_successful
       end
     end
@@ -24,6 +33,15 @@ RSpec.describe FullTextIndexingController, type: :controller, clean: true do
     describe "POST full_text_index" do
       it "returns 401" do
         post :full_text_index, params: { work_id: work.id, user_id: admin.id }, xhr: true
+
+        expect(response.code).to eq '401'
+      end
+    end
+
+    describe "POST full_text_index_with_pages" do
+      it "returns 401" do
+        post :full_text_index_with_pages, params: { work_id: work.id, user_id: admin.id }, xhr: true
+
         expect(response.code).to eq '401'
       end
     end

--- a/spec/jobs/reindex_object_children_job_spec.rb
+++ b/spec/jobs/reindex_object_children_job_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ReindexObjectChildrenJob, :clean do
+  let(:work) { FactoryBot.create(:public_generic_work) }
+  let(:job_instance) { described_class.new }
+  let(:file_set) { FactoryBot.create(:file_set, read_groups: ['public']) }
+  let(:pmf) { File.open(fixture_path + '/book_page/0003_preservation_master.tif') }
+
+  before { job_instance.instance_variable_set(:@id, work.id) }
+
+  context '#object_children' do
+    it 'logs an empty array with object with no member ids' do
+      expect(job_instance.object_children).to eq([])
+    end
+
+    describe 'object with member ids' do
+      it 'logs an array of objects' do
+        Hydra::Works::AddFileToFileSet.call(file_set, pmf, :preservation_master_file)
+        work.ordered_members << file_set
+        work.save!
+
+        expect(job_instance.object_children).not_to eq([])
+      end
+    end
+  end
+
+  context '#pull_child_objects' do
+    it 'returns an empty array when given an empty array' do
+      expect(job_instance.pull_child_objects([])).to eq([])
+    end
+
+    it 'returns an array of objects when given an array of ids' do
+      expect(job_instance.pull_child_objects([file_set.id])).not_to eq([])
+    end
+  end
+end

--- a/spec/routing/full_text_indexing_routing_spec.rb
+++ b/spec/routing/full_text_indexing_routing_spec.rb
@@ -12,4 +12,14 @@ RSpec.describe "routes for full-text indexing", type: :routing do
         "user_id" => "1"
       )
   end
+
+  it "routes full-text indexing with pages requests to the full_text_indexing#full_text_index_with_pages" do
+    expect(post("/concern/curate_generic_works/1/full_text_index_with_pages?user_id=1"))
+      .to route_to(
+        "controller" => "full_text_indexing",
+        "action" => "full_text_index_with_pages",
+        "work_id" => "1",
+        "user_id" => "1"
+      )
+  end
 end

--- a/spec/system/viewing_a_work_spec.rb
+++ b/spec/system/viewing_a_work_spec.rb
@@ -144,9 +144,12 @@ RSpec.describe 'viewing the importer guide', type: :system, clean: true do
       expect(page).to have_css('button', text: 'Add to collection')
     end
 
-    it 'has a full-text search indexing button' do
+    it 'has full-text search indexing options' do
       visit "/concern/curate_generic_works/#{user_work.id}"
-      expect(page).to have_selector('input[value="Index for Full-Text Search"]')
+
+      expect(page).to have_button('Index for Full-Text Search')
+      expect(page).to have_link('Volume Only', visible: false)
+      expect(page).to have_link('Volume and Pages', visible: false)
     end
   end
 


### PR DESCRIPTION
- app/assets/stylesheets/_work_show_page.scss: styles the new pulldown.
- app/controllers/full_text_indexing_controller.rb: adds new action and refactors the processing into private methods.
- app/jobs/reindex_object_children_job.rb: creates new Job class that reindexes a work's child members.
- app/views/hyrax/base/_show_actions.html.erb: changes the Full Text Indexing to a dropdown button.
- spec/*: updates the tests' expectations.