### PR TITLE
Adds CollectionResource Valkyrie model with metadata matching.

### DIFF
--- a/app/forms/collection_resource_form.rb
+++ b/app/forms/collection_resource_form.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:collection_resource CollectionResource`
+class CollectionResourceForm < Hyrax::Forms::PcdmCollectionForm
+  include Hyrax::FormFields(:emory_basic_metadata)
+  include Hyrax::FormFields(:collection_resource)
+end

--- a/app/indexers/collection_resource_indexer.rb
+++ b/app/indexers/collection_resource_indexer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:collection_resource CollectionResource`
+class CollectionResourceIndexer < Hyrax::PcdmCollectionIndexer
+  include Hyrax::Indexer(:emory_basic_metadata)
+  include Hyrax::Indexer(:collection_resource)
+end

--- a/app/models/collection_resource.rb
+++ b/app/models/collection_resource.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:collection_resource CollectionResource`
+class CollectionResource < Hyrax::PcdmCollection
+  include Hyrax::Schema(:emory_basic_metadata)
+  include Hyrax::Schema(:collection_resource)
+end

--- a/config/metadata/collection_resource.yaml
+++ b/config/metadata/collection_resource.yaml
@@ -1,0 +1,181 @@
+# Collection-specific metadata properties for the Valkyrie CollectionResource model.
+# These attributes match the ActiveFedora Collection model properties.
+#
+# Fields shared with works are defined in emory_basic_metadata.yaml.
+# Fields here are collection-specific. Note: Dry::Struct does not allow
+# redefining attributes, so fields already in emory_basic_metadata.yaml
+# (e.g. abstract, creator, holding_repository, emory_ark, etc.) must NOT
+# be redeclared here.
+#
+# Generated following the pattern from:
+#   `rails generate hyrax:collection_resource CollectionResource`
+
+attributes:
+  administrative_unit:
+    type: string
+    multiple: true
+    form:
+      primary: true
+    index_keys:
+      - "administrative_unit_tesim"
+    predicate: http://id.loc.gov/vocabulary/relators/cur
+  alt_title:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "alt_title_tesim"
+    predicate: http://purl.org/dc/terms/alternative
+  contact_information:
+    type: string
+    multiple: false
+    form:
+      primary: true
+      multiple: false
+    index_keys:
+      - "contact_information_tesi"
+    predicate: http://www.rdaregistry.info/Elements/u/#P60490
+  contributors:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "contributors_tesim"
+      - "contributors_sim"
+    predicate: http://purl.org/dc/elements/1.1/contributor
+  deduplication_key:
+    type: string
+    multiple: false
+    form:
+      primary: false
+      multiple: false
+    index_keys:
+      - "deduplication_key_tesi"
+    predicate: http://metadata.emory.edu/vocab/predicates#deduplicationKey
+  deposit_collection_ids:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "deposit_collection_ids_tesim"
+    predicate: http://metadata.emory.edu/vocab/cor-terms#depositCollectionID
+  finding_aid_link:
+    type: string
+    multiple: false
+    form:
+      primary: false
+      multiple: false
+    index_keys:
+      - "finding_aid_link_tesi"
+    predicate: http://metadata.emory.edu/vocab/cor-terms#findingAid
+  keywords:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "keywords_tesim"
+      - "keywords_sim"
+    predicate: http://schema.org/keywords
+  local_call_number:
+    type: string
+    multiple: false
+    form:
+      primary: false
+      multiple: false
+    index_keys:
+      - "local_call_number_tesi"
+    predicate: http://metadata.emory.edu/vocab/cor-terms#localCallNumber
+  notes:
+    type: string
+    multiple: true
+    form:
+      primary: false
+      multiple: true
+    index_keys:
+      - "notes_tesim"
+    predicate: http://www.w3.org/2004/02/skos/core#note
+  primary_language:
+    type: string
+    multiple: false
+    form:
+      primary: false
+      multiple: false
+    index_keys:
+      - "primary_language_tesi"
+      - "primary_language_si"
+    predicate: http://purl.org/dc/elements/1.1/language
+  primary_repository_ID:
+    type: string
+    multiple: false
+    form:
+      primary: false
+      multiple: false
+    index_keys:
+      - "primary_repository_ID_tesi"
+    predicate: http://purl.org/dc/terms/identifier
+  rights_documentation:
+    type: string
+    multiple: false
+    form:
+      primary: false
+      multiple: false
+    index_keys:
+      - "rights_documentation_tesi"
+    predicate: http://metadata.emory.edu/vocab/cor-terms#rightsDocumentationURI
+  sensitive_material:
+    type: string
+    multiple: false
+    form:
+      primary: false
+      multiple: false
+    index_keys:
+      - "sensitive_material_tesi"
+    predicate: http://metadata.emory.edu/vocab/cor-terms#sensitiveMaterial
+  source_collection_id:
+    type: string
+    multiple: false
+    form:
+      primary: false
+      multiple: false
+    index_keys:
+      - "source_collection_id_tesi"
+    predicate: http://metadata.emory.edu/vocab/cor-terms#sourceCollectionID
+  subject_geo:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "subject_geo_tesim"
+      - "subject_geo_sim"
+    predicate: http://purl.org/dc/elements/1.1/coverage
+  subject_names:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "subject_names_tesim"
+      - "subject_names_sim"
+    predicate: http://purl.org/dc/elements/1.1/subject#names
+  subject_time_periods:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "subject_time_periods_tesim"
+    predicate: http://schema.org/temporalCoverage
+  subject_topics:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "subject_topics_tesim"
+      - "subject_topics_sim"
+    predicate: http://purl.org/dc/elements/1.1/subject

--- a/config/metadata/emory_basic_metadata.yaml
+++ b/config/metadata/emory_basic_metadata.yaml
@@ -1,0 +1,213 @@
+# [Hyrax-override-v5.2.0] of basic_metadata.yaml
+#   Please be very careful in the changes made to this document.
+#   Generally, it is safe to alter the form options here (please
+#   match the "multiple" settings to the field level, which should
+#   never change).
+#   Altering "primary" and "required" within the form options will
+#   only affect how the form is built, which really doesn't affect
+#   persistence like the other settings.
+#
+# What has been changed:
+#   - `creator` is now maintaining the order of its array values.
+#   - `license` is no longer multiple nor required.
+#   - The following removed from the forms:
+#     - `alternative_title`
+#     - `arkivo_checksum`
+#     - `based_near`
+#     - `contributor`
+#     - `date_created`
+#     - `identifier`
+#     - `label`
+#     - `related_url`
+#     - `resource_type`
+#     - `source`
+#   - The following have been added as shared Emory fields
+#     (common to both works and collections):
+#     - `holding_repository`
+#     - `institution`
+#     - `internal_rights_note`
+#     - `system_of_record_ID`
+#     - `emory_ark`
+#     - `staff_notes`
+---
+attributes:
+  abstract:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "abstract_tesim"
+    predicate: http://purl.org/dc/terms/abstract
+  alternative_title:
+    type: string
+    multiple: true
+    index_keys:
+      - "alternative_title_tesim"
+    predicate: http://purl.org/dc/terms/alternative
+  arkivo_checksum:
+    type: string
+    multiple: false
+    predicate: http://scholarsphere.psu.edu/ns#arkivoChecksum
+  based_near:
+    type: string
+    multiple: true
+    index_keys:
+      - "based_near_sim"
+      - "based_near_tesim"
+    predicate: http://xmlns.com/foaf/0.1/based_near
+  bibliographic_citation:
+    type: string
+    multiple: true
+    predicate: http://purl.org/dc/terms/bibliographicCitation
+  contributor:
+    type: string
+    multiple: true
+    index_keys:
+      - "contributor_tesim"
+      - "contributor_sim"
+    predicate: http://purl.org/dc/elements/1.1/contributor
+  creator:
+    type: string
+    multiple: true
+    ordered: true
+    form:
+      required: true
+      primary: true
+    index_keys:
+      - "creator_tesim"
+      - "creator_ssim"
+    predicate: http://purl.org/dc/elements/1.1/creator
+  date_created:
+    type: date_time
+    multiple: true
+    index_keys:
+      - "date_created_tesim"
+    predicate: http://purl.org/dc/terms/created
+  emory_ark:
+    type: string
+    multiple: true
+    form:
+      primary: true
+    index_keys:
+      - 'emory_ark_tesim'
+    predicate: http://id.loc.gov/vocabulary/identifiers/local#ark
+  holding_repository:
+    type: string
+    multiple: false
+    form:
+      primary: true
+      required: true
+      multiple: false
+    index_keys:
+      - 'holding_repository_ssi'
+      - 'holding_repository_tesi'
+    predicate: http://id.loc.gov/vocabulary/relators/rps
+  identifier:
+    type: string
+    multiple: true
+    index_keys:
+      - "identifier_tesim"
+    predicate: http://purl.org/dc/terms/identifier
+  import_url:
+    type: string
+    predicate: http://scholarsphere.psu.edu/ns#importUrl
+  institution:
+    type: string
+    multiple: false
+    form:
+      primary: true
+      multiple: false
+    index_keys:
+      - 'institution_ssi'
+      - 'institution_tesi'
+    predicate: http://rdaregistry.info/Elements/u/P60402
+  internal_rights_note:
+    type: string
+    multiple: false
+    form:
+      primary: true
+      multiple: false
+    index_keys:
+      - 'internal_rights_note_tesi'
+    predicate: http://metadata.emory.edu/vocab/cor-terms#internalRightsNote
+  keyword:
+    type: string
+    multiple: true
+    index_keys:
+      - "keyword_sim"
+      - "keyword_tesim"
+    form:
+      primary: false
+    predicate: http://schema.org/keywords
+  label:
+    type: string
+    index_keys:
+      - "label_tesim"
+    predicate: info:fedora/fedora-system:def/model#downloadFilename
+  license:
+    type: string
+    multiple: false
+    form:
+      primary: false
+      required: false
+    index_keys:
+      - "license_tesi"
+    predicate: http://purl.org/dc/terms/license
+  relative_path:
+    type: string
+    predicate: http://scholarsphere.psu.edu/ns#relativePath
+  related_url:
+    type: string
+    multiple: true
+    index_keys:
+      - "related_url_tesim"
+    predicate: http://www.w3.org/2000/01/rdf-schema#seeAlso
+  resource_type:
+    type: string
+    multiple: true
+    index_keys:
+      - "resource_type_sim"
+      - "resource_type_tesim"
+    predicate: http://purl.org/dc/terms/type
+  rights_notes:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "rights_notes_tesim"
+    predicate: http://purl.org/dc/elements/1.1/rights
+  source:
+    type: string
+    multiple: true
+    index_keys:
+      - "source_tesim"
+    predicate: http://purl.org/dc/terms/source
+  staff_notes:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - 'staff_notes_tesim'
+    predicate: http://metadata.emory.edu/vocab/cor-terms#staffNote
+  subject:
+    type: string
+    multiple: true
+    index_keys:
+      - "subject_sim"
+      - "subject_tesim"
+    form:
+      primary: false
+    predicate: http://purl.org/dc/elements/1.1/subject
+  system_of_record_ID:
+    type: string
+    multiple: false
+    form:
+      primary: true
+      multiple: false
+    index_keys:
+      - 'system_of_record_ID_ssi'
+      - 'system_of_record_ID_tesi'
+    predicate: http://metadata.emory.edu/vocab/cor-terms#descriptiveSystemID

--- a/spec/forms/collection_resource_form_spec.rb
+++ b/spec/forms/collection_resource_form_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe CollectionResourceForm do
+  let(:change_set) { described_class.new(resource) }
+  let(:resource)   { CollectionResource.new }
+
+  it_behaves_like 'a Valkyrie::ChangeSet'
+
+  it 'has the expected fields' do
+    expected_fields = %w[
+      abstract
+      administrative_unit
+      alt_title
+      contact_information
+      contributors
+      deduplication_key
+      deposit_collection_ids
+      emory_ark
+      finding_aid_link
+      holding_repository
+      institution
+      internal_rights_note
+      keywords
+      local_call_number
+      notes
+      primary_language
+      primary_repository_ID
+      rights_documentation
+      sensitive_material
+      source_collection_id
+      staff_notes
+      subject_geo
+      subject_names
+      subject_time_periods
+      subject_topics
+      system_of_record_ID
+    ]
+
+    expect(change_set.fields.keys).to include(*expected_fields)
+  end
+end

--- a/spec/models/collection_resource_spec.rb
+++ b/spec/models/collection_resource_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'hyrax/specs/shared_specs/hydra_works'
+
+RSpec.describe CollectionResource do
+  subject(:collection) { described_class.new }
+
+  it_behaves_like 'a Hyrax::PcdmCollection'
+
+  it 'has abstracts' do
+    expect { collection.abstract = ['lorem ipsum', 'a story about moomins'] }
+      .to change { collection.abstract }
+      .to contain_exactly 'lorem ipsum', 'a story about moomins'
+  end
+
+  it 'has a label' do
+    expect { collection.label = 'one single label' }
+      .to change { collection.label }
+      .to eq 'one single label'
+  end
+
+  it 'has resource types' do
+    expect { collection.resource_type = ['book', 'image'] }
+      .to change { collection.resource_type }
+      .to contain_exactly 'book', 'image'
+  end
+
+  it 'has rights notes' do
+    expect { collection.rights_notes = ['secret', 'do not use'] }
+      .to change { collection.rights_notes }
+      .to contain_exactly 'secret', 'do not use'
+  end
+
+  it 'has sources' do
+    expect { collection.source = ['first', 'second'] }
+      .to change { collection.source }
+      .to contain_exactly 'first', 'second'
+  end
+
+  %w[
+    abstract
+    administrative_unit
+    alt_title
+    contact_information
+    contributors
+    creator
+    deduplication_key
+    deposit_collection_ids
+    emory_ark
+    finding_aid_link
+    holding_repository
+    institution
+    internal_rights_note
+    keywords
+    local_call_number
+    notes
+    primary_language
+    primary_repository_ID
+    rights_documentation
+    sensitive_material
+    source_collection_id
+    staff_notes
+    subject_geo
+    subject_names
+    subject_time_periods
+    subject_topics
+    system_of_record_ID
+  ].each do |attr|
+    include_examples('checks model for new attribute response', attr)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,8 @@ ENV['IMPORT_PATH'] ||= Rails.root.join('spec', 'fixtures', 'fake_images').to_s
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 require 'noid/rails/rspec'
+require 'valkyrie'
+Valkyrie::MetadataAdapter.register(Valkyrie::Persistence::Memory::MetadataAdapter.new, :test_adapter)
 # Add additional requires below this line. Rails is not loaded until this point!
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/support/shared_examples_for_models.rb
+++ b/spec/support/shared_examples_for_models.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'checks model for new attribute response' do |attribute_text|
+  describe "##{attribute_text}" do
+    it { is_expected.to respond_to(attribute_text.to_sym) }
+  end
+end


### PR DESCRIPTION

Creates a new CollectionResource model compatible with Valkyrie objects, following the SelfDeposit pattern. Includes emory_basic_metadata schema for shared fields and collection_resource schema for collection-specific attributes. All 28 custom properties from the ActiveFedora Collection model are represented. Registers Valkyrie test_adapter for shared specs.
