### PR TITLE
Kills the looping of the ValkyrieCreateDerivativesJob.

### DIFF
--- a/app/jobs/file_set_clean_up_job.rb
+++ b/app/jobs/file_set_clean_up_job.rb
@@ -57,23 +57,12 @@ class FileSetCleanUpJob < Hyrax::ApplicationJob
     end
 
     def process_valkyrie_fileset(file_set, csv)
-      fm = original_file_metadata(file_set)
+      fm = file_set.public_send(file_set.preferred_file)
       if fm.nil? || fm.mime_type.blank?
         csv << [file_set.id.to_s, "Fileset not characterized", "Not fixed"]
       else
-        solr_doc = SolrDocument.find(file_set.id.to_s)
-        if solr_doc.mime_type.nil?
-          reindex_valkyrie_file_set(file_set, csv)
-        elsif solr_doc.thumbnail_path.to_s.start_with?("/assets/default-")
-          regenerate_valkyrie_derivatives(file_set, fm, csv)
-        end
+        regenerate_valkyrie_derivatives(file_set, fm, csv)
       end
-    end
-
-    def original_file_metadata(file_set)
-      Hyrax.custom_queries
-           .find_many_file_metadata_by_use(resource: file_set, use: Hyrax::FileMetadata::Use::ORIGINAL_FILE)
-           .first
     end
 
     def reindex_af_file_set(file_set, csv)
@@ -96,10 +85,10 @@ class FileSetCleanUpJob < Hyrax::ApplicationJob
     end
 
     def regenerate_valkyrie_derivatives(file_set, file_metadata, csv)
-      Hyrax.publisher.publish('file.characterized',
-                              file_set:,
-                              file_id:   file_metadata.id.to_s,
-                              path_hint: file_metadata.file_identifier.to_s)
+      Hyrax.persister.delete(resource: file_set.thumbnail) if file_set.thumbnail.present?
+      ValkyrieCreateDerivativesJob
+        .perform_later(file_set.id.to_s, file_metadata.id.to_s)
+      reindex_valkyrie_file_set(file_set, csv)
       csv << [file_set.id.to_s, "Thumbnail_path mismatch in solr_doc", "Queued"]
     end
 end

--- a/app/services/hyrax/listeners/file_listener.rb
+++ b/app/services/hyrax/listeners/file_listener.rb
@@ -15,18 +15,14 @@ module Hyrax
       # @return [void]
       def on_file_characterized(event)
         file_set = event[:file_set]
-        Hyrax.index_adapter.save(resource: file_set)
-        preferred_file_metadata = file_set.public_send(file_set.preferred_file)
-
-        return if preferred_file_metadata.blank?
 
         case file_set
         when ActiveFedora::Base # ActiveFedora
           CreateDerivativesJob
-            .perform_later(file_set, preferred_file_metadata.id.to_s, event[:path_hint]) # Emory Alteration
+            .perform_later(file_set, event[:file_id], event[:path_hint])
         else
           ValkyrieCreateDerivativesJob
-            .perform_later(file_set.id.to_s, preferred_file_metadata.id.to_s) # Emory Alteration
+            .perform_later(file_set.id.to_s, event[:file_id])
         end
       end
 
@@ -35,9 +31,28 @@ module Hyrax
       # @param [Dry::Events::Event] event
       # @return [void]
       def on_file_uploaded(event)
-        # Run characterization for original file only and allow optional skip paramater
-        ValkyrieCharacterizationJob.perform_later(event[:metadata].id.to_s)
+        if event[:metadata]&.original_file?
+          # Run characterization for original file only and allow optional skip paramater
+          ValkyrieCharacterizationJob.perform_later(event[:metadata].id.to_s)
+        elsif curate_preferred_derivative_files.include?(event[:metadata].pcdm_use.first) # Emory Addition
+          file_set = Hyrax.query_service.find_by(id: event[:metadata].file_set_id)
+
+          case file_set
+          when ActiveFedora::Base # ActiveFedora
+            CreateDerivativesJob
+              .perform_later(file_set, event[:metadata].id.to_s, event[:metadata].file_identifier.to_s)
+          else
+            ValkyrieCreateDerivativesJob
+              .perform_later(file_set.id.to_s, event[:metadata].id.to_s)
+          end
+        end
       end
+
+      private
+
+        def curate_preferred_derivative_files
+          [Hyrax::FileMetadata::Use::INTERMEDIATE_FILE, Hyrax::FileMetadata::Use::SERVICE_FILE]
+        end
     end
   end
 end

--- a/config/initializers/valkyrie_characterization_service_override.rb
+++ b/config/initializers/valkyrie_characterization_service_override.rb
@@ -13,24 +13,23 @@ Rails.application.config.to_prepare do
     }.freeze
 
     def self.run(metadata:, file:, user: ::User.system_user, **options)
-      if metadata.pcdm_use.first == Hyrax::FileMetadata::Use::ORIGINAL_FILE
-        event_start = DateTime.current
-        characterizer_obj = new(metadata:, file:, **options)
-        characterizer_obj.characterize
-        characterizer_obj.detect_alpha_channels
-        saved = Hyrax.persister.save(resource: metadata)
-        file_set = Hyrax.query_service.find_by(id: saved.file_set_id)
+      event_start = DateTime.current
+      characterizer_obj = new(metadata:, file:, **options)
+      characterizer_obj.characterize
+      characterizer_obj.detect_alpha_channels
+      saved = Hyrax.persister.save(resource: metadata)
+      file_set = Hyrax.query_service.find_by(id: saved.file_set_id)
 
-        characterizer_obj.process_characterization_event(saved, user, file_set, event_start)
-        characterizer_obj.process_digest_event(saved.file_set_id, user, event_start, saved.original_checksum)
-      end
-      freshly_pulled_file_set = Hyrax.query_service.find_by(id: metadata.file_set_id)
-      freshly_pulled_metadata = Hyrax.query_service.find_by(id: metadata.id)
-      Hyrax.publisher.publish('file.metadata.updated', metadata: freshly_pulled_metadata, user:)
+      characterizer_obj.process_characterization_event(saved, user, file_set, event_start)
+      characterizer_obj.process_digest_event(saved.file_set_id, user, event_start, saved.original_checksum)
+      Hyrax.publisher.publish('file.metadata.updated', metadata: saved, user:)
+
+      return unless file_set.preferred_file == :preservation_master_file
+
       Hyrax.publisher.publish('file.characterized',
-                              file_set:  freshly_pulled_file_set,
-                              file_id:   freshly_pulled_metadata.id.to_s,
-                              path_hint: freshly_pulled_metadata.file_identifier.to_s)
+                              file_set:,
+                              file_id:   saved.id.to_s,
+                              path_hint: saved.file_identifier.to_s)
     end
 
     def characterize


### PR DESCRIPTION
- app/jobs/file_set_clean_up_job.rb: 
  - switches to using the `preferred_file` lookup method to pass the appropriate `FileMetadata` object.
  - skips reindexing the `SolrDocument` since that doesn't regenerate derivatives at all.
  - deletes the old thumbnail `FileMetadata` object if exists before recreating it (it will definitely create multiples--it just doesn't care it exists already).
- app/services/hyrax/listeners/file_listener.rb: 
  - reverts `#on_file_characterized` back to original.
  - adds switching so that only `original_file`s get Characterization, while `:intermediate_file`s or `:service_file`s get the Derivatives treatment.
- config/initializers/valkyrie_characterization_service_override.rb: returns this back to the original upgrade code, but adds a clause that initiates derivative generation (`file.characterized`) only if the `preferred_file` is `:preservation_master_file`.