### PR TITLE
Allows IIIF Search only when Work has all_text field.

### DIFF
--- a/app/views/manifest/manifest.json.jbuilder
+++ b/app/views/manifest/manifest.json.jbuilder
@@ -10,12 +10,13 @@ json.metadata @manifest_metadata do |child|
   json.value child['value']
 end
 
+enable_search = @image_concerns.any? { |id| SolrDocument&.find(id)&.[]('alto_xml_tesi')&.present? } && @solr_doc['all_text_timv'].present?
 # The code block below activates the IIIF Search tools within the
 #   Universal Viewer. This will use the presence of all_text_tsimv values
 #   within the Work to activate, but each text-optimized FileSet's alto_xml_tesi,
 #   transcript_text_tesi, and is_page_of_ssi fields must also be indexed for normal
 #   searching functions.
-if @image_concerns.any? { |id| SolrDocument&.find(id)&.[]('alto_xml_tesi')&.present? }
+if enable_search
   json.service do
     json.child! do
       json.set! :@context, 'http://iiif.io/api/search/0/context.json'

--- a/spec/views/manifest/manifest.json.jbuilder_spec.rb
+++ b/spec/views/manifest/manifest.json.jbuilder_spec.rb
@@ -96,16 +96,41 @@ RSpec.describe "manifest/manifest", type: :view, clean: true do
     expect(work.file_sets.count).to eq 5
   end
 
-  context 'when @image_concerns contains values in alto_xml_tesi' do
-    it 'renders a IIIF Search service' do
-      allow(image_concerns).to receive(:any?).and_return(true)
-      render
-      parsed_rendered_manifest = JSON.parse(rendered)
+  describe 'IIIF Search' do
+    context "FileSet's alto_xml_tesi and Work's all_text_timv are present" do
+      let(:solr_document) { SolrDocument.new(attributes.merge("all_text_timv": 'text, yada yada')) }
 
-      expect(parsed_rendered_manifest['service']).to be_present
-      expect(parsed_rendered_manifest['service'].first['@context']).to eq('http://iiif.io/api/search/0/context.json')
-      expect(parsed_rendered_manifest['service'].first['profile']).to eq('http://iiif.io/api/search/0/search')
-      expect(parsed_rendered_manifest['service'].first['@id']).to eq("/catalog/#{identifier}/iiif_search")
+      it 'renders a IIIF Search service' do
+        allow(image_concerns).to receive(:any?).and_return(true)
+        render
+        parsed_rendered_manifest = JSON.parse(rendered)
+
+        expect(parsed_rendered_manifest['service']).to be_present
+        expect(parsed_rendered_manifest['service'].first['@context']).to eq('http://iiif.io/api/search/0/context.json')
+        expect(parsed_rendered_manifest['service'].first['profile']).to eq('http://iiif.io/api/search/0/search')
+        expect(parsed_rendered_manifest['service'].first['@id']).to eq("/catalog/#{identifier}/iiif_search")
+      end
+    end
+
+    context "FileSet's alto_xml_tesi is present" do
+      it 'does not render the IIIF Search service' do
+        allow(image_concerns).to receive(:any?).and_return(true)
+        render
+        parsed_rendered_manifest = JSON.parse(rendered)
+
+        expect(parsed_rendered_manifest['service']).not_to be_present
+      end
+    end
+
+    context "Work's all_text_timv is present" do
+      let(:solr_document) { SolrDocument.new(attributes.merge("all_text_timv": 'text, yada yada')) }
+
+      it 'does not render the IIIF Search service' do
+        render
+        parsed_rendered_manifest = JSON.parse(rendered)
+
+        expect(parsed_rendered_manifest['service']).not_to be_present
+      end
     end
   end
 end


### PR DESCRIPTION
- app/views/manifest/manifest.json.jbuilder: checks for both the presence of `alto_xml_tesi` in the FileSets and `all_text_timv` in the Work before initiating the IIIF Search service in the manifest.
- spec/views/manifest/manifest.json.jbuilder_spec.rb: tests the expectations laid out above.