### PR TITLE
Properly uses our preferred_file derivative generation scheme.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,6 +113,7 @@ Metrics/MethodLength:
         - app/presenters/hyrax/curate_collection_presenter.rb
         - config/initializers/bulkrax.rb
         - config/initializers/hydra_access_control_overrides.rb
+        - config/initializers/valkyrie_characterization_service_override.rb
         - lib/frigg/persister.rb
         - spec/fixtures/manifest_output.rb
         - spec/fixtures/placeholder_manifest_output.rb

--- a/app/jobs/re_characterize_job.rb
+++ b/app/jobs/re_characterize_job.rb
@@ -45,19 +45,11 @@ class ReCharacterizeJob < Hyrax::ApplicationJob
     end
 
     def perform_valkyrie(file_set, _user)
-      file_metadata = original_file_metadata(file_set)
+      file_metadata = file_set.preservation_master_file
       return unless file_metadata
 
       empty_valkyrie_characterization(file_metadata)
       ValkyrieCharacterizationJob.perform_later(file_metadata.id.to_s)
-    end
-
-    # Finds the Hyrax::FileMetadata flagged as ORIGINAL_FILE (equivalent to
-    # AF's preservation_master_file) on the FileSetResource.
-    def original_file_metadata(file_set)
-      Hyrax.custom_queries
-           .find_many_file_metadata_by_use(resource: file_set, use: Hyrax::FileMetadata::Use::ORIGINAL_FILE)
-           .first
     end
 
     # Valkyrie counterpart to ReCharacterizationService.empty_out_characterization.

--- a/app/models/file_set_resource.rb
+++ b/app/models/file_set_resource.rb
@@ -8,4 +8,33 @@ class FileSetResource < Hyrax::FileSet
   include PreservationEvents
 
   attribute :preservation_event, Valkyrie::Types::Set.of(::PreservationEventResource)
+
+  # @return [Hyrax::FileMetadata, nil]
+  def preservation_master_file
+    original_file
+  end
+
+  # @return [Hyrax::FileMetadata, nil]
+  def intermediate_file
+    Hyrax.custom_queries.find_intermediate_file(file_set: self)
+  rescue Valkyrie::Persistence::ObjectNotFoundError
+    nil
+  end
+
+  # @return [Hyrax::FileMetadata, nil]
+  def service_file
+    Hyrax.custom_queries.find_service_file(file_set: self)
+  rescue Valkyrie::Persistence::ObjectNotFoundError
+    nil
+  end
+
+  def preferred_file
+    if service_file.present?
+      :service_file
+    elsif intermediate_file.present?
+      :intermediate_file
+    else
+      :preservation_master_file
+    end
+  end
 end

--- a/app/services/curate/custom_queries/find_files.rb
+++ b/app/services/curate/custom_queries/find_files.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+module Curate
+  module CustomQueries
+    ##
+    # @example
+    #   Hyrax.custom_queries.find_intermediate_file(file_set: file_set_resource)
+    #   Hyrax.custom_queries.find_service_file(file_set: file_set_resource)
+    #
+    # @see https://github.com/samvera/valkyrie/wiki/Queries#custom-queries
+    # @since 3.0.0
+    class FindFiles
+      def self.queries
+        [:find_intermediate_file,
+         :find_service_file]
+      end
+
+      def initialize(query_service:)
+        @query_service = query_service
+      end
+
+      attr_reader :query_service
+      delegate :resource_factory, to: :query_service
+
+      # Find intermediate file id of a given file set resource, and map to file metadata resource
+      # @param file_set [Hyrax::FileSet]
+      # @return [Hyrax::FileMetadata]
+      def find_intermediate_file(file_set:)
+        find_exactly_one_file_by_use(
+          file_set: file_set,
+          use: Hyrax::FileMetadata::Use::INTERMEDIATE_FILE
+        )
+      end
+
+      # Find service file id of a given file set resource, and map to file metadata resource
+      # @param file_set [Hyrax::FileSet]
+      # @return [Hyrax::FileMetadata]
+      def find_service_file(file_set:)
+        find_exactly_one_file_by_use(
+          file_set: file_set,
+          use: Hyrax::FileMetadata::Use::SERVICE_FILE
+        )
+      end
+
+      private
+
+      ##
+      # @api private
+      #
+      # @return [Hyrax::FileMetadata]
+      # @raise [Valkyrie::Persistence::ObjectNotFoundError]
+      def find_exactly_one_file_by_use(file_set:, use:)
+        files =
+          query_service.custom_queries.find_many_file_metadata_by_use(resource: file_set, use: use)
+
+        files.first || raise(Valkyrie::Persistence::ObjectNotFoundError, "FileSet #{file_set.id}'s #{use.fragment} is missing.")
+      end
+    end
+  end
+end

--- a/app/services/curate/custom_queries/find_files.rb
+++ b/app/services/curate/custom_queries/find_files.rb
@@ -26,8 +26,8 @@ module Curate
       # @return [Hyrax::FileMetadata]
       def find_intermediate_file(file_set:)
         find_exactly_one_file_by_use(
-          file_set: file_set,
-          use: Hyrax::FileMetadata::Use::INTERMEDIATE_FILE
+          file_set:,
+          use:      Hyrax::FileMetadata::Use::INTERMEDIATE_FILE
         )
       end
 
@@ -36,24 +36,24 @@ module Curate
       # @return [Hyrax::FileMetadata]
       def find_service_file(file_set:)
         find_exactly_one_file_by_use(
-          file_set: file_set,
-          use: Hyrax::FileMetadata::Use::SERVICE_FILE
+          file_set:,
+          use:      Hyrax::FileMetadata::Use::SERVICE_FILE
         )
       end
 
       private
 
-      ##
-      # @api private
-      #
-      # @return [Hyrax::FileMetadata]
-      # @raise [Valkyrie::Persistence::ObjectNotFoundError]
-      def find_exactly_one_file_by_use(file_set:, use:)
-        files =
-          query_service.custom_queries.find_many_file_metadata_by_use(resource: file_set, use: use)
+        ##
+        # @api private
+        #
+        # @return [Hyrax::FileMetadata]
+        # @raise [Valkyrie::Persistence::ObjectNotFoundError]
+        def find_exactly_one_file_by_use(file_set:, use:)
+          files =
+            query_service.custom_queries.find_many_file_metadata_by_use(resource: file_set, use:)
 
-        files.first || raise(Valkyrie::Persistence::ObjectNotFoundError, "FileSet #{file_set.id}'s #{use.fragment} is missing.")
-      end
+          files.first || raise(Valkyrie::Persistence::ObjectNotFoundError, "FileSet #{file_set.id}'s #{use.fragment} is missing.")
+        end
     end
   end
 end

--- a/app/services/hyrax/listeners/file_listener.rb
+++ b/app/services/hyrax/listeners/file_listener.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+# [Hyrax-override-v5.2.0] L#34 Since we sometimes user `intermediate_file` for derivatives
+#   and characterization, we remove the not `original_file` examption.
+
+module Hyrax
+  module Listeners
+    ##
+    # Listens for events related to Files ({Valkyrie::StorageAdapter::File})
+    class FileListener
+      ##
+      # Called when 'file.characterized' event is published;
+      # allows post-characterization handling, like derivatives generation.
+      #
+      # @param [Dry::Events::Event] event
+      # @return [void]
+      def on_file_characterized(event)
+        file_set = event[:file_set]
+        Hyrax.index_adapter.save(resource: file_set)
+        preferred_file_metadata = file_set.public_send(file_set.preferred_file)
+
+        if preferred_file_metadata.present?
+          case file_set
+          when ActiveFedora::Base # ActiveFedora
+            CreateDerivativesJob
+              .perform_later(file_set, preferred_file_metadata.id.to_s, event[:path_hint]) # Emory Alteration
+          else
+            ValkyrieCreateDerivativesJob
+              .perform_later(file_set.id.to_s, preferred_file_metadata.id.to_s) # Emory Alteration
+          end
+        end
+      end
+
+      ##
+      # Called when 'file.uploaded' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
+      def on_file_uploaded(event)
+        # Run characterization for original file only and allow optional skip paramater
+        ValkyrieCharacterizationJob.perform_later(event[:metadata].id.to_s)
+      end
+    end
+  end
+end

--- a/app/services/hyrax/listeners/file_listener.rb
+++ b/app/services/hyrax/listeners/file_listener.rb
@@ -18,15 +18,15 @@ module Hyrax
         Hyrax.index_adapter.save(resource: file_set)
         preferred_file_metadata = file_set.public_send(file_set.preferred_file)
 
-        if preferred_file_metadata.present?
-          case file_set
-          when ActiveFedora::Base # ActiveFedora
-            CreateDerivativesJob
-              .perform_later(file_set, preferred_file_metadata.id.to_s, event[:path_hint]) # Emory Alteration
-          else
-            ValkyrieCreateDerivativesJob
-              .perform_later(file_set.id.to_s, preferred_file_metadata.id.to_s) # Emory Alteration
-          end
+        return if preferred_file_metadata.blank?
+
+        case file_set
+        when ActiveFedora::Base # ActiveFedora
+          CreateDerivativesJob
+            .perform_later(file_set, preferred_file_metadata.id.to_s, event[:path_hint]) # Emory Alteration
+        else
+          ValkyrieCreateDerivativesJob
+            .perform_later(file_set.id.to_s, preferred_file_metadata.id.to_s) # Emory Alteration
         end
       end
 

--- a/app/services/hyrax/valkyrie_upload.rb
+++ b/app/services/hyrax/valkyrie_upload.rb
@@ -57,7 +57,7 @@ class Hyrax::ValkyrieUpload
                          user:)
 
     Hyrax.publisher.publish("file.uploaded", metadata: saved_metadata, skip_derivatives:)
-    Hyrax.publisher.publish('file.metadata.updated', metadata: saved_metadata, user:, skip_derivatices: skip_derivatives)
+    Hyrax.publisher.publish('file.metadata.updated', metadata: saved_metadata, user:, skip_derivatives:)
 
     saved_metadata
   end

--- a/config/initializers/valkyrie_characterization_service_override.rb
+++ b/config/initializers/valkyrie_characterization_service_override.rb
@@ -13,20 +13,24 @@ Rails.application.config.to_prepare do
     }.freeze
 
     def self.run(metadata:, file:, user: ::User.system_user, **options)
-      event_start = DateTime.current
-      characterizer_obj = new(metadata:, file:, **options)
-      characterizer_obj.characterize
-      characterizer_obj.detect_alpha_channels
-      saved = Hyrax.persister.save(resource: metadata)
-      file_set = Hyrax.query_service.find_by(id: saved.file_set_id)
+      if metadata.pcdm_use.first == Hyrax::FileMetadata::Use::ORIGINAL_FILE
+        event_start = DateTime.current
+        characterizer_obj = new(metadata:, file:, **options)
+        characterizer_obj.characterize
+        characterizer_obj.detect_alpha_channels
+        saved = Hyrax.persister.save(resource: metadata)
+        file_set = Hyrax.query_service.find_by(id: saved.file_set_id)
 
-      characterizer_obj.process_characterization_event(saved, user, file_set, event_start)
-      characterizer_obj.process_digest_event(saved.file_set_id, user, event_start, saved.original_checksum)
-      Hyrax.publisher.publish('file.metadata.updated', metadata: saved, user:)
+        characterizer_obj.process_characterization_event(saved, user, file_set, event_start)
+        characterizer_obj.process_digest_event(saved.file_set_id, user, event_start, saved.original_checksum)
+      end
+      freshly_pulled_file_set = Hyrax.query_service.find_by(id: metadata.file_set_id)
+      freshly_pulled_metadata = Hyrax.query_service.find_by(id: metadata.id)
+      Hyrax.publisher.publish('file.metadata.updated', metadata: freshly_pulled_metadata, user:)
       Hyrax.publisher.publish('file.characterized',
-                              file_set:,
-                              file_id:   saved.id.to_s,
-                              path_hint: saved.file_identifier.to_s)
+                              file_set:  freshly_pulled_file_set,
+                              file_id:   freshly_pulled_metadata.id.to_s,
+                              path_hint: freshly_pulled_metadata.file_identifier.to_s)
     end
 
     def characterize

--- a/config/initializers/wings.rb
+++ b/config/initializers/wings.rb
@@ -59,7 +59,8 @@ if Hyrax.config.valkyrie_transition?
       Curate::CustomQueries::FindBySourceIdentifier,
       Curate::CustomQueries::FindByEmoryPersistentId,
       Curate::CustomQueries::FindAllObjectsWithAlternateIdsPresent,
-      Curate::CustomQueries::FindParentWorks
+      Curate::CustomQueries::FindParentWorks,
+      Curate::CustomQueries::FindFiles
     ].each do |handler|
       Hyrax.query_service.services[0].custom_queries.register_query_handler(handler)
     end


### PR DESCRIPTION
- .rubocop.yml: adds in our override to this rule.
- app/jobs/re_characterize_job.rb: switches to out new `preservation_master_file` lookup method.
- app/models/file_set_resource.rb: adds lookup methods for everything we use, as well as the `preferred_file` method.
- app/services/curate/custom_queries/find_files.rb: this extends out Hyrax' custom queries of the same name to the the types we commonly use.
- app/services/hyrax/listeners/file_listener.rb: this overrides ensures we only create derivatives for our preferred files, as well as to send every file we upload to Characterization, because the Derivative Generation is directly kicked off after Characterization through a listener.
- app/services/hyrax/valkyrie_upload.rb: fixes typo.
- config/initializers/valkyrie_characterization_service_override.rb: this is necessary so that every file uploaded has a chance to be thumbnailed.
- config/initializers/wings.rb: this registers our new custom queries.