### PR TITLE
Makes the manifest link implicit and not open to Rails interpretation.

### DIFF
--- a/app/helpers/hyrax/iiif_helper.rb
+++ b/app/helpers/hyrax/iiif_helper.rb
@@ -21,5 +21,9 @@ module Hyrax
     def universal_viewer_config_url(id)
       "#{request&.base_url}/uv/config/#{id}"
     end
+
+    def universal_viewer_manifest_link_for_work_id(id)
+      "#{request&.base_url}/concern/curate_generic_works/#{id}/manifest"
+    end
   end
 end

--- a/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
+++ b/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
@@ -4,7 +4,7 @@
       class="universal-viewer-iframe"
       width="1140px"
       height="668px"
-      src="/uv/uv.html#?manifest=<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>&config=<%= universal_viewer_config_url(presenter.id) %>"
+      src="/uv/uv.html#?manifest=<%= universal_viewer_manifest_link_for_work_id(presenter.id) %>&config=<%= universal_viewer_config_url(presenter.id) %>"
       allowfullscreen="true"
       frameborder="0"
   ></iframe>


### PR DESCRIPTION
- app/helpers/hyrax/iiif_helper.rb: makes the link reliable by clearly defining its elements/
- app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb: changes away from the polymorphic URL method. It appeared to build links that referenced some filename built within the `ManifestBuilderService` class.